### PR TITLE
Add .only() for hasMany() relations

### DIFF
--- a/lib/Associations/Many.js
+++ b/lib/Associations/Many.js
@@ -72,10 +72,28 @@ exports.extend = function (Instance, Driver, associations, opts, cb) {
 function extendInstance(Instance, Driver, association, opts, cb) {
 	Object.defineProperty(Instance, association.getFunction, {
 		value: function () {
-			var conditions = {};
+			var conditions = null;
 			var options = {};
 			var limit;
 			var cb;
+
+			for (var i = 0; i < arguments.length; i++) {
+				switch (typeof arguments[i]) {
+					case "function":
+						cb = arguments[i];
+						break;
+					case "object":
+						if (conditions === null) {
+							conditions = arguments[i];
+						} else {
+							options = arguments[i];
+						}
+						break;
+					case "number":
+						limit = arguments[i];
+						break;
+				}
+			}
 
 			options.__merge = {
 				from: { table: association.mergeTable, field: association.mergeAssocId },
@@ -88,20 +106,6 @@ function extendInstance(Instance, Driver, association, opts, cb) {
 				id_prop: association.mergeId,
 				assoc_prop: association.mergeAssocId
 			};
-
-			for (var i = 0; i < arguments.length; i++) {
-				switch (typeof arguments[i]) {
-					case "function":
-						cb = arguments[i];
-						break;
-					case "object":
-						conditions = arguments[i];
-						break;
-					case "number":
-						limit = arguments[i];
-						break;
-				}
-			}
 
 			conditions[association.mergeTable + "." + association.mergeId] = Instance.id;
 


### PR DESCRIPTION
Limits the returned fields when using `hasMany()` relations

```
var Movie = db.define('movies', {
    id: Number,
    title: String,
    year: Number,
    rating: Number,
    description: String
});

var Genre = db.define('genres', {
    id: Number,
    title: String
});

Movie.hasMany('genres', Genre);

Movie.get(id, function(err, movie) {
    movie.getGenres({}, {only: 'id'}, function(err, genres) {
        movie.genres = genres;
        // ...
    });
});
```
