### PR TITLE
Correct 'returnAllErrors' setting behaviour

### DIFF
--- a/lib/Instance.js
+++ b/lib/Instance.js
@@ -50,7 +50,7 @@ function Instance(opts) {
 					err.msg   = msg;
 					err.type  = "validation";
 
-					if (opts.model.settings.get("instance.returnAllErrors")) {
+					if (!opts.model.settings.get("instance.returnAllErrors")) {
 						return cb(err);
 					}
 

--- a/lib/Settings.js
+++ b/lib/Settings.js
@@ -10,7 +10,7 @@ var default_settings = {
 		autoFetch       : false,
 		autoFetchLimit  : 1,
 		cascadeRemove   : true,
-		returnAllErrors : true
+		returnAllErrors : false
 	}
 };
 


### PR DESCRIPTION
I think when you renamed `breakSaveOnErrors` to `returnAllErrors` you forgot to flip the value.

As a side note, I noticed one of the tests is failing (test-aggregate-groupby), but it seems unrelated to this issue.
