### PR TITLE
Implement eager loading

### DIFF
--- a/lib/ChainFind.js
+++ b/lib/ChainFind.js
@@ -132,6 +132,21 @@ function ChainFind(Model, opts) {
 			}
 			return promise.fail(cb);
 		},
+		eager: function () {
+			// This will allow params such as ("abc", "def") or (["abc", "def"])
+			var associations = _.flatten(arguments);
+
+			// TODO: Implement eager loading for Mongo and delete this.
+			if (opts.driver.config.protocol == "mongodb:") {
+				throw new Error("MongoDB does not currently support eager loading");
+			}
+
+			opts.__eager = _.filter(opts.associations, function (association) {
+				return ~associations.indexOf(association.name);
+			});
+
+			return this;
+		},
 		all: function (cb) {
 			opts.driver.find(opts.only, opts.table, opts.conditions, {
 				limit  : opts.limit,
@@ -153,8 +168,38 @@ function ChainFind(Model, opts) {
 						data[idx] = instance;
 
 						if (--pending === 0) {
-							return cb(null, data);
+							return (opts.__eager && opts.__eager.length ? eagerLoading : cb)(null, data);
 						}
+					});
+				};
+
+				var eagerLoading = function (err, data) {
+					var pending = opts.__eager.length;
+					var idMap = {};
+					var count = 0;
+
+					var ids = _.map(data, function (instance) {
+						var id = instance[opts.id[0]];
+						// Create the association arrays
+						for (var i = 0, association; association = opts.__eager[i]; i++) {
+							instance[association.name] = [];
+						}
+
+						idMap[id] = count++;
+						return id;
+					});
+
+					_.map(opts.__eager, function (association) {
+						opts.driver.eagerQuery(association, opts, ids, function (err, instances) {
+							for (var i = 0, instance; instance = instances[i]; i++) {
+								// Perform a parent lookup with $p, and initialize it as an instance.
+								data[idMap[instance.$p]][association.name].push(association.model(instance));
+							}
+
+							if (--pending === 0) {
+								return cb(null, data);
+							}
+						});
 					});
 				};
 

--- a/lib/Drivers/DML/mysql.js
+++ b/lib/Drivers/DML/mysql.js
@@ -143,6 +143,24 @@ Driver.prototype.find = function (fields, table, conditions, opts, cb) {
 	this.execSimpleQuery(q, cb);
 };
 
+Driver.prototype.eagerQuery = function (association, opts, ids, cb) {
+	var desiredKey = Object.keys(association.field);
+	var assocKey = Object.keys(association.mergeAssocId);
+
+	var where = {};
+	where[desiredKey] = ids;
+
+	var query = this.query.select()
+		.from(association.model.table)
+		.select(opts.only)
+		.from(association.mergeTable, assocKey, opts.id)
+		.select(desiredKey).as("$p")
+		.where(association.mergeTable, where)
+		.build();
+
+	this.execSimpleQuery(query, cb);
+};
+
 Driver.prototype.count = function (table, conditions, opts, cb) {
 	var q = this.query.select()
 	                  .from(table)

--- a/lib/Drivers/DML/postgres.js
+++ b/lib/Drivers/DML/postgres.js
@@ -185,6 +185,24 @@ Driver.prototype.find = function (fields, table, conditions, opts, cb) {
 	this.execSimpleQuery(q, cb);
 };
 
+Driver.prototype.eagerQuery = function (association, opts, ids, cb) {
+	var desiredKey = Object.keys(association.field);
+	var assocKey = Object.keys(association.mergeAssocId);
+
+	var where = {};
+	where[desiredKey] = ids;
+
+	var query = this.query.select()
+		.from(association.model.table)
+		.select(opts.only)
+		.from(association.mergeTable, assocKey, opts.id)
+		.select(desiredKey).as("$p")
+		.where(association.mergeTable, where)
+		.build();
+
+	this.execSimpleQuery(query, cb);
+};
+
 Driver.prototype.count = function (table, conditions, opts, cb) {
 	var q = this.query.select().from(table).count(null, 'c');
 

--- a/lib/Drivers/DML/sqlite.js
+++ b/lib/Drivers/DML/sqlite.js
@@ -127,6 +127,24 @@ Driver.prototype.find = function (fields, table, conditions, opts, cb) {
 	this.db.all(q, cb);
 };
 
+Driver.prototype.eagerQuery = function (association, opts, ids, cb) {
+	var desiredKey = Object.keys(association.field);
+	var assocKey = Object.keys(association.mergeAssocId);
+
+	var where = {};
+	where[desiredKey] = ids;
+
+	var query = this.query.select()
+		.from(association.model.table)
+		.select(opts.only)
+		.from(association.mergeTable, assocKey, opts.id)
+		.select(desiredKey).as("$p")
+		.where(association.mergeTable, where)
+		.build();
+
+	this.execSimpleQuery(query, cb);
+};
+
 Driver.prototype.count = function (table, conditions, opts, cb) {
 	var q = this.query.select()
 	                  .from(table)


### PR DESCRIPTION
### Description

Here's a simple implementation of eager loading (**NOTE:** I am not familiar with MongoDB so this will need to be added or refactored in a way that Mongo can handle it, I left relevant TODO comments on what to remove). Autofetch on large queries can be quite detrimental and this should help remedy the problem. This should also resolve #389, however bulk updates should be added.
### How it works

Assume I have a database table with the models `Image` and `Tag` with a relationship `Image.hasMany("tags", Tag)`. If I do `Image.find(...).run(...)` currently it will do n+1 queries (query for images, n queries for tags). The implementation I have provided will only perform two queries to fetch the data. In order to use it, autofetch can be left off and do `Image.find(...).eager("tags").run(...)`. The returned result will be the same, but will be far more performant.
