### PR TITLE
Adds ability to have unique keys in mongodb schema.

### DIFF
--- a/lib/Drivers/DML/mongodb.js
+++ b/lib/Drivers/DML/mongodb.js
@@ -45,6 +45,13 @@ Driver.prototype.sync = function (opts, cb) {
 		}
 
 		pending = indexes.length;
+		
+		collection.dropIndexes();
+		for (var i = 0; i < opts.id.length; i++) {
+			var obj = {};
+			obj[opts.id[i]] = 1;
+			collection.createIndex(obj, {unique: true});
+		}
 
 		for (i = 0; i < indexes.length; i++) {
 			collection.createIndex(indexes[i], function () {


### PR DESCRIPTION
Checks for key fields in schema and runs collection.createIndex({fieldName: 1}, {unique: true}); for each.

Runs collection.dropIndexes(); before hand to clear any previous keys.