### PR TITLE
[Driver:sqlite].clear should reset autoincrement

### DIFF
--- a/lib/Drivers/DML/sqlite.js
+++ b/lib/Drivers/DML/sqlite.js
@@ -225,9 +225,10 @@ Driver.prototype.clear = function (table, cb) {
         if (err) {
             return cb(err);
         }
-        var query = "DELETE FROM "
-                + this.query.escapeId("sqlite_sequence")
-                + " WHERE name=" + this.query.escapeVal(table);
+        var query = "DELETE FROM " + 
+		this.query.escapeId("sqlite_sequence") + 
+		" WHERE name=" + 
+		this.query.escapeVal(table);
 
         if (debug) {
             require("../../Debug").sql('sqlite', query);


### PR DESCRIPTION
Sqlite stores sequences differently, you have to reset them manually after clearing the table.
Added basic implementation
