### PR TITLE
Add flag to exclude instance properties from enumeration

### DIFF
--- a/lib/Instance.js
+++ b/lib/Instance.js
@@ -519,7 +519,7 @@ function Instance(Model, opts) {
 					opts.changes.push(key);
 				}
 			},
-			enumerable: true
+			enumerable: !(prop && !prop.enumerable)
 		});
 	};
 	var addInstanceExtraProperty = function (key) {

--- a/lib/Property.js
+++ b/lib/Property.js
@@ -40,10 +40,15 @@ exports.normalize = function (opts) {
 
 	if (KNOWN_TYPES.indexOf(opts.prop.type) === -1 && !(opts.prop.type in opts.customTypes)) {
 		throw new ORMError("Unknown property type: " + opts.prop.type, 'NO_SUPPORT');
-  }
+	}
 
 	if (!opts.prop.hasOwnProperty("required") && opts.settings.get("properties.required")) {
 		opts.prop.required = true;
+	}
+
+	// Defaults to true. Setting to false hides properties from JSON.stringify(modelInstance).
+	if (!opts.prop.hasOwnProperty("enumerable") || opts.prop.enumerable === true) {
+		opts.prop.enumerable = true;
 	}
 
 	// Defaults to true. Rational means floating point here.

--- a/test/integration/instance.js
+++ b/test/integration/instance.js
@@ -16,7 +16,8 @@ describe("Model instance", function() {
 				name   : String,
 				age    : { type: 'integer', required: false },
 				height : { type: 'integer', required: false },
-				weight : { type: 'number',  required: false },
+				weight : { type: 'number',  required: false, enumerable: true },
+				secret : { type: 'text',  required: false, enumerable: false },
 				data   : { type: 'object',  required: false }
 			}, {
 				identityCache: false,
@@ -444,6 +445,22 @@ describe("Model instance", function() {
 					});
 				});
 			}
+		});
+
+		describe("Enumerable", function () {
+			it("should not stringify properties marked as not enumerable", function (done) {
+				Person.create({ name: 'Dilbert', secret: 'dogbert', weight: 100, data: {data: 3} }, function (err, p) {
+					if (err) return done(err);
+
+					var result = JSON.parse(JSON.stringify(p));
+					should.not.exist(result.secret);
+					should.exist(result.weight);
+					should.exist(result.data);
+					should.exist(result.name);
+
+					done();
+				});
+			});
 		});
 	});
 });


### PR DESCRIPTION
We would like to be able to have certain properties not get serialized by ```JSON.stringify```. Eg:

```javascript
orm.define('user', {
    login: {
      type: 'text',
      required: true,
    },
    password: {
      type: 'text',
      required: true,
      enumerable: false   // <--- Supported with this PR
    },
   // ... other properties
});

expressApp.get('/user', (req, res) => {
  orm.user.get(req.userId, (err, user) => {
    if (err) { /*500*/ }
    res.send(user); // will call JSON.stringify - we don't want to send the password!
  });
});
```

Currently we have a ```serialize()``` method declared on the ```user``` definition which only includes properties we want. We call ```res.send(user.serialize())``` but this isn't recursive, is quite unclean, and can potentially allow us to 'leak' secret properties if we are forgetful to call ```.serialize()```.

When this merges I will update the Wiki accordingly.