### PR TITLE
Add extra props on associations to delete

### DIFF
--- a/lib/Drivers/DML/mongodb.js
+++ b/lib/Drivers/DML/mongodb.js
@@ -316,7 +316,13 @@ Driver.prototype.hasMany = function (Model, association) {
 			pull[association.name] = [];
 
 			for (var i = 0; i < Associations.length; i++) {
-				pull[association.name].push({ _id: Associations[i][association.model.id] });
+				var props = {_id: Associations[i][association.model.id]};
+				
+				if (Associations[i].extra !== undefined) {
+					props = _.merge(props, _.pick(Associations[i].extra, _.keys(association.props)));
+				}
+				
+				pull[association.name].push(props);
 			}
 
 			return db.update({


### PR DESCRIPTION
When we need to delete some record on association, this driver use the $pullAll command.
But the $pullAll requires an exact match.
So, when the association has some extra properties, we need to include these properties in the pull object.
