### PR TITLE
DML mysql Driver this.config bug

### DIFF
--- a/lib/Drivers/DML/mysql.js
+++ b/lib/Drivers/DML/mysql.js
@@ -13,7 +13,7 @@ function Driver(config, connection, opts) {
 	if (!this.config.timezone) {
 		this.config.timezone = "local";
 	}
-	this.query  = new Query({ dialect: "mysql", timezone: config.timezone });
+	this.query  = new Query({ dialect: "mysql", timezone: this.config.timezone });
 
 	this.reconnect(null, connection);
 


### PR DESCRIPTION
The `this.config` is well checked  at line 13 but for the query used the passed config on line 16 and failed if the config is `null`
