### PR TITLE
Trigger defaultValue when data value is undefined (not set)

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -13,7 +13,7 @@ npm install orm
 
 ## Node.js Version Support
 
-Tests are done using [Travis CI](https://travis-ci.org/) for node versions `0.6.x`, `0.8.x` and `0.10.x`. If you want you can run
+Tests are done using [Travis CI](https://travis-ci.org/) for node versions `0.8.x` and `0.10.x`. If you want you can run
 tests locally.
 
 ```sh

--- a/lib/Instance.js
+++ b/lib/Instance.js
@@ -480,8 +480,9 @@ function Instance(Model, opts) {
 		// Its presence doesn't affect tests, so I'm just gonna log if it ever gets called.
 		// If someone complains about noise, we know it does something, and figure it out then.
 		if (instance.hasOwnProperty(key)) console.log("Overwriting instance property");
-
-		if (key in opts.data) {
+		
+		//Undefined data values are not setted so skip to defaultvalue
+		if (opts.data[key] != undefined) {
 			defaultValue = opts.data[key];
 		} else if (prop && 'defaultValue' in prop) {
 			defaultValue = prop.defaultValue;


### PR DESCRIPTION
When a data value is undefined trigger the defaultValue.

And deleted node version 0.6 from the readme (also deleted form .travis.yml).