### PR TITLE
Removing unnecessary check for aggregates in aggreate().get

### DIFF
--- a/lib/Drivers/DML/mysql.js
+++ b/lib/Drivers/DML/mysql.js
@@ -1,5 +1,5 @@
 var _       = require("lodash");
-var mysql   = require("mysql2");
+var mysql   = require("mysql");
 var Query   = require("sql-query").Query;
 var shared  = require("./_shared");
 var DDL     = require("../DDL/SQL");

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
 		"lodash"       : "2.4.1"
 	},
 	"devDependencies": {
-		"mysql2"  : "0.15.8",
+		"mysql"   : "2.5.5",
 		"pg"      : "4.3.0",
 		"sqlite3" : "3.0.5",
 		"async"   : "0.9.0",


### PR DESCRIPTION
I removed the check for `aggregates.length` as: 
- It iterates over the array, where of `.length` of will simply skip the aggregates
- The execution of the method will run as expected if no literal aggregates are supplied

Where, in the example:

```
db.aggregate({column: "value"}).groupBy('column');
```

Because there are no aggregates, the method would have originally thrown an exception. However, in this case, aggregates aren't needed (just the group by), where the check prevents the execution and the expected output of this "aggregate" function.
