### PR TITLE
Allow multiple calls to order in aggregates

### DIFF
--- a/lib/AggregateFunctions.js
+++ b/lib/AggregateFunctions.js
@@ -10,6 +10,7 @@ function AggregateFunctions(opts) {
 
 	var aggregates    = [ [] ];
 	var group_by      = null;
+	var order_by      = opts.order ? [opts.order] : [];
 	var used_distinct = false;
 
 	var appendFunction = function (fun) {
@@ -44,7 +45,7 @@ function AggregateFunctions(opts) {
 			return this;
 		},
 		order: function (property, order) {
-			opts.order = [ property, order ];
+			order_by.push([ property, order ]);
 			return this;
 		},
 		select: function () {
@@ -92,9 +93,10 @@ function AggregateFunctions(opts) {
 				query.groupBy.apply(query, group_by);
 			}
 
-			if (opts.order) {
-				query.order.apply(query, opts.order);
+			for(var i = 0; i < order_by.length; i++){
+				query.order.apply(query, order_by[i]);
 			}
+
 			if (opts.limit) {
 				query.offset(opts.limit[0]).limit(opts.limit[1]);
 			}


### PR DESCRIPTION
In `Model.find()` you can order by multiple columns, this was not possible in aggregates
