### PR TITLE
Fix type to text instead of string for extended property

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -271,8 +271,8 @@ It's also possible to have composite keys:
 
 ```js
 var Person = db.define("person", {
-	firstname : { type: 'string', key: true },
-	lastname  : { type: 'string', key: true }
+	firstname : { type: 'text', key: true },
+	lastname  : { type: 'text', key: true }
 });
 ```
 


### PR DESCRIPTION
If one wanted to define a key with type "String", one has to provide "text" but not "string"