### PR TITLE
Adds support for chaining and rechaining with ChainFind

### DIFF
--- a/lib/ChainFind.js
+++ b/lib/ChainFind.js
@@ -3,8 +3,14 @@ var ChainInstance   = require("./ChainInstance");
 
 module.exports = ChainFind;
 
-function ChainFind(opts) {
+function ChainFind(Model, opts) {
 	var chain = {
+		find: function (conditions) {
+			for (var k in conditions) {
+				opts.conditions[k] = conditions[k];
+			}
+			return this;
+		},
 		only: function () {
 			if (arguments.length && Array.isArray(arguments[0])) {
 				opts.only = arguments[0];
@@ -115,6 +121,14 @@ function ChainFind(opts) {
 		for (var i = 0; i < opts.associations.length; i++) {
 			addChainMethod(chain, opts.associations[i], opts);
 		}
+	}
+	for (var k in Model) {
+		if ([ "hasOne", "hasMany",
+		      "drop", "sync", "get", "find", "count", "clear", "create",
+		      "exists", "settings", "aggregate" ].indexOf(k) >= 0) continue;
+		if (typeof Model[k] != "function") continue;
+
+		chain[k] = Model[k];
 	}
 	return chain;
 }

--- a/lib/Model.js
+++ b/lib/Model.js
@@ -229,7 +229,7 @@ function Model(opts) {
 			order = Utilities.standardizeOrder(order);
 		}
 
-		var chain = new ChainFind({
+		var chain = new ChainFind(model, {
 			only         : options.only || model_fields,
 			id           : opts.id,
 			table        : opts.table,

--- a/test/integration/test-find-rechain.js
+++ b/test/integration/test-find-rechain.js
@@ -1,0 +1,34 @@
+var common     = require('../common');
+var assert     = require('assert');
+
+common.createConnection(function (err, db) {
+	common.createModelTable('test_find_rechain', db.driver.db, function () {
+		common.insertModelData('test_find_rechain', db.driver.db, [
+			{ id : 1, name : 'test1' },
+			{ id : 2, name : 'test2' },
+			{ id : 3, name : 'test1' },
+			{ id : 4, name : 'test2' },
+			{ id : 5, name : 'test1' },
+			{ id : 6, name : 'test2' }
+		], function (err) {
+			if (err) throw err;
+
+			var TestModel = db.define('test_find_rechain', common.getModelProperties());
+
+			TestModel.aboveId3 = function () {
+				return this.find({ id : db.tools.gt(3) });
+			};
+			TestModel.onlyTest1 = function () {
+				return this.find({ name : 'test1' });
+			};
+
+			TestModel.aboveId3().onlyTest1().run(function (err, Instances) {
+				assert.equal(err, null);
+				assert.equal(Array.isArray(Instances), true);
+				assert.equal(Instances[0].id, 5);
+				assert.equal(Instances[0].name, 'test1');
+				db.close();
+			});
+		});
+	});
+});


### PR DESCRIPTION
As pointed out by @dxg in #131 , this might be a very good feature.

An example (similar to the test file in this pull request):

``` js
var Person = db.define('person', {
    // ...
});

Person.onlyAdmins = function () {
    return this.find({ admin : true });
};
Person.fromCountry = function (country) {
    return this.find({ country : country });
};

Person.onlyAdmins().fromCountry("India").run(function (err, people) {
    // people with admin = true and country = "India"
});
```

The `this.find` used in the first 2 functions is actually a function of the `ChainFind` that for now only accepts conditions but other stuff can be added. Also, when a new `ChainFind` instance is created, the methods added to `Person` are also linked to the chain. That's why it's possible to chain more than one method, otherwise chaining only one method was already possible.
