### PR TITLE
Update package.json to work with proxy

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,8 +37,8 @@
 	"analyse"     : false,
 	"dependencies": {
 		"enforce"      : "0.1.2",
-		"sql-query"    : "http://github.com/dresende/node-sql-query.git#v0.1.17",
-		"sql-ddl-sync" : "http://github.com/dresende/node-sql-ddl-sync.git#v0.3.5",
+		"sql-query"    : "git+http://github.com/dresende/node-sql-query.git#v0.1.17",
+		"sql-ddl-sync" : "git+http://github.com/dresende/node-sql-ddl-sync.git#v0.3.5",
 		"hat"          : "0.0.3",
 		"lodash"       : "2.4.1"
 	},


### PR DESCRIPTION
There is an issue when you develop behind a proxy. General git URL won't work.
