### PR TITLE
Update express middleware for express.io

### DIFF
--- a/lib/Express.js
+++ b/lib/Express.js
@@ -47,6 +47,11 @@ module.exports = function (uri, opts) {
 			req.db     = _db;
 		}
 
+		if (next === undefined && typeof res === 'function')
+		{
+			next = res;
+		}
+
 		if (_pending > 0) {
 			_queue.push(next);
 			return;


### PR DESCRIPTION
Express.io does not use the response object, so in the middleware the second argument will be the "next()" function. This fix allows it to use orm with express.io, while still fully support native express middleware functionality.
