### PR TITLE
Typo in property definition

### DIFF
--- a/lib/Instance.js
+++ b/lib/Instance.js
@@ -489,7 +489,7 @@ function Instance(Model, opts) {
 		Object.defineProperty(instance, k, {
 			value      : opts.methods[k].bind(instance),
 			enumerable : false,
-			writeable  : true
+			writable  : true
 		});
 	}
 


### PR DESCRIPTION
There is much dispute about the name of this attribute, but the EMCA6 spec says 'writable' not 'writeable'. Spent some time trying to figure out why we could not get spy's in our testing libs to run on instance methods... mystery solved!

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/defineProperty
