### PR TITLE
Bugfix for optional foreign keys

### DIFF
--- a/lib/Instance.js
+++ b/lib/Instance.js
@@ -546,7 +546,7 @@ function Instance(Model, opts) {
 			addInstanceProperty(asc.field);
 		}
 		if (opts.data.hasOwnProperty(asc.name)) {
-			if (typeof opts.data[asc.name] == "object") {
+			if (opts.data[asc.name] instanceof Object) {
 				if (opts.data[asc.name].isInstance) {
 					instance[asc.name] = opts.data[asc.name];
 				} else {


### PR DESCRIPTION
lib/Instance.js:549 uses 'typeof' to check if opts.data[asc.name] is an object. However, 'typeof null == "object"'. Therefore when opts.data[asc.name] == null the condition on line 549 would evaluate to true and line 550 will throw an error.

This situation occurs at least when an optional FK is defined (postgres) and its value is null. Other situations might trigger this error as well.

This bugfix changes line 549 such that it uses 'instanceof' instead of 'typeof'.
