### PR TITLE
Allow property.select to override the property field name.

### DIFF
--- a/lib/Model.js
+++ b/lib/Model.js
@@ -625,6 +625,7 @@ function Model(opts) {
 		}
 	}
 
+	var cur_fields = {};
 	// standardize properties
 	for (k in opts.properties) {
 		opts.properties[k] = Property.normalize(opts.properties[k], opts.db.customTypes, opts.settings);
@@ -635,8 +636,9 @@ function Model(opts) {
 			opts.properties[k].key = true;
 		}
 
-		if (opts.properties[k].lazyload !== true && model_fields.indexOf(k) == -1) {
-			model_fields.push(k);
+		if (opts.properties[k].lazyload !== true && !cur_fields[k]) {
+			cur_fields[k] = true;
+			model_fields.push(opts.properties[k].select || k);
 		}
 		if (opts.properties[k].required) {
 			// Prepend `required` validation


### PR DESCRIPTION
This is a generic way to address
https://github.com/dresende/node-orm2/issues/273
Important: property.select can be a function, whose
return value won't be escaped.

I'll happily add a test and modify readme.md if that PR is ok.
