### PR TITLE
Pool and debug settings always are true

### DIFF
--- a/lib/ORM.js
+++ b/lib/ORM.js
@@ -112,8 +112,8 @@ exports.connect = function (opts, cb) {
 		var debug    = extractOption(opts, "debug");
 		var pool     = extractOption(opts, "pool");
 		var driver   = new Driver(opts, null, {
-			debug    : (debug !== null ? Boolean(debug) : settings.get("connection.debug")),
-			pool     : (pool !== null ? Boolean(pool) : settings.get("connection.pool")),
+			debug    : (debug !== null ? ((debug === "false" || debug === "0") ? false : true) : settings.get("connection.debug")),
+			pool     : (pool !== null ? ((pool === "false" || pool === "0") ? false : true) : settings.get("connection.pool")),
 			settings : settings
 		});
 

--- a/test/integration/orm-exports.js
+++ b/test/integration/orm-exports.js
@@ -190,6 +190,15 @@ describe("ORM.connect()", function () {
 				return done();
 			});
 		});
+
+		it("should allow pool and debug settings to be false", function(done) {
+			var connString = common.getConnectionString() + "debug=false&pool=false";
+			ORM.connect(connString, function(err, db) {
+				db.driver.opts.pool.should.equal(false);
+				db.driver.opts.debug.should.equal(false);
+				done();
+			});
+		});
 	});
 });
 


### PR DESCRIPTION
example:
ORM.connect("mysql://something:nothing@beep/boop?pool=false&debug=false", ...)
will still set debug == true and pool == true because calling the boolean constructor on a non-empty string always yields true. 

This fix simply checks the val of debug and pool, and if they are falsy, sets them to false, or true otherwise. (still maintains the null-defaulting case).
