### PR TITLE
Include merge options in chain find count

### DIFF
--- a/lib/ChainFind.js
+++ b/lib/ChainFind.js
@@ -67,7 +67,9 @@ function ChainFind(Model, opts) {
 			return this;
 		},
 		count: function (cb) {
-			opts.driver.count(opts.table, opts.conditions, {}, function (err, data) {
+			opts.driver.count(opts.table, opts.conditions, {
+				merge: opts.merge
+			}, function (err, data) {
 				if (err || data.length === 0) {
 					return cb(err);
 				}

--- a/test/integration/model-find-chain.js
+++ b/test/integration/model-find-chain.js
@@ -194,6 +194,35 @@ describe("Model.find() chaining", function() {
 				return done();
 			});
 		});
+
+		// TODO: Make this code Mongo compatible?
+		// it("should account for associations", function (done) {
+		// 	var Bob = new Person({
+		// 		name: "Bob",
+		// 		surname: "Smith",
+		// 		age: 20
+		// 	});
+		// 	var Jill = new Person({
+		// 		name: "Jill",
+		// 		surname: "Smith",
+		// 		age: 20
+		// 	});
+
+		// 	Person.find({ name: "John" }, function (err, John) {
+		// 		should.equal(err, null);
+		// 		John = John[0];
+
+		// 		John.setParents([ Bob, Jill ], function (err) {
+		// 			should.equal(err, null);
+		// 			Person(John.id).getParents({ name: "Bob" }).count(function (err, count) {
+		// 				should.equal(err, null);
+		// 				count.should.equal(1);
+
+		// 				return done();
+		// 			});
+		// 		});
+		// 	});
+		// });
 	});
 
 	describe(".first()", function () {


### PR DESCRIPTION
This change will not affect any existing results, however the use of such a feature looks like it's only compatible with SQL databases. I included a test case but I could not get it to pass on MongoDB (as such I have commented it out, but these tests will pass on MySQL, Postgres, and SQLite).

I was doing a chain find filter to do 2 separate queries: 1 would fetch a count of all results, one would use the exact same chain find data and do a count on it (for pagination reasons). While the regular .find() was returning the correct results (8 results), the count would return incorrect results since the merge information was absent (24 results), throwing off the pagination count data. This simple change will take that into account.
