### PR TITLE
pass the original options string to drivers

### DIFF
--- a/lib/ORM.js
+++ b/lib/ORM.js
@@ -24,7 +24,7 @@ exports.use = function (connection, proto, opts, cb) {
 
 exports.connect = function (opts, cb) {
 	var url = require("url");
-
+	var orig = opts;
 	if (typeof opts == "string") {
 		opts = url.parse(opts, true);
 	}
@@ -40,7 +40,7 @@ exports.connect = function (opts, cb) {
 	}
 
 	var Driver = require("./Drivers/" + proto).Driver;
-	var driver = new Driver(opts, null, {
+	var driver = new Driver(orig, null, {
 		debug: (opts.query && opts.query.debug == 'true')
 	});
 


### PR DESCRIPTION
Extra query parameters such as socketPath seem to be dropped with the limited options in ORM.js - so this would pass along the query string to be fully parsed at the loaded driver.
