### PR TITLE
Fix: undefined model instance parameter causes fatal error

### DIFF
--- a/lib/Model.js
+++ b/lib/Model.js
@@ -42,6 +42,8 @@ function Model(opts) {
 				});
 			});
 			return instance;
+		} else if (typeof data == "undefined") {
+			data = {};
 		}
 		return new Instance({
 			id                     : opts.id,


### PR DESCRIPTION
This push allows using no parameters to create an empty instance of a model.

``` Javascript
var User = db.define("user", {
    //...
});

var empty = new User({}); // Ok
var empty2 = new User(); // Error
```
