### PR TITLE
Test for setting primary key on string ids. 

### DIFF
--- a/test/integration/model-keys.js
+++ b/test/integration/model-keys.js
@@ -48,6 +48,18 @@ describe("Model keys option", function() {
 				return done();
 			});
 		});
+
+		it("should not allow duplicate IDs", function (done) {
+			Person.create({
+				uid     : "john-doe",
+				name    : "John",
+				surname : "Doe"
+			}, function (err, JohnDoe) {
+				should.notEqual(err, null);
+				should.equal(err.code, 'ER_DUP_ENTRY');
+				return done();
+			});
+		});
 	});
 
 	describe("if model defines several keys", function () {

--- a/test/integration/model-keys.js
+++ b/test/integration/model-keys.js
@@ -56,7 +56,6 @@ describe("Model keys option", function() {
 				surname : "Doe"
 			}, function (err, JohnDoe) {
 				should.notEqual(err, null);
-				should.equal(err.code, 'ER_DUP_ENTRY');
 				return done();
 			});
 		});


### PR DESCRIPTION
As of right now sqlite3 fails this test and mysql passes. 

It appears it does not set the column as a primary key in sqlite3 for text or integer types. If the DB is manually edited primary keys are successfully added to the column.  
