### PR TITLE
With association autoFetch  cache may return incomplete instance.

### DIFF
--- a/lib/Model.js
+++ b/lib/Model.js
@@ -92,6 +92,21 @@ function Model(opts) {
 			ExtendAssociation.extend(model, instance, opts.driver, extend_associations, assoc_opts);
 		};
 
+                // check all the auto-fetch associations have been populated for the given instance
+                var checkAssociations = function(instance) {
+                  var checkAssn = function(associations) {
+                    for (var assn = 0; assn < associations.length; assn++) {
+                      if(associations[assn].autoFetch && ! instance.hasOwnProperty(associations[assn].name)) {
+                        return false;
+                      }
+                    };
+                    return true;
+                  };
+                  return checkAssn(one_associations) &&
+                         checkAssn(many_associations) &&
+                         checkAssn(extend_associations);
+                };
+
 		var pending  = 2, create_err = null;
 		var instance = new Instance(model, {
 			uid                    : inst_opts.uid, // singleton unique id
@@ -112,6 +127,7 @@ function Model(opts) {
 			extend_associations    : extend_associations,
 			association_properties : association_properties,
 			setupAssociations      : setupAssociations,
+                        checkAssociations      : checkAssociations,
 			fieldToPropertyMap     : fieldToPropertyMap,
 			keyProperties          : keyProperties
 		});

--- a/lib/Singleton.js
+++ b/lib/Singleton.js
@@ -15,18 +15,20 @@ exports.get = function (key, opts, createCb, returnCb) {
 	}
 	if (map.hasOwnProperty(key)) {
 		if (opts && opts.save_check && typeof map[key].o.saved === "function" && !map[key].o.saved()) {
-			// if not saved, don't return it, fetch original from db
+			// if not saved, don't return it, fetch original from db, but don't refresh the cache
 			return createCb(returnCb);
 		} else if (map[key].t !== null && map[key].t <= Date.now()) {
 			delete map[key];
-                } else if (! map[key].o.__opts.checkAssociations(map[key].o)) {
-                        // instance in cache doesn't have all auto-fetch associations populated
-                        return createCb(returnCb);
-		} else  {
-			return returnCb(null, map[key].o);
-		}
+                } else {
+                  var instance = map[key].o;
+                  if(instance.__opts.checkAssociations(instance)) {
+                        // instance in cache has all auto-fetch associations populated - we can re-use it
+                        return returnCb(null, instance);
+		  }
+                }
 	}
 
+        // Can't re-use item in cache - or it's not in cache - re-fetch from db & load the cache
 	createCb(function (err, value) {
 		if (err) return returnCb(err);
 

--- a/lib/Singleton.js
+++ b/lib/Singleton.js
@@ -19,6 +19,9 @@ exports.get = function (key, opts, createCb, returnCb) {
 			return createCb(returnCb);
 		} else if (map[key].t !== null && map[key].t <= Date.now()) {
 			delete map[key];
+                } else if (! map[key].o.__opts.checkAssociations(map[key].o)) {
+                        // instance in cache doesn't have all auto-fetch associations populated
+                        return createCb(returnCb);
 		} else  {
 			return returnCb(null, map[key].o);
 		}

--- a/test/integration/association-hasone-recursive.js
+++ b/test/integration/association-hasone-recursive.js
@@ -1,0 +1,138 @@
+var ORM    = require('../../');
+var helper = require('../support/spec_helper');
+var should = require('should');
+var async  = require('async');
+var _      = require('lodash');
+
+describe("hasOne", function() {
+	var db     = null;
+	var Animal = null;
+
+	var setup = function (opts) {
+		return function (done) {
+			db.settings.set('instance.cache', opts.cache);
+			db.settings.set('instance.returnAllErrors', true);
+
+		        Animal = db.define('animal', {
+                          id        : {type : "integer", key:true},
+			  name      : {type : "text",    size:"255"},
+                          damId     : {type : "integer"},
+                          sireId    : {type : "integer"}
+			});
+
+		        Animal.hasOne('sire', Animal, {field: 'sireId', autoFetch:opts.autoFetch});
+		        Animal.hasOne('dam',  Animal, {field: 'damId',  autoFetch:opts.autoFetch});
+
+		        helper.dropSync([Animal], function(err) {
+                          if (err) return done(err);
+                          Animal.create([{ id:1,   name: 'Bronson',  sireId:10, damId:20},
+
+                                         { id:10,  name: 'McTavish', sireId:11, damId:12},
+                                         { id:11, name:'Todd'},
+                                         { id:12, name:'Jemima'},
+
+                                         { id:20,  name: 'Suzy',    sireId:21,  damId:22},
+                                         { id:21,  name:'Liam'},
+                                         { id:22,  name:'Glencora'}
+                                        ], done);
+                        });
+		};
+	};
+
+	before(function(done) {
+	  helper.connect(function (connection) {
+	    db = connection;
+	    done();
+	  });
+	});
+
+        [{cache:false, autoFetch:true},
+         {cache:true, autoFetch:true}
+        ].forEach(function(opts) {
+
+	  describe("recursive hasOne() with " + (opts.cache ? "" : "out ") + "cache", function () {
+	    before(setup(opts));
+
+	    it("should get Bronson's sire & dam", function (done) {
+	      Animal.find({name: "Bronson"}, function(err, animals) {
+                should.not.exist(err);
+
+                animals[0].name.should.equal("Bronson");
+
+                // All of Bronson's Sire & Dam stuff should be present
+                animals[0].sireId.should.equal(10);
+                animals[0].damId.should.equal(20);
+
+                animals[0].should.have.property("sire");
+                animals[0].should.have.property("dam");
+
+                animals[0].sire.name.should.equal("McTavish");
+                animals[0].dam.name.should.equal("Suzy");
+
+                // Bronson's GrandSire & GrandDam shouldn't be present
+                animals[0].sire.should.not.have.property("sire");
+                animals[0].sire.should.not.have.property("dam");
+
+                animals[0].dam.should.not.have.property("sire");
+                animals[0].dam.should.not.have.property("dam");
+
+                // but Bronson's GrandSire & GrandDam ID's should be known
+                animals[0].sire.sireId.should.equal(11);
+                animals[0].sire.damId.should.equal(12);
+
+                animals[0].dam.sireId.should.equal(21);
+                animals[0].dam.damId.should.equal(22);
+
+		return done();
+	      });
+	    });
+
+	    it("should get McTavish's sire & dam", function (done) {
+	      Animal.find({name: "McTavish"}, function(err, animals) {
+                should.not.exist(err);
+
+                animals[0].name.should.equal("McTavish");
+
+                // All of McTavish's Sire & Dam stuff should be present (won't be with cache turned on)
+                animals[0].sireId.should.equal(11);
+                animals[0].damId.should.equal(12);
+
+                animals[0].should.have.property("sire");
+                animals[0].should.have.property("dam");
+
+                animals[0].sire.name.should.equal("Todd");
+                animals[0].dam.name.should.equal("Jemima");
+
+		return done();
+	      });
+	    });
+
+	    it("should get Suzy's sire & dam", function (done) {
+	      Animal.find({name: "Suzy"}, function(err, animals) {
+                should.not.exist(err);
+
+                animals[0].name.should.equal("Suzy");
+
+                // All of Suzy's Sire & Dam stuff should be present (won't be with cache turned on)
+                animals[0].sireId.should.equal(21);
+                animals[0].damId.should.equal(22);
+
+                animals[0].should.have.property("sire")
+                animals[0].should.have.property("dam");
+
+                animals[0].sire.name.should.equal("Liam");
+                animals[0].dam.name.should.equal("Glencora");
+
+                Animal.get(20, function(err, Suzy) {
+                  should.not.exist(err);
+
+                  Suzy.name.should.equal("Suzy");
+                  Suzy.sire.name.should.equal("Liam");
+                  Suzy.dam.name.should.equal("Glencora");
+                });
+		return done();
+	      });
+	    });
+	  });
+        });
+});

--- a/test/integration/association-hasone-recursive.js
+++ b/test/integration/association-hasone-recursive.js
@@ -8,9 +8,9 @@ describe("hasOne", function() {
 	var db     = null;
 	var Animal = null;
 
-	var setup = function (opts) {
+	var setup = function (cache) {
 		return function (done) {
-			db.settings.set('instance.cache', opts.cache);
+			db.settings.set('instance.cache', cache);
 			db.settings.set('instance.returnAllErrors', true);
 
 		        Animal = db.define('animal', {
@@ -18,7 +18,7 @@ describe("hasOne", function() {
 			  name      : {type : "text",    size:"255"},
                           damId     : {type : "integer"},
                           sireId    : {type : "integer"}
-			}, {cache:opts.timeout});
+			});
 
 		        Animal.hasOne('sire', Animal, {field: 'sireId', autoFetch:true});
 		        Animal.hasOne('dam',  Animal, {field: 'damId',  autoFetch:false});
@@ -46,10 +46,10 @@ describe("hasOne", function() {
 	  });
 	});
 
-        [false, true].forEach(function(cache) {
+        [false, 1].forEach(function(cache) {
 
 	  describe("recursive hasOne() with " + (cache ? "" : "out ") + "cache", function () {
-	    before(setup({cache:cache, timeout:0.5}));
+	    before(setup(cache));
 
 	    it("should get Bronson's Sire but not Dam", function (done) {
 	      Animal.find({name: "Bronson"}, function(err, animals) {
@@ -74,7 +74,7 @@ describe("hasOne", function() {
                 animals[0].sire.sireId.should.equal(11);
                 animals[0].sire.damId.should.equal(12);
 
-		return done();
+                return done();
 	      });
 	    });
 
@@ -93,21 +93,17 @@ describe("hasOne", function() {
 
                 animals[0].sire.name.should.equal("Todd");    // just to be sure
 
-                // Go get McTavish again
-                Animal.get(10, function(err, McTavish) {
+                // Let's make sure the cache is still working...
+                Animal.get(animals[0].id, function(err, McTavish) {
                   should.not.exist(err);
+
                   if(cache) {
-                    McTavish.id.should.equal(animals[0].id);
-                    McTavish.name.should.equal(animals[0].name);
-                    McTavish.should.equal(animals[0]);        // Should be the same one from cache again
+                    McTavish.should.equal(animals[0]);
+                  } else {
+                    McTavish.should.not.equal(animals[0]);
                   }
-                  else {
-                    McTavish.id.should.equal(animals[0].id);
-                    McTavish.name.should.equal(animals[0].name);
-                    McTavish.should.not.equal(animals[0]);    // Should be different one (not using cache)
-                  }
+		  return done();
                 });
-		return done();
 	      });
 	    });
 
@@ -126,21 +122,17 @@ describe("hasOne", function() {
 
                 animals[0].sire.name.should.equal("Liam");      // just to be sure
 
-                // Go get Suzy again
-                Animal.get(20, function(err, Suzy) {
+                // Let's make sure the cache is still working...
+                Animal.get(animals[0].id, function(err, Suzy) {
                   should.not.exist(err);
+
                   if(cache) {
-                    Suzy.id.should.equal(animals[0].id);
-                    Suzy.name.should.equal(animals[0].name);
-                    Suzy.should.equal(animals[0]);        // Should be the same one from cache again
+                    Suzy.should.equal(animals[0]);
+                  } else {
+                    Suzy.should.not.equal(animals[0]);
                   }
-                  else {
-                    Suzy.id.should.equal(animals[0].id);
-                    Suzy.name.should.equal(animals[0].name);
-                    Suzy.should.not.equal(animals[0]);    // Should be different one (not using cache)
-                  }
+		  return done();
                 });
-		return done();
 	      });
 	    });
 	  });


### PR DESCRIPTION
When cache has instance that has been loaded from auto-fetch,   autoFetchLimit means can sometimes have instance in cache with no associations populated.

A subsequent independent get() or find() will return the underpopulated instance from the cache.

Updated the Singleton cache to check all autoFetch associations are populated before re-using object from cache.