### PR TITLE
Preserve column names when association_key is a function

### DIFF
--- a/lib/Utilities.js
+++ b/lib/Utilities.js
@@ -166,7 +166,7 @@ exports.wrapFieldObject = function (params) {
 		var assoc_key = params.model.settings.get("properties.association_key");
 
 		if (typeof assoc_key === "function") {
-		    params.field = assoc_key(params.altName.toLowerCase(), params.model.id[0]);
+		    params.field = assoc_key(params.altName, params.model.id[0]);
 		} else {
 			params.field = assoc_key.replace("{name}", params.altName.toLowerCase())
 			               .replace("{field}", params.model.id[0]);
@@ -209,7 +209,7 @@ exports.formatField = function (model, name, required, reversed) {
 		if (reversed) {
 			field_name = keys[i];
 		} else if (typeof assoc_key === "function") {
-			field_name = assoc_key(name.toLowerCase(), keys[i]);
+			field_name = assoc_key(name, keys[i]);
 		} else {
 			field_name = assoc_key.replace("{name}", name.toLowerCase())
 			                      .replace("{field}", keys[i]);


### PR DESCRIPTION
Node-orm2 is case-sensitive. Column names are properly escaped so we can use camelCase columns if we like to.

There is however one exception - `association_key`s are automatically lowercased. This is a bit surprising, but no big deal.

In version 2.1 we got the ability to use functions as `association_key` so we can choose our own formatting of `assocation_key`. But the column names supplied to the function are _already lowercased_. I believe this is wrong – if you are supplying a function you obviously want to design your own format, then you should be given the original names and lowercase/uppercase/do what you want with them.

This PR simply removes automatic `.toLowerCase()` when `association_key` is a function. 
It makes it possible to format `association_key` with proper camelCase, e.g. `someTableId`
