### PR TITLE
escape camelCase tableName for uniqueness validation

### DIFF
--- a/lib/Validators.js
+++ b/lib/Validators.js
@@ -77,7 +77,7 @@ validators.unique = function () {
 
 			if (opts.ignoreCase === true && ctx.model.properties[prop].type === 'text') {
 				query = util.format('LOWER(%s.%s) LIKE LOWER(?)',
-					ctx.model.table, ctx.driver.query.escapeId(prop)
+					ctx.driver.query.escapeId(ctx.model.table), ctx.driver.query.escapeId(prop)
 				);
 				chain.where(query, [value]);
 			} else {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
 		"sqlite",
 		"mongodb"
 	],
-	"version"     : "2.1.20",
+	"version"     : "2.1.21",
 	"license"     : "MIT",
 	"homepage"    : "http://dresende.github.io/node-orm2",
 	"repository"  : "http://github.com/dresende/node-orm2.git",

--- a/test/integration/validation.js
+++ b/test/integration/validation.js
@@ -115,7 +115,7 @@ describe("Validations", function() {
 
 			var setupUnique = function (ignoreCase, scope, msg) {
 				return function (done) {
-					Product = db.define("product_unique", {
+					Product = db.define("productUnique", {
 						instock  : { type: 'boolean', required: true, defaultValue: false },
 						name     : String,
 						category : String


### PR DESCRIPTION
validation for uniqueness on a field in a table with a camelCase name was failing with error of missing FROM.
escaping the table name preserves camelCase and allows my validation to work.
