### PR TITLE
Made some Model methods defined by `defineProperty` writable so they can be mocked

### DIFF
--- a/lib/Instance.js
+++ b/lib/Instance.js
@@ -506,7 +506,8 @@ function Instance(Model, opts) {
 
 			return this;
 		},
-		enumerable: false
+		enumerable: false,
+		writable: true
 	});
 	Object.defineProperty(instance, "save", {
 		value: function () {
@@ -548,13 +549,15 @@ function Instance(Model, opts) {
 
 			return this;
 		},
-		enumerable: false
+		enumerable: false,
+		writable: true
 	});
 	Object.defineProperty(instance, "saved", {
 		value: function () {
 			return opts.changes.length === 0;
 		},
-		enumerable: false
+		enumerable: false,
+		writable: true
 	});
 	Object.defineProperty(instance, "remove", {
 		value: function (cb) {
@@ -562,7 +565,8 @@ function Instance(Model, opts) {
 
 			return this;
 		},
-		enumerable: false
+		enumerable: false,
+		writable: true
 	});
 	Object.defineProperty(instance, "isInstance", {
 		value: true,
@@ -572,7 +576,8 @@ function Instance(Model, opts) {
 		value: function () {
 			return !opts.is_new;
 		},
-		enumerable: false
+		enumerable: false,
+		writable: true
 	});
 	Object.defineProperty(instance, "isShell", {
 		value: function () {
@@ -586,7 +591,8 @@ function Instance(Model, opts) {
 				cb(null, errors || false);
 			});
 		},
-		enumerable: false
+		enumerable: false,
+		writable: true
 	});
 	Object.defineProperty(instance, "__singleton_uid", {
 		value: function (cb) {

--- a/test/integration/event.js
+++ b/test/integration/event.js
@@ -79,5 +79,19 @@ describe("Event", function() {
 				return done();
 			});
 		});
+
+		it("should be writable for mocking", function (done) {
+			var triggered = false;
+			var John = new Person();
+
+			John.on = function(event, cb) {
+				triggered = true;
+			};
+			triggered.should.be.false;
+
+			John.on("mocked", function (err) {} );
+			triggered.should.be.true;
+			done();
+		});
 	});
 });

--- a/test/integration/instance.js
+++ b/test/integration/instance.js
@@ -130,6 +130,16 @@ describe("Model instance", function() {
 		it("should return false for new instances", function () {
 			should.equal((new Person).isPersisted(), false);
 		});
+
+		it("should be writable for mocking", function() {
+			var person = new Person()
+			var triggered = false;
+			person.isPersisted = function() {
+				triggered = true;
+			};
+			person.isPersisted()
+			triggered.should.be.true;
+		});
 	});
 
 	describe("#isShell", function () {

--- a/test/integration/model-remove.js
+++ b/test/integration/model-remove.js
@@ -1,0 +1,60 @@
+var should   = require('should');
+var helper   = require('../support/spec_helper');
+var ORM      = require('../../');
+
+describe("Model.remove()", function() {
+  var db = null;
+  var Person = null;
+
+  var setup = function () {
+    return function (done) {
+      Person = db.define("person", {
+        name   : String
+      });
+
+      return helper.dropSync(Person, function () {
+        Person.create([{
+          id  : 1,
+          name: "Jeremy Doe"
+        }, {
+          id  : 2,
+          name: "John Doe"
+        }, {
+          id  : 3,
+          name: "Jane Doe"
+        }], done);
+      });
+    };
+  };
+
+  before(function (done) {
+    helper.connect(function (connection) {
+      db = connection;
+
+      return done();
+    });
+  });
+
+  after(function () {
+    return db.close();
+  });
+
+  describe("mockable", function() {
+    before(setup());
+
+    it("remove should be writable", function(done) {
+      var John = new Person({
+        name: "John"
+      });
+      var removeCalled = false;
+      John.remove = function(cb) {
+        removeCalled = true;
+        cb(null);
+      };
+      John.remove(function(err) {
+        should.equal(removeCalled,true);
+        return done();
+      });
+    });
+  });
+});

--- a/test/integration/model-save.js
+++ b/test/integration/model-save.js
@@ -217,4 +217,38 @@ describe("Model.save()", function() {
 			});
 		});
 	});
+
+	describe("mockable", function() {
+		before(setup());
+
+		it("save should be writable", function(done) {
+			var John = new Person({
+				name: "John"
+			});
+			var saveCalled = false;
+			John.save = function(cb) {
+				saveCalled = true;
+				cb(null);
+			};
+			John.save(function(err) {
+				should.equal(saveCalled,true);
+				return done();
+			});
+		});
+
+		it("saved should be writable", function(done) {
+			var John = new Person({
+				name: "John"
+			});
+			var savedCalled = false;
+			John.saved = function() {
+				savedCalled = true;
+				return true;
+			};
+
+			John.saved()
+			savedCalled.should.be.true;
+			done();
+		})
+	});
 });

--- a/test/integration/validation.js
+++ b/test/integration/validation.js
@@ -344,4 +344,23 @@ describe("Validations", function() {
 			});
 		});
 	});
+
+	describe("mockable", function() {
+		before(setup());
+
+		it("validate should be writable", function(done) {
+			var John = new Person({
+				name: "John"
+			});
+			var validateCalled = false;
+			John.validate = function(cb) {
+				validateCalled = true;
+				cb(null);
+			};
+			John.validate(function(err) {
+				should.equal(validateCalled,true);
+				return done();
+			});
+		});
+	});
 });


### PR DESCRIPTION
Useful for functional testing and not integration testing when using orm2.
- writable added to some model instance defineProperty calls, some properties were left alone because they were static or had unknown function (isShell for example)
- added a model-remove test that currently only tests the writable aspect (there appears to be no direct test of this function, other than from the hooks tests)
