### PR TITLE
Allow db.load() to work outside of module.exports

### DIFF
--- a/lib/ORM.js
+++ b/lib/ORM.js
@@ -224,6 +224,8 @@ ORM.prototype.load = function (file, cb) {
 		cwd = path.dirname(m[1]);
 	} else if ((m = tmp.match(/^\s*at\s+module\.exports\s+\((.+?)\)/)) !== null) {
 		cwd = path.dirname(m[1]);
+	} else if ((m = tmp.match(/^\s*at\s+.+\s+\((.+):\d+:\d+\)$/)) !== null) {
+		cwd = path.dirname(m[1]);
 	}
 
 	if (file[0] != path.sep) {


### PR DESCRIPTION
As it works now, db.load() will load models correctly from a call at the highest level of a script, or from within module.exports, but not from an arbitrary function. This change aims to correct behavior:

Before:

``` javascript```
MyObj.prototype.initDB = function() {
    this.db.load("./model", function(err) {
        console.log(err);
    });
    console.log(this.db.models);
};

{ [Error: Cannot find module '/<SRC DIRECTORY>/./model'] code: 'MODULE_NOT_FOUND' }
{}
```

After:

``` javascript```
MyObj.prototype.initDB = function() {
    this.db.load("./model", function(err) {
        console.log(err);
    });
    console.log(this.db.models);
};

undefined
{<MODEL CONTENTS>}
```
