### PR TITLE
Allow the table name to be set/overridden

### DIFF
--- a/lib/ORM.js
+++ b/lib/ORM.js
@@ -85,7 +85,7 @@ function prepare(driver) {
 
 			this.models[name] = new Model({
 				driver         : driver,
-				table          : name,
+				table          : opts.table || name,
 				properties     : properties,
 				cache          : opts.cache,
 				autoSave       : opts.autoSave || false,


### PR DESCRIPTION
enables the table name to be explicitly set within the models options
