### PR TITLE
Fix for saving of Instance.extra fields.

### DIFF
--- a/lib/Instance.js
+++ b/lib/Instance.js
@@ -312,7 +312,7 @@ function Instance(Model, opts) {
 			}
 		}
 
-		for (i = 0; i < opts.extra_info.id; i++) {
+		for (i = 0; i < opts.extra_info.id.length; i++) {
 		    conditions[opts.extra_info.id_prop[i]] = opts.extra_info.id[i];
 		    conditions[opts.extra_info.assoc_prop[i]] = opts.data[opts.id[i]];
 		}


### PR DESCRIPTION
When an extra value in a to-many relationship table has been changed, the saving logic breaks in the instance class. This fix worked for me. In the snippet I changed, opts.extra_info.id is an array containing the column names of each of the extra fields that need to be saved. I changed it so that instead of comparing the iterator variable i to the id array (which didn't make sense), you instead compare to the length of the array.
