### PR TITLE
hasMany association properties not being checked

### DIFF
--- a/lib/Associations/Many.js
+++ b/lib/Associations/Many.js
@@ -1,6 +1,7 @@
 var InstanceConstructor = require("../Instance").Instance;
 var Singleton           = require("../Singleton");
 var Settings            = require("../Settings");
+var Property            = require("../Property");
 
 exports.prepare = function (Model, associations) {
 	Model.hasMany = function () {
@@ -28,6 +29,10 @@ exports.prepare = function (Model, associations) {
 		}
 		if (props === null) {
 			props = {};
+		} else {
+			for (var k in props) {
+				props[k] = Property.check(props[k]);
+			}
 		}
 
 		var assocName = opts.name || ucfirst(name);


### PR DESCRIPTION
(The following has been tested with the MySQL driver)

Consider the following hasMany relationship:

``` javascript
Person.hasMany('things', {
    price_paid: {type:'number'},
    year_bought: String
});
```

Now imagine `sync` is invoked on all tables. In 2.0.2 price_paid works fine, however year_bought results in a value of `undefined` being passed for the `prop` argument in `buildColumnDefinition`, and throws an error.

I poked around and I think this is due to the fact that `Property`s `check` method is not transforming the types of any `many_associations`. The attached code is a simple copy/paste job that duplicates the check code from `ORM.prototype.define` into the `Many` class.

This fix allows both of the additional properties for this association to sync correctly.

I can help if more is needed or this should be organized in a different manner.
