### PR TITLE
Fixes erroneous misformatting of top-level $and/$or clauses

### DIFF
--- a/lib/Drivers/DML/mongodb.js
+++ b/lib/Drivers/DML/mongodb.js
@@ -353,7 +353,7 @@ Driver.prototype.clear = function (table, cb) {
 
 function convertToDB(obj, timeZone) {
 	for (var k in obj) {
-		if (Array.isArray(obj[k])) {
+		if (Array.isArray(obj[k]) && k[0] != '$') {
 			for (var i = 0; i < obj[k].length; i++) {
 				obj[k][i] = convertToDBVal(k, obj[k][i], timeZone);
 			}


### PR DESCRIPTION
Top-level $and/$or clauses are surprisingly common when you're doing nontrivial queries from your app. Example:

```
{
    field: cond,
    $and: [condA, condB, condC]
}
```

Often there's no way to rewrite these subconditions as top-level conditions. They can be arbitrarily complex.

A simple check for $operators in the `convertToDB` helper function allows this to happen.
