### PR TITLE
Check for the existence of this.config.query in sqlite driver

### DIFF
--- a/lib/Drivers/DML/sqlite.js
+++ b/lib/Drivers/DML/sqlite.js
@@ -229,7 +229,7 @@ Driver.prototype.propertyToValue = function (value, property) {
 		case "object":
 			return JSON.stringify(value);
 		case "date":
-			if (this.config.query.strdates) {
+			if (this.config.query && this.config.query.strdates) {
 				if (value instanceof Date) {
 					var year = value.getUTCFullYear();
 					var month = value.getUTCMonth() + 1;


### PR DESCRIPTION
Otherwise, if there is no query section in the config then we'll
throw an exception when we check this.config.query.strdates.

see https://github.com/thedjpetersen/subway/issues/256
