### PR TITLE
Bump sql-query version

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,6 @@
+### v2.1.24
+- Bump dependencies; Allow left/right joins in underlying db.driver.query
+
 ### v2.1.23
 - Green tests on io.js & node 0.12 (#618)
 - Don't crash on null dates if timezone is set (#618)

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
 		"sqlite",
 		"mongodb"
 	],
-	"version"     : "2.1.23",
+	"version"     : "2.1.24",
 	"license"     : "MIT",
 	"homepage"    : "http://dresende.github.io/node-orm2",
 	"repository"  : "http://github.com/dresende/node-orm2.git",
@@ -36,9 +36,9 @@
 	},
 	"analyse"     : false,
 	"dependencies": {
-		"enforce"      : "0.1.5",
-		"sql-query"    : "0.1.24",
-		"sql-ddl-sync" : "git+https://github.com/dresende/node-sql-ddl-sync.git#v0.3.10",
+		"enforce"      : "0.1.6",
+		"sql-query"    : "0.1.25",
+		"sql-ddl-sync" : "0.3.11",
 		"hat"          : "0.0.3",
 		"lodash"       : "2.4.1"
 	},


### PR DESCRIPTION
Brings dresende/node-sql-query#22 and dresende/node-sql-query#27 to ORM.