### PR TITLE
Adds test for Issue #69

### DIFF
--- a/test/integration/test-hook-before-create-define-property.js
+++ b/test/integration/test-hook-before-create-define-property.js
@@ -17,10 +17,8 @@ common.createConnection(function (err, db) {
 		var Test = new TestModel();
 		Test.save(function (err) {
 			assert.equal(err, null);
-			
-			db.close(function () {
-				assert.equal(Test.name, name);
-			});
+			assert.equal(Test.name, name);
+			db.close();
 		});
 	});
 });


### PR DESCRIPTION
I think this is sufficient to test for Issue #69. Creates a test model from the `common.js` description with no properties defined, then the `beforeCreate` hook initializes the `name` property. I tested with Postgres:

```
$ ORM_PROTOCOL=postgres node test/run                                
[i] Testing postgres
[i] URI: postgres://markroberts@localhost/node-orm2-test
[0:00:19 0 78/78 100.0% node test/integration/test-validators.js]
```
