### PR TITLE
using process.cwd() to require modules relative to project directory

### DIFF
--- a/lib/ORM.js
+++ b/lib/ORM.js
@@ -123,7 +123,7 @@ ORM.prototype.close = function (cb) {
 };
 ORM.prototype.load = function (file, cb) {
 	try {
-		require(file)(this, cb);
+		require(process.cwd() + '/' + file)(this, cb);
 	} catch (ex) {
 		return cb(ex);
 	}


### PR DESCRIPTION
Tiny change that could resolve my issue (#44).  The issue here is that absolute directories wouldn't work - you couldn't do `db.load('/models.db')`.

A straightforward fix could be to look at file being passed into ORM::load and leaving it intact if it starts with a `/`. Not sure if this is the best approach.
