### PR TITLE
Various integration fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ test/config.js
 test/coverage.html
 lib-cov/
 *~
+/.idea

--- a/test/config.example.js
+++ b/test/config.example.js
@@ -17,7 +17,13 @@ exports.postgres = {
 	password : "",
 	database : "test"
 };
+exports.redshift = {
+	user      : "root",
+	password  : "",
+	database  : "test"
+};
 exports.mongodb = {
     host: "localhost",
     database: "test"
 };
+exports.sqlite = { }; // uses in-memory database

--- a/test/integration/association-hasmany-extra.js
+++ b/test/integration/association-hasmany-extra.js
@@ -28,6 +28,8 @@ describe("hasMany extra properties", function() {
 	};
 
 	before(function(done) {
+		this.timeout(4000);
+
 		helper.connect(function (connection) {
 			db = connection;
 			done();

--- a/test/integration/association-hasmany.js
+++ b/test/integration/association-hasmany.js
@@ -697,7 +697,7 @@ describe("hasMany", function () {
 				if (protocol == 'sqlite') {
 					sql = "PRAGMA table_info(?)";
 				} else {
-					sql = "SELECT column_name, data_type FROM information_schema.columns WHERE table_name = ?";
+					sql = "SELECT column_name, data_type FROM information_schema.columns WHERE table_name = ? ORDER BY data_type";
 				}
 
 				db.driver.execQuery(sql, ['account_emails'], function (err, cols) {
@@ -730,13 +730,14 @@ describe("hasMany", function () {
 				should.not.exist(err);
 				var sql;
 
-				if (protocol == 'postgres') {
+				if (protocol == 'postgres' || protocol === 'redshift') {
 					sql = "" +
 						"SELECT c.column_name, c.data_type " +
 						"FROM  information_schema.table_constraints tc " +
 						"JOIN information_schema.constraint_column_usage AS ccu USING (constraint_schema, constraint_name) " +
 						"JOIN information_schema.columns AS c ON c.table_schema = tc.constraint_schema AND tc.table_name = c.table_name AND ccu.column_name = c.column_name " +
-						"where constraint_type = ? and tc.table_name = ?";
+						"WHERE constraint_type = ? AND tc.table_name = ? " +
+						"ORDER BY column_name";
 
 					db.driver.execQuery(sql, ['PRIMARY KEY', 'account_emails'], function (err, data) {
 						should.not.exist(err);

--- a/test/integration/association-hasone-reverse.js
+++ b/test/integration/association-hasone-reverse.js
@@ -8,6 +8,7 @@ var _ = require('lodash');
 describe("hasOne", function () {
 	var db = null;
 	var Person = null;
+	var Pet = null;
 
 	var setup = function () {
 		return function (done) {
@@ -23,7 +24,8 @@ describe("hasOne", function () {
 			});
 
 			return helper.dropSync([Person, Pet], function () {
-				async.parallel([
+				// Running in series because in-memory sqlite encounters problems
+				async.series([
 					Person.create.bind(Person, { name: "John Doe" }),
 					Person.create.bind(Person, { name: "Jane Doe" }),
 					Pet.create.bind(Pet, { name: "Deco" }),

--- a/test/integration/error_spec.js
+++ b/test/integration/error_spec.js
@@ -1,5 +1,6 @@
 var should   = require('should');
 var ORMError = require('../../lib/Error');
+var path     = require('path');
 
 describe("Error", function () {
 	describe("constructor", function () {
@@ -9,10 +10,13 @@ describe("Error", function () {
 		});
 
 		it("should have a valid stack", function () {
-			var e = new ORMError("Test message", 'PARAM_MISMATCH');
-			var stackArr = e.stack.split('\n');
-			// [0] is ''
-			should(stackArr[1].indexOf('test/integration/error_spec.js') > 0);
+			try {
+				throw new ORMError("Test message", 'PARAM_MISMATCH');
+			} catch (e) {
+				var stackArr = e.stack.split('\n');
+				// [0] is ''
+				should(stackArr[1].indexOf(path.join('test', 'integration', 'error_spec.js')) > 0);
+			}
 		});
 
 		it("should have the right name", function () {

--- a/test/integration/instance.js
+++ b/test/integration/instance.js
@@ -37,6 +37,8 @@ describe("Model instance", function() {
 	};
 
 	before(function (done) {
+		this.timeout(4000);
+
 		helper.connect(function (connection) {
 			db = connection;
 

--- a/test/integration/model-keys.js
+++ b/test/integration/model-keys.js
@@ -6,6 +6,8 @@ describe("Model keys option", function() {
 	var db = null;
 
 	before(function (done) {
+		this.timeout(4000);
+
 		helper.connect(function (connection) {
 			db = connection;
 

--- a/test/integration/orm-exports.js
+++ b/test/integration/orm-exports.js
@@ -74,7 +74,7 @@ describe("ORM.connect()", function () {
 	it("should allow protocol alias", function (done) {
 		var db = ORM.connect("pg://127.0.0.2");
 
-		db.on("connect", function (err) {
+		db.once("connect", function (err) {
 			should.exist(err);
 			err.message.should.not.equal("CONNECTION_PROTOCOL_NOT_SUPPORTED");
 


### PR DESCRIPTION
Fixed some integration tests that were causing Travis build failures and local build failures on a Windows box:
- Added sorting to columns before verifying to resolve issues where ordering can differ with different database versions
- Fixed issue where the stack for `ORMError` objects was undefined
- Fixed "done called multiple times" issue
- Fixed test that was failing for the redshift driver
- Fixed test that intermittently fails for sqlite due to race conditions with in-memory driver
- Increased timeout for a few test setups that were intermittently failing
