### PR TITLE
use keyProperties in removeInstance to keep column names when using mapsTo

### DIFF
--- a/lib/Instance.js
+++ b/lib/Instance.js
@@ -373,8 +373,9 @@ function Instance(Model, opts) {
 		}
 
 		var conditions = {};
-		for (var i = 0; i < opts.keys.length; i++) {
-		    conditions[opts.keys[i]] = opts.data[opts.keys[i]];
+		for (i = 0; i < opts.keyProperties.length; i++) {
+			prop = opts.keyProperties[i];
+			conditions[prop.mapsTo] = opts.originalKeyValues[prop.name];
 		}
 
 		Hook.wait(instance, opts.hooks.beforeRemove, function (err) {


### PR DESCRIPTION
instance.remove does not work when using mapsTo, here's a pull request to fix it.