### PR TITLE
Added support for continuation-local-storage namespaces with the postgres driver

### DIFF
--- a/lib/Drivers/DML/postgres.js
+++ b/lib/Drivers/DML/postgres.js
@@ -1,14 +1,16 @@
-var _       = require("lodash");
-var pg      = require("pg");
-var Query   = require("sql-query").Query;
-var shared  = require("./_shared");
-var DDL     = require("../DDL/SQL");
+var _         = require("lodash");
+var pg        = require("pg");
+var Query     = require("sql-query").Query;
+var shared    = require("./_shared");
+var DDL       = require("../DDL/SQL");
+var clsBinder = require('cls-binder');
 
 exports.Driver = Driver;
 
 var switchableFunctions = {
 	pool: {
 		connect: function (cb) {
+			cb = clsBinder.bind( cb );
 			this.db.connect(this.config, function (err, client, done) {
 				if (!err) {
 					done();
@@ -17,6 +19,7 @@ var switchableFunctions = {
 			});
 		},
 		execSimpleQuery: function (query, cb) {
+			cb = clsBinder.bind( cb );
 			if (this.opts.debug) {
 				require("../../Debug").sql('postgres', query);
 			}
@@ -45,9 +48,11 @@ var switchableFunctions = {
 	},
 	client: {
 		connect: function (cb) {
-			this.db.connect(cb);
+			this.db.connect( clsBinder.bind( cb ) );
 		},
 		execSimpleQuery: function (query, cb) {
+			cb = clsBinder.bind( cb );
+
 			if (this.opts.debug) {
 				require("../../Debug").sql('postgres', query);
 			}
@@ -62,7 +67,7 @@ var switchableFunctions = {
 		},
 		on: function(ev, cb) {
 			if (ev == "error") {
-				this.db.on("error", cb);
+				this.db.on("error", clsBinder.bind( cb ));
 			}
 			return this;
 		}

--- a/package.json
+++ b/package.json
@@ -40,7 +40,8 @@
 		"sql-query"    : "0.1.26",
 		"sql-ddl-sync" : "0.3.11",
 		"hat"          : "0.0.3",
-		"lodash"       : "2.4.1"
+		"lodash"       : "2.4.1",
+		"cls-binder"   : "git@github.com:benkitzelman/cls-binder.git#master"
 	},
 	"devDependencies": {
 		"mysql"   : "2.5.5",


### PR DESCRIPTION
Pushed this up for comment.....
continuation-local-storage provides a support for namespaces - data containers that exist for the life of bound event emitters...

A number of systems use this to provide for such facilities as contextual logging. For details see https://datahero.com/blog/2014/05/22/node-js-preserving-data-across-async-callbacks/

The pg driver breaks support of this (see at the end of the article) - this PR preserves cls namespaces across async PG calls.

