### PR TITLE
Added a different postgres driver to the orm 

### DIFF
--- a/lib/Drivers/DDL/postgresaxomic.js
+++ b/lib/Drivers/DDL/postgresaxomic.js
@@ -1,0 +1,136 @@
+exports.drop = function (driver, opts, cb) {
+	var queries = [], pending;
+
+	queries.push("DROP TABLE IF EXISTS " + driver.escapeId(opts.table));
+
+	for (i = 0; i < opts.many_associations.length; i++) {
+		queries.push("DROP TABLE IF EXISTS " + driver.escapeId(opts.many_associations[i].mergeTable));
+	}
+
+	pending = queries.length;
+	for (i = 0; i < queries.length; i++) {
+		driver.db.query(queries[i], function (err) {
+			if (--pending === 0) {
+				return cb(err);
+			}
+		});
+	}
+};
+
+exports.sync = function (driver, opts, cb) {
+	var tables = [];
+	var subqueries = [];
+	var definitions = [];
+	var k, i, pending, tmp;
+
+	definitions.push(driver.escapeId(opts.id) + " SERIAL");
+
+	for (k in opts.properties) {
+		switch (opts.properties[k].type) {
+			case "text":
+				definitions.push(driver.escapeId(k) + " VARCHAR(" + Math.min(Math.max(parseInt(opts.properties[k].size, 10) || 255, 1), 10485760) + ")");
+				break;
+			case "number":
+				definitions.push(driver.escapeId(k) + " REAL");
+				break;
+			case "boolean":
+				definitions.push(driver.escapeId(k) + " BOOLEAN NOT NULL");
+				break;
+			case "date":
+				if (opts.properties[k].time === false) {
+					definitions.push(driver.escapeId(k) + " DATE");
+				} else {
+					definitions.push(driver.escapeId(k) + " TIMESTAMP WITHOUT TIME ZONE"); // hmm... I'm not sure..
+				}
+				break;
+			case "binary":
+				definitions.push(driver.escapeId(k) + " BYTEA");
+				break;
+			case "enum":
+				tmp = driver.escapeId("enum_" + opts.table + "_" + k);
+				subqueries.push(
+					"CREATE TYPE " + tmp + " AS ENUM (" +
+					opts.properties[k].values.map(driver.escape.bind(driver.db)) + ")"
+				);
+				definitions.push(driver.escapeId(k) + " " + tmp);
+				break;
+			default:
+				throw new Error("Unknown property type: '" + opts.properties[k].type + "'");
+		}
+	}
+
+	for (i = 0; i < opts.one_associations.length; i++) {
+		definitions.push(driver.escapeId(opts.one_associations[i].field) + " INTEGER NOT NULL");
+	}
+	for (k in opts.properties) {
+		if (opts.properties[k].unique === true) {
+			definitions.push("UNIQUE (" + driver.escapeId(k) + ")");
+		}
+	}
+
+	tables.push({
+		name       : opts.table,
+		query      : "CREATE TABLE " + driver.escapeId(opts.table) +
+		             " (" + definitions.join(", ") + ")",
+		subqueries : subqueries
+	});
+	tables[tables.length - 1].subqueries.push(
+		"CREATE INDEX ON " + driver.escapeId(opts.table) +
+		" (" + driver.escapeId(opts.id) + ")"
+	);
+
+	for (i = 0; i < opts.one_associations.length; i++) {
+		tables[tables.length - 1].subqueries.push(
+			"CREATE INDEX ON " + driver.escapeId(opts.table) +
+			" (" + driver.escapeId(opts.one_associations[i].field) + ")"
+		);
+	}
+
+	for (i = 0; i < opts.many_associations.length; i++) {
+		tables.push({
+			name       : opts.many_associations[i].mergeTable,
+			query      : "CREATE TABLE IF NOT EXISTS " + driver.escapeId(opts.many_associations[i].mergeTable) +
+			             " (" +
+			             driver.escapeId(opts.many_associations[i].mergeId) + " INTEGER NOT NULL, " +
+			             driver.escapeId(opts.many_associations[i].mergeAssocId) + " INTEGER NOT NULL" +
+			             ")",
+			subqueries : []
+		});
+		tables[tables.length - 1].subqueries.push(
+			"CREATE INDEX ON " + driver.escapeId(opts.many_associations[i].mergeTable) +
+			" (" +
+			driver.escapeId(opts.many_associations[i].mergeId) + ", " +
+			driver.escapeId(opts.many_associations[i].mergeAssocId) +
+			")"
+		);
+	}
+
+	pending = tables.length;
+	for (i = 0; i < tables.length; i++) {
+		createTableSchema(driver, tables[i], function (err) {
+			if (--pending === 0) {
+				// this will bring trouble in the future...
+				// some errors are not avoided (like ENUM types already defined, etc..)
+				return cb(err);
+			}
+		});
+	}
+};
+
+function createTableSchema(driver, table, cb) {
+	driver.db.query(table.query, function (err) {
+		if (err || table.subqueries.length === 0) {
+			return cb();
+		}
+
+		var pending = table.subqueries.length;
+
+		for (var i = 0; i < table.subqueries.length; i++) {
+			driver.db.query(table.subqueries[i], function (err) {
+				if (--pending === 0) {
+					return cb();
+				}
+			});
+		}
+	});
+}

--- a/lib/Drivers/DML/postgresaxomic.js
+++ b/lib/Drivers/DML/postgresaxomic.js
@@ -1,0 +1,224 @@
+var postgres       = require("pg"),
+	connectionString = '';
+
+exports.Driver = Driver;
+
+function Driver(config, connection, opts) {
+	this.connectionString = "postgresql"+config.href.substring(14);
+	this.config = config || {};
+	this.opts   = opts || {};
+	this.db = postgres;
+	var escapes = {
+		escape   : this.escape.bind(this),
+		escapeId : this.escapeId.bind(this)
+	};
+
+	this.QuerySelect = new (require("../../sql/Select"))(escapes);
+	this.QueryInsert = new (require("../../sql/Insert"))(escapes);
+	this.QueryUpdate = new (require("../../sql/Update"))(escapes);
+	this.QueryRemove = new (require("../../sql/Remove"))(escapes);
+}
+Driver.prototype.sync = function (opts, cb) {
+	return require("../DDL/postgres").sync(this, opts, cb);
+};
+
+Driver.prototype.drop = function (opts, cb) {
+	return require("../DDL/postgres").drop(this, opts, cb);
+};
+Driver.prototype.connect = function (cb) {
+	//console.log("connect called");
+	cb(null);
+	//this.db.connect(cb);
+};
+
+Driver.prototype.close = function (cb) {
+	//console.log("end called");
+	cb(null);
+	//
+	//this.db.end(cb);
+};
+Driver.prototype.on = function (ev, cb) {
+	//console.log("Driver.on called");
+	//console.log(ev);
+	if (ev == "error") {
+//		this.db.on("error", cb);
+	}
+	return this;
+};
+
+Driver.prototype.find = function (fields, table, conditions, opts, cb) {
+	this.QuerySelect
+		.clear()
+		.fields(fields)
+		.table(table);
+	if (opts.fields) {
+		this.QuerySelect.fields(opts.fields);
+	}
+	if (opts.merge) {
+		this.QuerySelect.merge(opts.merge.from, opts.merge.to);
+	}
+	if (opts.offset) {
+		this.QuerySelect.offset(opts.offset);
+	}
+	if (typeof opts.limit == "number") {
+		this.QuerySelect.limit(opts.limit);
+	}
+	if (opts.order) {
+		this.QuerySelect.order(opts.order[0], opts.order[1]);
+	}
+	for (var k in conditions) {
+		this.QuerySelect.where(k, conditions[k]);
+	}
+
+	if (this.opts.debug) {
+		require("../Debug").sql('postgres', this.QuerySelect.build());
+	}
+	this.hijackQuery(this.QuerySelect.build(), handleQuery(cb));
+};
+Driver.prototype.count = function (table, conditions, cb) {
+	this.QuerySelect
+		.clear()
+		.count()
+		.table(table);
+	for (var k in conditions) {
+		this.QuerySelect.where(k, conditions[k]);
+	}
+
+	if (this.opts.debug) {
+		require("../../Debug").sql('postgres', this.QuerySelect.build());
+	}
+	this.hijackQuery(this.QuerySelect.build(), handleQuery(cb));
+};
+Driver.prototype.insert = function (table, data, cb) {
+	this.QueryInsert
+		.clear()
+		.table(table);
+	for (var k in data) {
+		this.QueryInsert.set(k, data[k]);
+	}
+	if (this.opts.debug) {
+		require("../../Debug").sql('postgres', this.QueryInsert.build());
+	}
+	this.hijackQuery(this.QueryInsert.build() + " RETURNING *", function (err, result) {
+		if (err) {
+			return cb(err);
+		}
+		return cb(null, {
+			id: result.rows[0].id || null
+		});
+	});
+};
+
+Driver.prototype.update = function (table, changes, conditions, cb) {
+	this.QueryUpdate
+		.clear()
+		.table(table);
+	for (var k in conditions) {
+		this.QueryUpdate.where(k, conditions[k]);
+	}
+	for (k in changes) {
+		this.QueryUpdate.set(k, changes[k]);
+	}
+	if (this.opts.debug) {
+		require("../../Debug").sql('postgres', this.QueryUpdate.build());
+	}
+	this.hijackQuery(this.QueryUpdate.build(), handleQuery(cb));
+};
+
+Driver.prototype.remove = function (table, conditions, cb) {
+	this.QueryRemove
+		.clear()
+		.table(table);
+	for (var k in conditions) {
+		this.QueryRemove.where(k, conditions[k]);
+	}
+
+	if (this.opts.debug) {
+		require("../../Debug").sql('postgres', this.QueryRemove.build());
+	}
+	this.hijackQuery(this.QueryRemove.build(), handleQuery(cb));
+};
+
+Driver.prototype.clear = function (table, cb) {
+	var query = "TRUNCATE TABLE " + escapeId(table);
+
+	if (this.opts.debug) {
+		require("../../Debug").sql('postgres', query);
+	}
+	this.hijackQuery(query, handleQuery(cb));
+};
+
+Driver.prototype.valueToProperty = function (value, property) {
+	switch (property.type) {
+		case "object":
+			try {
+				return JSON.parse(value);
+			} catch (e) {
+				return null;
+			}
+			break;
+		default:
+			return value;
+	}
+};
+
+Driver.prototype.propertyToValue = function (value, property) {
+	switch (property.type) {
+		case "object":
+			return JSON.stringify(value);
+		default:
+			return value;
+	}
+};
+
+Driver.prototype.hijackQuery = function (receievedQuery, cb) {
+
+  this.db.connect(this.connectionString, function(err, client) {
+	  if(err){
+		  console.log("Error from PostgresAxomic");
+		  console.log(err);
+	  }
+	client.query(receievedQuery, cb);
+  })
+}
+
+Driver.prototype.escapeId = function (id) {
+	var m = id.match(/^(.+)\.\*$/);
+	if (m) {
+		return '"' + m[1].replace(/\"/g, '""') + '".*';
+	}
+	return '"' + id.replace(/\"/g, '""').replace(/\./g, '"."') + '"';
+};
+
+Driver.prototype.escape = function (value) {
+	if (Array.isArray(value)) {
+		if (value.length === 1 && Array.isArray(value[0])) {
+			return "(" + value[0].map(this.escape.bind(this)) + ")";
+		}
+		return "(" + value.map(this.escape.bind(this)) + ")";
+	}
+	switch (typeof value) {
+		case "number":
+			return value;
+	}
+
+
+	if(!value) {
+		return value
+	} else {
+		return "'" + value.replace(/\'/g, "''") + "'";
+	}
+};
+
+function handleQuery(cb) {
+	return function (err, result) {
+		if (err) {
+			return cb(err);
+		}
+		return cb(null, result.rows);
+	};
+}
+
+
+
+

--- a/lib/Drivers/aliases.js
+++ b/lib/Drivers/aliases.js
@@ -1,4 +1,5 @@
 module.exports = {
 	postgresql : "postgres",
-	pg         : "postgres"
+	pg         : "postgres",
+	postgresaxomic: "postgresaxomic"
 };


### PR DESCRIPTION
The driver uses the client pooling functionality in BrianC's Postgres driver.

There are some rough edges - internally we just replaced 'postgres' in the connection string with 'postgresaxomic' to access the driver in keeping with the established behaviour in node-orm2. 

Each 'postgresaxomic' Driver object also isn't following normal procedure of attaching itself as a listener for errors but that can be reinstated. 

The DDL file has no changes at the moment. 

Also trying to make certain that the ORM objects are being properly removed and then cleared up during GC. Early stress-testing didn't uncover anything.

Feel free to change the name to something like 'postgress-clientpooling' or whatever :)
