### PR TITLE
fixed thrown error check

### DIFF
--- a/lib/ORM.js
+++ b/lib/ORM.js
@@ -134,7 +134,7 @@ exports.connect = function (opts, cb) {
 			db.emit("connect", err, !err ? db : null);
 		});
 	} catch (ex) {
-		if (ex.code === "MODULE_NOT_FOUND" || ex.message.indexOf('find module')) {
+		if (ex.code === "MODULE_NOT_FOUND" || ex.message.indexOf('find module') > -1) {
 			return ORM_Error(new ORMError("Connection protocol not supported - have you installed the database driver for " + proto + "?", 'NO_SUPPORT'), cb);
 		}
 		return ORM_Error(ex, cb);

--- a/test/integration/orm-exports.js
+++ b/test/integration/orm-exports.js
@@ -139,6 +139,26 @@ describe("ORM.connect()", function () {
 		});
 	});
 
+	it("should emit valid error if exception being thrown during connection try", function (done) {
+		var testConfig = {
+			protocol : 'mongodb',
+			href     : 'unknownhost',
+			database : 'unknowndb',
+			user     : '',
+			password : ''
+		},
+		db = ORM.connect(testConfig);
+
+		db.on("connect", function (err) {
+			should.exist(err);
+			should.equal(err.message.indexOf("Connection protocol not supported"), -1);
+			err.message.should.not.equal("CONNECTION_URL_NO_PROTOCOL");
+			err.message.should.not.equal("CONNECTION_URL_EMPTY");
+
+			return done();
+		});
+	});
+
 	it("should not modify connection opts", function (done) {
 		var opts = {
 			protocol : 'mysql',


### PR DESCRIPTION
Because if there's no ``` 'find module' ``` in ```ex.message``` ,the ```-1``` value from ```indexOf``` is equal to ```true``` and you'll never know what hit you.

Right now basically on any error thrown in this ```try {} catch``` - you'll get ``` "Connection protocol not supported" ``` , which is wrong

Please review.