### PR TITLE
Custom type.datastoreSelect as a default prop.select

### DIFF
--- a/lib/Model.js
+++ b/lib/Model.js
@@ -626,6 +626,7 @@ function Model(opts) {
 	}
 
 	var cur_fields = {};
+	var field_select;
 	// standardize properties
 	for (k in opts.properties) {
 		opts.properties[k] = Property.normalize(opts.properties[k], opts.db.customTypes, opts.settings);
@@ -638,7 +639,17 @@ function Model(opts) {
 
 		if (opts.properties[k].lazyload !== true && !cur_fields[k]) {
 			cur_fields[k] = true;
-			model_fields.push(opts.properties[k].select || k);
+			field_select = opts.db.customTypes && opts.db.customTypes[opts.properties[k].type];
+			if (field_select) field_select = field_select.datastoreSelect;
+			// wrap function to pass k as argument and keep context (unlike bind)
+			if (typeof field_select == "function") {
+				field_select = (function(fun, prop) {
+					return function(helpers) {
+						return fun.call(this, prop, helpers);
+					};
+				})(field_select, k);
+			}
+			model_fields.push(opts.properties[k].select || field_select || k);
 		}
 		if (opts.properties[k].required) {
 			// Prepend `required` validation


### PR DESCRIPTION
This follows https://github.com/dresende/node-orm2/pull/375

Typical example on a PostGIS table

```
orm.db.defineType('GeoJSON', {
    datastoreType: function(prop) {
        return 'geometry(Geometry, 4326)';
    },
    datastoreSelect: function(prop, helper) {
        return 'ST_AsGeoJSON(' + prop + ') AS ' + prop;
    },
    valueToProperty: function(value, prop) {
        return JSON.parse(value);
    },
    propertyToValue: function(value, prop) {
        return "ST_SetSRID(ST_GeomFromGeoJSON('" + JSON.stringify(value) + "'), 4326)";
    }
});
```
