### PR TITLE
Allow passing a single object to Model.create.

### DIFF
--- a/lib/Model.js
+++ b/lib/Model.js
@@ -398,10 +398,10 @@ function Model(opts) {
 	model.create = function () {
 		var Instances = [];
 		var options = {};
-		var cb = null, idx = 0;
+		var cb = null, idx = 0, single = false;
 		var createNext = function () {
 			if (idx >= Instances.length) {
-				return cb(null, Instances);
+				return cb(null, single ? Instances[0] : Instances);
 			}
 
 			Instances[idx] = createInstance(Instances[idx], {
@@ -423,14 +423,16 @@ function Model(opts) {
 		};
 
 		for (var i = 0; i < arguments.length; i++) {
-			if (Array.isArray(arguments[i])) {
-				Instances = Instances.concat(arguments[i]);
-				continue;
-			}
-
 			switch (typeof arguments[i]) {
 				case "object":
-					options = arguments[i];
+					if ( !single && Array.isArray(arguments[i]) ) {
+						Instances = Instances.concat(arguments[i]);
+					} else if (i == 0) {
+						single = true;
+						Instances.push(arguments[i]);
+					} else {
+						options = arguments[i];
+					}
 					break;
 				case "function":
 					cb = arguments[i];

--- a/package.json
+++ b/package.json
@@ -43,7 +43,8 @@
     "urun"      : "0.0.6",
     "mysql"     : "2.0.0-alpha7",
     "pg"        : "1.0.0",
-    "sqlite3"   : "2.1.5"
+    "sqlite3"   : "2.1.5",
+    "async"     : "*"
   },
   "optionalDependencies": {}
 }

--- a/test/integration/test-create.js
+++ b/test/integration/test-create.js
@@ -1,20 +1,58 @@
 var common     = require('../common');
 var assert     = require('assert');
+var async      = require('async');
 
 common.createConnection(function (err, db) {
 	common.createModelTable('test_create', db.driver.db, function () {
 		var TestModel = db.define('test_create', common.getModelProperties());
 
-		TestModel.create([
-			{ name: 'test1' },
-			{ name: 'test2' },
-			{ name: 'test3' }
-		], function (err) {
-			TestModel.count(function (err, count) {
-				assert.equal(err, null);
-				assert.equal(count, 3);
-				db.close();
-			});
+		async.series([
+			// Test that items are actually created
+			function (done) {
+				TestModel.create([
+					{ name: 'test1' },
+					{ name: 'test2' },
+					{ name: 'test3' }
+				], function (err) {
+					TestModel.count(function (err, count) {
+						assert.equal(err, null);
+						assert.equal(count, 3);
+						done();
+					});
+				});
+			},
+			function (done) {
+				TestModel.create({ name: 'test4' }, function (err) {
+					TestModel.count(function (err, count) {
+						assert.equal(err, null);
+						assert.equal(count, 4);
+						done();
+					});
+				});
+			},
+			// Test callback arguments
+			function (done) {
+				TestModel.create([
+					{ name: 'test5' },
+					{ name: 'test6' }
+				], function (err, items) {
+					assert.equal(err, null);
+					assert.equal(Array.isArray(items), true);
+					assert.equal(items.length, 2);
+					done();
+				});
+			},
+			function (done) {
+				TestModel.create({ name: 'test7' }, function (err, item) {
+					assert.equal(err, null);
+					assert.equal(Array.isArray(item), false);
+					assert.equal(item.name, 'test7');
+					assert.equal(item.hasOwnProperty('id'), true);
+					done();
+				});
+			}
+		], function complete() {
+			db.close();
 		});
 	});
 });


### PR DESCRIPTION
Addresses #159 

Enables:

``` js
Model.create({name: 'jane'}, function(err, item) {
  // item is not an array, but a single object
});
Model.create([{name: 'jane'}], function(err, items) {
  // items is an array
});
```

It seems that you can pass the same parameters to `Model.create` in many different ways.
Eg:

``` js
Model.create([{name: 'jane'}, {name: 'john'}], function (err, items) { ... } );
Model.create([{name: 'jane'}], [{name: 'john'}], function (err, items) { ... } );
Model.create([{name: 'jane'}], function (err, items) { ... }, [{name: 'john'}] );
Model.create([{name: 'jane'}], function (err, items) { ... }, {someOption: false}, [{name: 'john'}] );
```

are all equivalent.

This PR limits this somewhat, as the first argument which is an object but not an array is assumed to be a single item to be created.

I think this is resonable.
I also think the way parameters are accepted is a little _too_ flexible. Requiring that the first parameter is the item(s) to be created, and last parameter is the callback (with an optional middle options param) would make the code a bit easier to read.
