### PR TITLE
fixed bug on like expression using MongoDB

### DIFF
--- a/lib/Drivers/DML/mongodb.js
+++ b/lib/Drivers/DML/mongodb.js
@@ -399,10 +399,10 @@ function convertToDBVal(key, value, timezone) {
 			case "lt":
 			case "lte":
 			case "ne":
-				condition["$" + comp] = val;
+				condition["$" + comp] = val.val;
 				break;
 			case "eq":
-				condition = val;
+				condition = val.val;
 				break;
 			case "between":
 				condition["$min"] = val.from;


### PR DESCRIPTION
```
model.find { fb_id: orm.like(websiteId + '%') }, (err, websites) ->
```

wouldn't work because the passed expression only contains .exp and no val.
After removing .val it all started working again.    

Added a commit to correct objects that do have a '.val'
