### PR TITLE
postgres: always use TEXT for text. VARCHAR is just an alias.

### DIFF
--- a/lib/Drivers/DDL/postgres.js
+++ b/lib/Drivers/DDL/postgres.js
@@ -183,11 +183,7 @@ function buildColumnDefinition(driver, table, name, prop) {
 
 	switch (prop.type) {
 	    case "text":
-			if (prop.big === true) {
-				def += " TEXT";
-			} else {
-				def += " VARCHAR(" + Math.max(parseInt(prop.size, 10) || 255, 1) + ")";
-			}
+			def += " TEXT";
 			break;
 		case "serial":
 			def += " SERIAL";


### PR DESCRIPTION
And it's been like that for a long time:
http://www.postgresql.org/docs/8.0/interactive/datatype-character.html
