### PR TITLE
add possibility to manage manually a connection with pool feature

### DIFF
--- a/lib/Associations/Many.js
+++ b/lib/Associations/Many.js
@@ -317,14 +317,14 @@ function extendInstance(Model, Instance, Driver, association, opts, createInstan
 				}
 
 				if (Associations.length === 0) {
-					return Driver.remove(association.mergeTable, conditions, cb);
+					return Driver.remove(association.mergeTable, conditions, Instance.getConnectionId(), cb);
 				}
 
 				for (var i = 0; i < Associations.length; i++) {
 					util.populateConditions(association.model, Object.keys(association.mergeAssocId), Associations[i], conditions, false);
 				}
 
-				Driver.remove(association.mergeTable, conditions, cb);
+				Driver.remove(association.mergeTable, conditions, Instance.getConnectionId(), cb);
 			};
 
 			util.populateConditions(Model, Object.keys(association.mergeId), Instance, conditions);
@@ -393,7 +393,7 @@ function extendInstance(Model, Instance, Driver, association, opts, createInstan
 							util.populateConditions(Model, Object.keys(association.mergeId), Instance, data);
 							util.populateConditions(association.model, Object.keys(association.mergeAssocId), Association, data);
 
-							Driver.insert(association.mergeTable, data, null, function (err) {
+							Driver.insert(association.mergeTable, data, null, Instance.getConnectionId(), function (err) {
 								if (err) {
 									return cb(err);
 								}

--- a/lib/ChainFind.js
+++ b/lib/ChainFind.js
@@ -131,7 +131,7 @@ function ChainFind(Model, opts) {
 					conditions.or.push(or);
 				}
 
-				return opts.driver.remove(opts.table, conditions, cb);
+				return opts.driver.remove(opts.table, conditions, null, cb);
 			});
 			return this;
 		},

--- a/lib/Drivers/DML/_shared.js
+++ b/lib/Drivers/DML/_shared.js
@@ -4,11 +4,24 @@ module.exports = {
 		if (arguments.length == 2) {
 			var query = arguments[0];
 			var cb    = arguments[1];
+			var connectionId = null;
 		} else if (arguments.length == 3) {
-			var query = this.query.escape(arguments[0], arguments[1]);
-			var cb    = arguments[2];
+			if (arguments[1].constructor === Array) {
+				var query = this.query.escape(arguments[0], arguments[1]);
+				var cb    = arguments[2];
+			}
+			else {
+				var query = arguments[0];
+				var connectionId = arguments[1];
+				var cb    = arguments[2];
+			}
 		}
-		return this.execSimpleQuery(query, cb);
+		else if (arguments.length == 4) {
+			var query = this.query.escape(arguments[0], arguments[1]);
+			var connectionId = arguments[2];
+			var cb    = arguments[3];
+		}
+		return this.execSimpleQuery(query, connectionId, cb);
 	},
 	eagerQuery: function (association, opts, keys, cb) {
 		var desiredKey = Object.keys(association.field);
@@ -25,6 +38,6 @@ module.exports = {
 			.where(association.mergeTable, where)
 			.build();
 
-		this.execSimpleQuery(query, cb);
+		this.execSimpleQuery(query, null, cb);
 	}
 };

--- a/lib/Drivers/DML/mongodb.js
+++ b/lib/Drivers/DML/mongodb.js
@@ -185,7 +185,7 @@ Driver.prototype.count = function (table, conditions, opts, cb) {
 	});
 };
 
-Driver.prototype.insert = function (table, data, keyProperties, cb) {
+Driver.prototype.insert = function (table, data, keyProperties, connectionId, cb) {
 	convertToDB(data, this.config.timezone);
 
 	return this.db.collection(table).insert(
@@ -337,7 +337,7 @@ Driver.prototype.hasMany = function (Model, association) {
 	};
 };
 
-Driver.prototype.update = function (table, changes, conditions, cb) {
+Driver.prototype.update = function (table, changes, conditions, connectionId, cb) {
 	convertToDB(changes, this.config.timezone);
 	convertToDB(conditions, this.config.timezone);
 
@@ -354,7 +354,7 @@ Driver.prototype.update = function (table, changes, conditions, cb) {
 	);
 };
 
-Driver.prototype.remove = function (table, conditions, cb) {
+Driver.prototype.remove = function (table, conditions, connectionId, cb) {
 	convertToDB(conditions, this.config.timezone);
 
 	return this.db.collection(table).remove(conditions, cb);

--- a/lib/Drivers/DML/mysql.js
+++ b/lib/Drivers/DML/mysql.js
@@ -3,6 +3,7 @@ var mysql   = require("mysql");
 var Query   = require("sql-query").Query;
 var shared  = require("./_shared");
 var DDL     = require("../DDL/SQL");
+var poolConnection = require("../../PoolConnection");
 
 exports.Driver = Driver;
 
@@ -92,12 +93,12 @@ Driver.prototype.getQuery = function () {
 	return this.query;
 };
 
-Driver.prototype.execSimpleQuery = function (query, cb) {
+Driver.prototype.execSimpleQuery = function (query, connectionId, cb) {
 	if (this.opts.debug) {
 		require("../../Debug").sql('mysql', query);
 	}
 	if (this.opts.pool) {
-		this.poolQuery(query, cb);
+		this.poolQuery(query, connectionId, cb);
 	} else {
 		this.db.query(query, cb);
 	}
@@ -141,7 +142,7 @@ Driver.prototype.find = function (fields, table, conditions, opts, cb) {
 
 	q = q.build();
 
-	this.execSimpleQuery(q, cb);
+	this.execSimpleQuery(q, null, cb);
 };
 
 Driver.prototype.count = function (table, conditions, opts, cb) {
@@ -168,16 +169,16 @@ Driver.prototype.count = function (table, conditions, opts, cb) {
 
 	q = q.build();
 
-	this.execSimpleQuery(q, cb);
+	this.execSimpleQuery(q, null, cb);
 };
 
-Driver.prototype.insert = function (table, data, keyProperties, cb) {
+Driver.prototype.insert = function (table, data, keyProperties, connectionId, cb) {
 	var q = this.query.insert()
 	                  .into(table)
 	                  .set(data)
 	                  .build();
 
-	this.execSimpleQuery(q, function (err, info) {
+	this.execSimpleQuery(q, connectionId, function (err, info) {
 		if (err) return cb(err);
 
 		var i, ids = {}, prop;
@@ -196,47 +197,73 @@ Driver.prototype.insert = function (table, data, keyProperties, cb) {
 	});
 };
 
-Driver.prototype.update = function (table, changes, conditions, cb) {
+Driver.prototype.update = function (table, changes, conditions, connectionId, cb) {
 	var q = this.query.update()
 	                  .into(table)
 	                  .set(changes)
 	                  .where(conditions)
 	                  .build();
 
-	this.execSimpleQuery(q, cb);
+	this.execSimpleQuery(q, connectionId, cb);
 };
 
-Driver.prototype.remove = function (table, conditions, cb) {
+Driver.prototype.remove = function (table, conditions, connectionId, cb) {
 	var q = this.query.remove()
 	                  .from(table)
 	                  .where(conditions)
 	                  .build();
 
-	this.execSimpleQuery(q, cb);
+	this.execSimpleQuery(q, connectionId, cb);
 };
 
 Driver.prototype.clear = function (table, cb) {
 	var q = "TRUNCATE TABLE " + this.query.escapeId(table);
 
-	this.execSimpleQuery(q, cb);
+	this.execSimpleQuery(q, null, cb);
 };
 
-Driver.prototype.poolQuery = function (query, cb) {
+Driver.prototype.createPool = function (cb) {
 	this.db.pool.getConnection(function (err, con) {
-		if (err) {
+		if (err)
 			return cb(err);
+		return cb(null, poolConnection.addConnection(con));
+	});
+};
+
+Driver.prototype.releasePool = function (connectionId) {
+	var connection = poolConnection.getConnection(connectionId);
+	if (connection != null) {
+		if (connection.release) {
+			connection.release();
+		} else {
+			connection.end();
 		}
+		poolConnection.removeConnection(connectionId);
+	}
+};
 
-		con.query(query, function (err, data) {
-			if (con.release) {
-				con.release();
-			} else {
-				con.end();
-			}
-
+Driver.prototype.poolQuery = function (query, connectionId, cb) {
+	var connection = poolConnection.getConnection(connectionId);
+	if (connection != null)
+		connection.query(query, function (err, data) {
 			return cb(err, data);
 		});
-	});
+	else
+		this.db.pool.getConnection(function (err, con) {
+			if (err) {
+				return cb(err);
+			}
+
+			con.query(query, function (err, data) {
+				if (con.release) {
+					con.release();
+				} else {
+					con.end();
+				}
+
+				return cb(err, data);
+			});
+		});
 };
 
 Driver.prototype.valueToProperty = function (value, property) {

--- a/lib/Drivers/DML/postgres.js
+++ b/lib/Drivers/DML/postgres.js
@@ -3,6 +3,7 @@ var pg      = require("pg");
 var Query   = require("sql-query").Query;
 var shared  = require("./_shared");
 var DDL     = require("../DDL/SQL");
+var poolConnection = require("../../PoolConnection");
 
 exports.Driver = Driver;
 
@@ -16,25 +17,35 @@ var switchableFunctions = {
 				cb(err);
 			});
 		},
-		execSimpleQuery: function (query, cb) {
+		execSimpleQuery: function (query, connectionId, cb) {
 			if (this.opts.debug) {
 				require("../../Debug").sql('postgres', query);
 			}
-			this.db.connect(this.config, function (err, client, done) {
-				if (err) {
-					return cb(err);
-				}
-
-				client.query(query, function (err, result) {
-					done();
-
+			var connection = poolConnection.getConnection(connectionId);
+			if (connection != null)
+				connection.client.query(query, function (err, result) {
 					if (err) {
 						cb(err);
 					} else {
 						cb(null, result.rows);
 					}
 				});
-			});
+			else
+				this.db.connect(this.config, function (err, client, done) {
+					if (err) {
+						return cb(err);
+					}
+
+					client.query(query, function (err, result) {
+						done();
+
+						if (err) {
+							cb(err);
+						} else {
+							cb(null, result.rows);
+						}
+					});
+				});
 			return this;
 		},
 		on: function(ev, cb) {
@@ -47,7 +58,7 @@ var switchableFunctions = {
 		connect: function (cb) {
 			this.db.connect(cb);
 		},
-		execSimpleQuery: function (query, cb) {
+		execSimpleQuery: function (query, connectionId, cb) {
 			if (this.opts.debug) {
 				require("../../Debug").sql('postgres', query);
 			}
@@ -119,8 +130,25 @@ function Driver(config, connection, opts) {
 
 _.extend(Driver.prototype, shared, DDL);
 
+Driver.prototype.createPool = function (cb) {
+	this.db.connect(this.config, function (err, client, done) {
+		if (err) {
+			return cb(err);
+		}
+		return cb(null, poolConnection.addConnection({client: client, done: done}));
+	});
+};
+
+Driver.prototype.releasePool = function (connectionId) {
+	var connection = poolConnection.getConnection(connectionId);
+	if (connection != null) {
+		connection.done();
+		poolConnection.removeConnection(connectionId);
+	}
+};
+
 Driver.prototype.ping = function (cb) {
-	this.execSimpleQuery("SELECT * FROM pg_stat_activity LIMIT 1", function () {
+	this.execSimpleQuery("SELECT * FROM pg_stat_activity LIMIT 1", null, function () {
 		return cb();
 	});
 	return this;
@@ -172,7 +200,7 @@ Driver.prototype.find = function (fields, table, conditions, opts, cb) {
 
 	q = q.build();
 
-	this.execSimpleQuery(q, cb);
+	this.execSimpleQuery(q, null, cb);
 };
 
 Driver.prototype.count = function (table, conditions, opts, cb) {
@@ -197,13 +225,13 @@ Driver.prototype.count = function (table, conditions, opts, cb) {
 
 	q = q.build();
 
-	this.execSimpleQuery(q, cb);
+	this.execSimpleQuery(q, null, cb);
 };
 
-Driver.prototype.insert = function (table, data, keyProperties, cb) {
+Driver.prototype.insert = function (table, data, keyProperties, connectionId, cb) {
 	var q = this.query.insert().into(table).set(data).build();
 
-	this.execSimpleQuery(q + " RETURNING *", function (err, results) {
+	this.execSimpleQuery(q + " RETURNING *", connectionId, function (err, results) {
 		if (err) {
 			return cb(err);
 		}
@@ -221,22 +249,22 @@ Driver.prototype.insert = function (table, data, keyProperties, cb) {
 	});
 };
 
-Driver.prototype.update = function (table, changes, conditions, cb) {
+Driver.prototype.update = function (table, changes, conditions, connectionId, cb) {
 	var q = this.query.update().into(table).set(changes).where(conditions).build();
 
-	this.execSimpleQuery(q, cb);
+	this.execSimpleQuery(q, connectionId, cb);
 };
 
-Driver.prototype.remove = function (table, conditions, cb) {
+Driver.prototype.remove = function (table, conditions, connectionId, cb) {
 	var q = this.query.remove().from(table).where(conditions).build();
 
-	this.execSimpleQuery(q, cb);
+	this.execSimpleQuery(q, connectionId, cb);
 };
 
 Driver.prototype.clear = function (table, cb) {
 	var q = "TRUNCATE TABLE " + this.query.escapeId(table);
 
-	this.execSimpleQuery(q, cb);
+	this.execSimpleQuery(q, null, cb);
 };
 
 Driver.prototype.valueToProperty = function (value, property) {

--- a/lib/Drivers/DML/redshift.js
+++ b/lib/Drivers/DML/redshift.js
@@ -9,7 +9,7 @@ function Driver(config, connection, opts) {
 
 util.inherits(Driver, postgres.Driver);
 
-Driver.prototype.insert = function (table, data, keyProperties, cb) {
+Driver.prototype.insert = function (table, data, keyProperties, connectionId, cb) {
 	var q = this.query.insert()
 	                  .into(table)
 	                  .set(data)

--- a/lib/Drivers/DML/sqlite.js
+++ b/lib/Drivers/DML/sqlite.js
@@ -66,7 +66,7 @@ Driver.prototype.getQuery = function () {
 	return this.query;
 };
 
-Driver.prototype.execSimpleQuery = function (query, cb) {
+Driver.prototype.execSimpleQuery = function (query, connectionId, cb) {
 	if (this.opts.debug) {
 		require("../../Debug").sql('sqlite', query);
 	}
@@ -147,7 +147,7 @@ Driver.prototype.count = function (table, conditions, opts, cb) {
 	this.db.all(q, cb);
 };
 
-Driver.prototype.insert = function (table, data, keyProperties, cb) {
+Driver.prototype.insert = function (table, data, keyProperties, connectionId, cb) {
 	var q = this.query.insert()
 	                  .into(table)
 	                  .set(data)
@@ -183,7 +183,7 @@ Driver.prototype.insert = function (table, data, keyProperties, cb) {
 	}.bind(this));
 };
 
-Driver.prototype.update = function (table, changes, conditions, cb) {
+Driver.prototype.update = function (table, changes, conditions, connectionId, cb) {
 	var q = this.query.update()
 	                  .into(table)
 	                  .set(changes)
@@ -196,7 +196,7 @@ Driver.prototype.update = function (table, changes, conditions, cb) {
 	this.db.all(q, cb);
 };
 
-Driver.prototype.remove = function (table, conditions, cb) {
+Driver.prototype.remove = function (table, conditions, connectionId, cb) {
 	var q = this.query.remove()
 	                  .from(table)
 	                  .where(conditions)

--- a/lib/Instance.js
+++ b/lib/Instance.js
@@ -18,6 +18,13 @@ function Instance(Model, opts) {
 	var instance_saving = false;
 	var events = {};
 	var instance = {};
+	var connectionId = opts.connectionId || null;
+	var setConnectionId = function (conId) {
+		connectionId = conId;
+	}
+	var getConnectionId = function () {
+		return connectionId;
+	}
 	var emitEvent = function () {
 		var args = Array.prototype.slice.apply(arguments);
 		var event = args.shift();
@@ -193,7 +200,7 @@ function Instance(Model, opts) {
 
 		data = Utilities.transformPropertyNames(data, Model.allProperties);
 
-		opts.driver.insert(opts.table, data, opts.keyProperties, function (save_err, info) {
+		opts.driver.insert(opts.table, data, opts.keyProperties, connectionId, function (save_err, info) {
 			if (save_err) {
 				return saveError(cb, save_err);
 			}
@@ -256,7 +263,7 @@ function Instance(Model, opts) {
 			}
 			changes = Utilities.transformPropertyNames(changes, Model.allProperties);
 
-			opts.driver.update(opts.table, changes, conditions, function (err) {
+			opts.driver.update(opts.table, changes, conditions, connectionId, function (err) {
 				if (err) {
 					return saveError(cb, err);
 				}
@@ -363,7 +370,7 @@ function Instance(Model, opts) {
 			conditions[opts.extra_info.assoc_prop[i]] = opts.data[opts.keys[i]];
 		}
 
-		opts.driver.update(opts.extra_info.table, data, conditions, function (err) {
+		opts.driver.update(opts.extra_info.table, data, conditions, connectionId, function (err) {
 			return cb(err);
 		});
 	};
@@ -388,7 +395,7 @@ function Instance(Model, opts) {
 
 			emitEvent("beforeRemove", instance);
 
-			opts.driver.remove(opts.table, conditions, function (err, data) {
+			opts.driver.remove(opts.table, conditions, connectionId, function (err, data) {
 				Hook.trigger(instance, opts.hooks.afterRemove, !err);
 
 				emitEvent("remove", err, instance);
@@ -422,7 +429,7 @@ function Instance(Model, opts) {
 				return;
 			}
 
-			opts.driver.update(opts.table, changes, conditions, function (err) {
+			opts.driver.update(opts.table, changes, conditions, connectionId, function (err) {
 				if (!err) {
 					opts.data[key] = value;
 				}
@@ -564,6 +571,21 @@ function Instance(Model, opts) {
 		addInstanceExtraProperty(k);
 	}
 
+	Object.defineProperty(instance, "useConnectionId", {
+		value: function (conId) {
+			setConnectionId(conId);
+			return this;
+		},
+		enumerable: false,
+		writable: true
+	});
+	Object.defineProperty(instance, "getConnectionId", {
+		value: function (conId) {
+			return getConnectionId();
+		},
+		enumerable: false,
+		writable: false
+	});
 	Object.defineProperty(instance, "on", {
 		value: function (event, cb) {
 			if (!events.hasOwnProperty(event)) {

--- a/lib/Model.js
+++ b/lib/Model.js
@@ -113,7 +113,8 @@ function Model(opts) {
 			association_properties : association_properties,
 			setupAssociations      : setupAssociations,
 			fieldToPropertyMap     : fieldToPropertyMap,
-			keyProperties          : keyProperties
+			keyProperties          : keyProperties,
+			connectionId           : inst_opts.connectionId
 		});
 		instance.on("ready", function (err) {
 			if (--pending > 0) {
@@ -564,6 +565,7 @@ function Model(opts) {
 		var Instances = [];
 		var options = {};
 		var cb = null, idx = 0, single = false;
+		var connectionId = null;
 		var createNext = function () {
 			if (idx >= Instances.length) {
 				return cb(null, single ? Instances[0] : Instances);
@@ -572,7 +574,8 @@ function Model(opts) {
 			Instances[idx] = createInstance(Instances[idx], {
 				is_new    : true,
 				autoSave  : opts.autoSave,
-				autoFetch : false
+				autoFetch : false,
+				connectionId : connectionId
 			}, function (err) {
 				if (err) {
 					err.index = idx;
@@ -607,6 +610,9 @@ function Model(opts) {
 					break;
 				case "function":
 					cb = arguments[i];
+					break;
+				case "string":
+					connectionId = arguments[i];
 					break;
 			}
 		}

--- a/lib/PoolConnection.js
+++ b/lib/PoolConnection.js
@@ -1,0 +1,27 @@
+var uuid = require('node-uuid');
+
+var connection = [];
+
+exports.addConnection = function(con) {
+	var id = uuid.v4();
+	connection.push({
+		obj: con,
+		id: id
+	});
+	return id;
+}
+
+exports.getConnection = function(id) {
+	for (var i = 0; i < connection.length; ++i)
+		if (connection[i].id == id)
+			return connection[i].obj;
+	return null;
+}
+
+exports.removeConnection = function(id) {
+	for (var i = 0; i < connection.length; ++i)
+		if (connection[i].id == id) {
+			connection.splice(i, 1);
+			break;
+		}
+}

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
 		"sql-ddl-sync"     : "0.3.11",
 		"hat"              : "0.0.3",
 		"lodash"           : "4.11.2",
+		"node-uuid"        : "^1.4.7",
 		"path-is-absolute" : "1.0.0"
 	},
 	"devDependencies": {


### PR DESCRIPTION
Issue #284 

New function : 
```
db.driver.createPool(cb) --> return connectionId;
db.driver.releasePool(connectionId);
```

Updated function :
```
Model.create(data, connectionId, cb)
Instance.useConnection(connectionId).chainFunction()
```
