### PR TITLE
Added support for changing accessor names on reverse relation

### DIFF
--- a/lib/Associations/Many.js
+++ b/lib/Associations/Many.js
@@ -93,7 +93,13 @@ exports.prepare = function (db, Model, associations) {
 				mergeAssocId   : association.mergeId,
 				field          : association.field,
 				autoFetch      : association.autoFetch,
-				autoFetchLimit : association.autoFetchLimit
+				autoFetchLimit : association.autoFetchLimit,
+				getAccessor: opts.reverseGetAccessor,
+				setAccessor: opts.reverseSetAccessor,
+				hasAccessor: opts.reverseHasAccessor,
+				delAccessor: opts.reverseDelAccessor,
+				addAccessor: opts.reverseAddAccessor
+
 			});
 		}
 		return this;


### PR DESCRIPTION
First let me say thank you for this awesome library! I tried 2 others for a new project I am starting, but had various issues. This one has hit the sweet spot so far!

One slight issue I had was that when defining a hasMany relation, one can change the name of the accessor functions (i.e. get, set, has, del or add), but the accessors generated for the "reverse" relationship seem to be fixed. For instance, when I defined a hasMany between "users" and "roles" on the Role model (with option "reverse='roles'), I could change the method "addUsers" to "addUser", but was unable to change the reverse "addRoles" method (that was generated on the User model object.  

I added support for changing these names by specifying these parameters in options object:  
* reverseGetAccessor
* reverseSetAccessor
* reverseHasAccessor
* reverseDelAccessor
* reverseAddAccessor