### PR TITLE
omit should return instances populated ids and foreign keys

### DIFF
--- a/lib/ChainFind.js
+++ b/lib/ChainFind.js
@@ -45,7 +45,7 @@ function ChainFind(Model, opts) {
 			} else {
 				omit = Array.prototype.slice.apply(arguments);
 			}
-			this.only(_.difference(Object.keys(Model.properties), omit));
+			this.only(_.difference(Object.keys(Model.allProperties), omit));
 			return this;
 		},
 		limit: function (limit) {

--- a/test/integration/model-find-chain.js
+++ b/test/integration/model-find-chain.js
@@ -16,22 +16,26 @@ describe("Model.find() chaining", function() {
 				age     : Number
 			});
 			Person.hasMany("parents");
+			Person.hasOne("friend");
 
 			ORM.singleton.clear(); // clear cache
 
 			return helper.dropSync(Person, function () {
 				Person.create([{
-					name    : "John",
-					surname : "Doe",
-					age     : 18
+					name      : "John",
+					surname   : "Doe",
+					age       : 18,
+					friend_id : 1
 				}, {
-					name    : "Jane",
-					surname : "Doe",
-					age     : 20
+					name      : "Jane",
+					surname   : "Doe",
+					age       : 20,
+					friend_id : 1
 				}, {
-					name    : "Jane",
-					surname : "Dean",
-					age     : 18
+					name      : "Jane",
+					surname   : "Dean",
+					age       : 18,
+					friend_id : 1
 				}], done);
 			});
 		};
@@ -215,6 +219,8 @@ describe("Model.find() chaining", function() {
 			Person.find().omit("age", "surname").order("-age").run(function (err, instances) {
 				should.equal(err, null);
 				instances.should.have.property("length", 3);
+				should.exist(instances[0].id);
+				should.exist(instances[0].friend_id);
 				instances[0].should.have.property("age", null);
 				instances[0].should.have.property("surname", null);
 				instances[0].should.have.property("name", "Jane");


### PR DESCRIPTION
when using omit - the returned instance did not include ids and foreign keys. This PR fixes this
