### PR TITLE
postgres: always save object as Buffer

### DIFF
--- a/lib/Drivers/DML/postgres.js
+++ b/lib/Drivers/DML/postgres.js
@@ -302,7 +302,9 @@ Driver.prototype.propertyToValue = function (value, property) {
 
 	switch (property.type) {
 		case "object":
-			value = JSON.stringify(value);
+			if (!Buffer.isBuffer(value)) {
+				value = new Buffer(JSON.stringify(value));
+			}
 			break;
 		case "date":
 			if (this.config.timezone && this.config.timezone != 'local') {


### PR DESCRIPTION
There is either a problem with Dialect.escapeVal,
or a problem with postgres 9.3 when casting string
to bytea. Some strings are not accepted (because of \ ?)
