### PR TITLE
Add capability for an array to be passed to the reversed hasOne set accessor

### DIFF
--- a/lib/Associations/One.js
+++ b/lib/Associations/One.js
@@ -187,9 +187,33 @@ function extendInstance(Model, Instance, Driver, association, opts) {
 						return cb(err);
 					}
 
-					util.populateConditions(Model, Object.keys(association.field), Instance, OtherInstance, true);
+					if (!Array.isArray(OtherInstance)) {
+						util.populateConditions(Model, Object.keys(association.field), Instance, OtherInstance, true);
 
-					return OtherInstance.save({}, { saveAssociations: false }, cb);
+						return OtherInstance.save({}, { saveAssociations: false }, cb);
+					}
+
+					var associations = _.clone(OtherInstance);
+
+					var saveNext = function () {
+						if (!associations.length) {
+							return cb();
+						}
+
+						var other = associations.pop();
+
+						util.populateConditions(Model, Object.keys(association.field), Instance, other, true);
+
+						other.save({}, { saveAssociations: false }, function (err) {
+							if (err) {
+								return cb(err);
+							}
+
+							saveNext();
+						});
+					};
+
+					return saveNext();
 				});
 			} else {
 				OtherInstance.save({}, { saveAssociations: false }, function (err) {


### PR DESCRIPTION
Obviously hasOne is a one to many relationship. When fetching the reversed model of the hasOne association we get an array, however trying to set an array results in an error.

This should help alleviate the problem and act as sugar so users don't have to make their own looping construct to save these associations.
