### PR TITLE
ISO dates for SQLite

### DIFF
--- a/lib/Drivers/DML/sqlite.js
+++ b/lib/Drivers/DML/sqlite.js
@@ -260,21 +260,20 @@ Driver.prototype.valueToProperty = function (value, property) {
 			}
 			break;
 		case "date":
-			if (typeof value == 'string') {
-				if (value.indexOf('Z', value.length - 1) === -1) {
-					value = new Date(value + 'Z');
-				} else {
-					value = new Date(value);
-				}
+			if (typeof value === 'string') {
+				var hasTimezone = value.indexOf('Z') !== -1;
+				value = new Date(value);
 
-				if (this.config.timezone && this.config.timezone != 'local') {
-					var tz = convertTimezone(this.config.timezone);
-
+				if (!hasTimezone) {
 					// shift local to UTC
 					value.setTime(value.getTime() - (value.getTimezoneOffset() * 60000));
-					if (tz !== false) {
-						// shift UTC to timezone
-						value.setTime(value.getTime() - (tz * 60000));
+
+					if (this.config.timezone && this.config.timezone != 'local') {
+						var tz = convertTimezone(this.config.timezone);
+						if (tz !== false) {
+							// shift UTC to timezone
+							value.setTime(value.getTime() - (tz * 60000));
+						}
 					}
 				}
 			}
@@ -301,45 +300,8 @@ Driver.prototype.propertyToValue = function (value, property) {
 			}
 			break;
 		case "date":
-			if (this.config.query && this.config.query.strdates) {
-				if (value instanceof Date) {
-					var year = value.getUTCFullYear();
-					var month = value.getUTCMonth() + 1;
-					if (month < 10) {
-						month = '0' + month;
-					}
-					var date = value.getUTCDate();
-					if (date < 10) {
-						date = '0' + date;
-					}
-					var strdate = year + '-' + month + '-' + date;
-					if (property.time === false) {
-						value = strdate;
-						break;
-					}
-
-					var hours = value.getUTCHours();
-					if (hours < 10) {
-						hours = '0' + hours;
-					}
-					var minutes = value.getUTCMinutes();
-					if (minutes < 10) {
-						minutes = '0' + minutes;
-					}
-					var seconds = value.getUTCSeconds();
-					if (seconds < 10) {
-						seconds = '0' + seconds;
-					}
-					var millis = value.getUTCMilliseconds();
-					if (millis < 10) {
-						millis = '0' + millis;
-					}
-					if (millis < 100) {
-						millis = '0' + millis;
-					}
-					strdate += ' ' + hours + ':' + minutes + ':' + seconds + '.' + millis + '000';
-					value = strdate;
-				}
+			if (value instanceof Date) {
+				value = value.toISOString();
 			}
 			break;
 		default:

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
 	"analyse"     : false,
 	"dependencies": {
 		"enforce"      : "0.1.2",
-		"sql-query"    : "git+https://github.com/dresende/node-sql-query.git#v0.1.23",
+		"sql-query"    : "git+https://github.com/apoco/node-sql-query.git#sqlite-utc-dates",
 		"sql-ddl-sync" : "git+https://github.com/dresende/node-sql-ddl-sync.git#v0.3.10",
 		"hat"          : "0.0.3",
 		"lodash"       : "2.4.1"

--- a/test/integration/association-extend.js
+++ b/test/integration/association-extend.js
@@ -7,6 +7,8 @@ describe("Model.extendsTo()", function() {
 	var Person = null;
 	var PersonAddress = null;
 
+	this.timeout(5000);
+
 	var setup = function () {
 		return function (done) {
 			Person = db.define("person", {

--- a/test/integration/association-hasmany-hooks.js
+++ b/test/integration/association-hasmany-hooks.js
@@ -7,6 +7,8 @@ describe("hasMany hooks", function() {
 	var Person = null;
 	var Pet    = null;
 
+	this.timeout(5000);
+
 	var setup = function (props, opts) {
 		return function (done) {
 			db.settings.set('instance.cache', false);

--- a/test/integration/association-hasmany.js
+++ b/test/integration/association-hasmany.js
@@ -6,10 +6,11 @@ var common   = require('../common');
 var protocol = common.protocol();
 
 describe("hasMany", function () {
-	this.timeout(4000);
 	var db     = null;
 	var Person = null;
 	var Pet    = null;
+
+	this.timeout(5000);
 
 	before(function(done) {
 		helper.connect(function (connection) {

--- a/test/integration/association-hasone-reverse.js
+++ b/test/integration/association-hasone-reverse.js
@@ -10,6 +10,8 @@ describe("hasOne", function () {
 	var Person = null;
 	var Pet = null;
 
+	this.timeout(5000);
+
 	var setup = function () {
 		return function (done) {
 			Person = db.define('person', {

--- a/test/integration/association-hasone.js
+++ b/test/integration/association-hasone.js
@@ -13,6 +13,8 @@ describe("hasOne", function() {
 	var treeId = null;
 	var stalkId = null;
 
+	this.timeout(5000);
+
 	var setup = function (opts) {
 		opts = opts || {};
 		return function (done) {

--- a/test/integration/db.js
+++ b/test/integration/db.js
@@ -284,7 +284,7 @@ describe("db.driver", function () {
 				db.driver.execQuery(query, args, function (err, data) {
 					should.not.exist(err);
 
-					should(JSON.stringify(data) == JSON.stringify([{ "what": "user login" }]));
+					JSON.stringify(data).should.equal(JSON.stringify([{ "what": "user login" }]));
 					done();
 				});
 			});

--- a/test/integration/model-find-chain.js
+++ b/test/integration/model-find-chain.js
@@ -9,6 +9,8 @@ describe("Model.find() chaining", function() {
 	var Person = null;
 	var Dog = null;
 
+	this.timeout(5000);
+
 	var setup = function (extraOpts) {
 		if (!extraOpts) extraOpts = {};
 

--- a/test/integration/model-one.js
+++ b/test/integration/model-one.js
@@ -6,6 +6,8 @@ describe("Model.one()", function() {
 	var db = null;
 	var Person = null;
 
+	this.timeout(5000);
+
 	var setup = function () {
 		return function (done) {
 			Person = db.define("person", {

--- a/test/integration/model-sync.js
+++ b/test/integration/model-sync.js
@@ -7,6 +7,8 @@ var common = require('../common');
 describe("Model.sync", function () {
   var db     = null;
 
+  this.timeout(5000);
+
   before(function(done) {
     helper.connect(function (connection) {
       db = connection;

--- a/test/integration/orm-exports.js
+++ b/test/integration/orm-exports.js
@@ -220,7 +220,10 @@ describe("ORM.connect()", function () {
 		});
 
 		it("should allow pool and debug settings to be false", function(done) {
-			var connString = common.getConnectionString() + "debug=false&pool=false";
+			var connString = common
+				.getConnectionString()
+				.replace(/\b(debug|pool)=.*\b&?/g, '');
+			connString += "debug=false&pool=false";
 			ORM.connect(connString, function(err, db) {
 				db.driver.opts.pool.should.equal(false);
 				db.driver.opts.debug.should.equal(false);

--- a/test/integration/property-timezones.js
+++ b/test/integration/property-timezones.js
@@ -36,7 +36,7 @@ describe("Timezones", function() {
 	};
 
 	describe("specified", function () {
-		var a, zones = [ 'local', '-0734'/*, '+11:22'*/ ];
+		var a, zones = [ 'local', '-0734', 'Z' /*, '+11:22'*/ ];
 
 		for (a = 0; a < zones.length; a++ ) {
 			describe(zones[a], function () {
@@ -64,6 +64,10 @@ describe("Timezones", function() {
 		}
 	});
 
+	if (common.protocol() == "sqlite") {
+		return; // Dates are stored as UTC
+	}
+
 	describe("different for each connection", function () {
 		before(setup({
 			sync  : true,
@@ -74,7 +78,7 @@ describe("Timezones", function() {
 			return db.close();
 		});
 
-		// This isn't consistent accross drivers. Needs more thinking and investigation.
+		// This isn't consistent across drivers. Needs more thinking and investigation.
 		it("should get back a correctly offset time", function (done) {
 			var when = new Date(2013, 12, 5, 5, 34, 27);
 
@@ -88,7 +92,7 @@ describe("Timezones", function() {
 
 					db.close(function () {
 						setup({
-							sync  : false, // don't recreate table, don't want to loose previous value
+							sync  : false, // don't recreate table, don't want to lose previous value
 							query : { timezone: '+0400' }
 						})(function () {
 							Event.one({ name: "raid fridge" }, function (err, item) {


### PR DESCRIPTION
Simplified the way that dates are handled for SQLite.

Note that this also depends on changes to `node-sql-query`, so for now `package.config` references my fork. I'll update this once my PR changes or similar is available.

Some timeouts and a few other things were adjusted because they were causing failures when running against SQLite not in-memory.
