### PR TITLE
When using a condition in hasMany(), make sure the original id is part of the condition

### DIFF
--- a/lib/Associations/Many.js
+++ b/lib/Associations/Many.js
@@ -70,6 +70,7 @@ function extendInstance(Instance, Driver, association, opts, cb) {
 						break;
 					case "object":
 						conditions = arguments[i];
+						if (!(association.mergeId in conditions)) conditions[association.mergeId] = Instance.id;
 						break;
 					case "number":
 						limit = arguments[i];


### PR DESCRIPTION
Fix for the behavior I described in https://github.com/dresende/node-orm2/issues/3#issuecomment-11188171
