### PR TITLE
Fixes a bug in the express README documentation

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -93,6 +93,7 @@ var app = express();
 app.use(orm.express("mysql://username:password@host/database", {
 	define: function (db, models, next) {
 		models.person = db.define("person", { ... });
+		next();
 	}
 }));
 app.listen(80);


### PR DESCRIPTION
In the README in the part with the express setup, The next() method isn't called which causes the nodejs application to just hang if applied in a real application. I added it to the README.
