### PR TITLE
Adding a instance loaded hook

### DIFF
--- a/lib/Instance.js
+++ b/lib/Instance.js
@@ -299,5 +299,7 @@ function Instance(opts) {
 		opts.changes = Object.keys(opts.data);
 	}
 
+	Hook.trigger(instance, opts.hooks.loaded);
+	
 	return instance;
 }


### PR DESCRIPTION
Adding a hook that is trigger once the model instance has been loaded, allows extra "calculated" attributes to be set
