### PR TITLE
Fix postgresql integer columns

### DIFF
--- a/lib/Drivers/DDL/postgres.js
+++ b/lib/Drivers/DDL/postgres.js
@@ -130,7 +130,7 @@ function buildColumnDefinition(driver, table, name, prop) {
 			break;
 		case "number":
 			if (prop.rational === false) {
-				def = driver.escapeId(name) + " NUMERIC(0)";
+				def = driver.escapeId(name) + " INTEGER";
 			} else {
 				def = driver.escapeId(name) + " REAL";
 			}

--- a/lib/Drivers/DDL/postgresaxomic.js
+++ b/lib/Drivers/DDL/postgresaxomic.js
@@ -130,7 +130,7 @@ function buildColumnDefinition(driver, table, name, prop) {
 			break;
 		case "number":
 			if (prop.rational === false) {
-				def = driver.escapeId(name) + " NUMERIC(0)";
+				def = driver.escapeId(name) + " INTEGER";
 			} else {
 				def = driver.escapeId(name) + " REAL";
 			}


### PR DESCRIPTION
Version: 2.0.2, Database: PostgreSQL

``` javascript
db.define('house', {
  toiletCount: { type: 'number', rational: false }
}).sync();
```

executes:

``` sql
CREATE TABLE "house"(
 "id"               SERIAL PRIMARY KEY,
 "toiletCount"  NUMERIC(0)
);
```

which results in:
`ERROR: NUMERIC precision 0 must be between 1 and 1000`

`INTEGER` is a much better choice; From the PostgreSQL docs:

> ...arithmetic on numeric values is very slow compared to the integer types...
