### PR TITLE
Bugfix: wrong column used in JOIN clause when querying a reverse association

### DIFF
--- a/lib/Associations/One.js
+++ b/lib/Associations/One.js
@@ -94,7 +94,7 @@ exports.prepare = function (Model, associations, association_properties, model_f
 			}
 
 			options.__merge = {
-				from  : { table: association.model.table, field: association.model.id },
+				from  : { table: association.model.table, field: association.reversed ? Object.keys(association.field) : association.model.id },
 				to    : { table: Model.table, field: Object.keys(association.field) },
 				where : [ association.model.table, conditions ],
 				table : Model.table


### PR DESCRIPTION
(Fixes #446) When querying a reverse association, one of the two columns used in the generated 'JOIN...ON' clause was not the right one. One of the columns being used was the table's primary key, whereas the expected one was the foreign key.
