### PR TITLE
Fix for incorrect argument handling in delete accessor of Many association

### DIFF
--- a/lib/Associations/Many.js
+++ b/lib/Associations/Many.js
@@ -257,9 +257,22 @@ function extendInstance(Model, Instance, Driver, association, opts, createInstan
 	});
 	Object.defineProperty(Instance, association.delAccessor, {
 		value: function () {
-			var Associations = Array.prototype.slice.apply(arguments);
-			var cb = (typeof Associations[Associations.length - 1] == "function" ? Associations.pop() : noOperation);
-			Associations = (Associations[0] instanceof Array ? Associations.pop() : Associations)
+			var Associations = [];
+			var cb = noOperation;
+			for (var i = 0; i < arguments.length; i++) {
+				switch (typeof arguments[i]) {
+					case "function":
+						cb = arguments[i];
+						break;
+					case "object":
+						if (Array.isArray(arguments[i])) {
+							Associations = Associations.concat(arguments[i]);
+						} else if (arguments[i].isInstance) {
+							Associations.push(arguments[i]);
+						}
+						break;
+				}
+			}
 			var conditions = {};
 			var run = function () {
 				if (Driver.hasMany) {


### PR DESCRIPTION
The delete accessor of the Many association wasn't correctly handling the removal of several associations when it was passed an array. It set the Associations variable incorrectly, so the conditions were being built wrong and no records were being deleted. I replaced the old argument handling logic with the more robust logic used in the add accessor.
