### PR TITLE
Adds posibility to define order array in options argument of Model.find method regards addition of order to hasMany getAccessor

### DIFF
--- a/lib/Model.js
+++ b/lib/Model.js
@@ -191,6 +191,10 @@ function Model(opts) {
 							if (options.hasOwnProperty("__merge")) {
 								merge = options.__merge;
 								delete options.__merge;
+							} 
+							if (options.hasOwnProperty("order")) {
+								order = options.order;
+								delete options.order;
 							}
 						}
 					}


### PR DESCRIPTION
Hi,
I think there is a little problem in your [https://github.com/dresende/node-orm2/commit/742212caef8a01b776dd6d553efc8f14d22be3ba], because the `order` array is passed within the `options` argument, but in the `Model.find` method is just checked as an argument. So I added the `options` argument checking for `order`.

Perhaps it would be more elegant to modify `Model.find` call in `association.getAccessor` of `Many.js`.

So there is my first try for pull request. I hope you don't mind. 
