### PR TITLE
Convert tabs to spaces to avoid constant linting.

### DIFF
--- a/lib/AggregateFunctions.js
+++ b/lib/AggregateFunctions.js
@@ -4,172 +4,172 @@ var Utilities  = require("./Utilities");
 module.exports = AggregateFunctions;
 
 function AggregateFunctions(opts) {
-	if (typeof opts.driver.getQuery !== "function") {
-		throw new ORMError('NO_SUPPORT', "This driver does not support aggregate functions");
-	}
-	if (!Array.isArray(opts.driver.aggregate_functions)) {
-		throw new ORMError('NO_SUPPORT', "This driver does not support aggregate functions");
-	}
+  if (typeof opts.driver.getQuery !== "function") {
+    throw new ORMError('NO_SUPPORT', "This driver does not support aggregate functions");
+  }
+  if (!Array.isArray(opts.driver.aggregate_functions)) {
+    throw new ORMError('NO_SUPPORT', "This driver does not support aggregate functions");
+  }
 
-	var aggregates    = [ [] ];
-	var group_by      = null;
-	var used_distinct = false;
+  var aggregates    = [ [] ];
+  var group_by      = null;
+  var used_distinct = false;
 
-	var appendFunction = function (fun) {
-		return function () {
-			var args = (arguments.length && Array.isArray(arguments[0]) ? arguments[0] : Array.prototype.slice.apply(arguments));
+  var appendFunction = function (fun) {
+    return function () {
+      var args = (arguments.length && Array.isArray(arguments[0]) ? arguments[0] : Array.prototype.slice.apply(arguments));
 
-			if (args.length > 0) {
-				aggregates[aggregates.length - 1].push({ f: fun, a: args, alias: aggregateAlias(fun, args) });
-				aggregates.push([]);
-			} else {
-				aggregates[aggregates.length - 1].push({ f: fun, alias: aggregateAlias(fun, args) });
-			}
+      if (args.length > 0) {
+        aggregates[aggregates.length - 1].push({ f: fun, a: args, alias: aggregateAlias(fun, args) });
+        aggregates.push([]);
+      } else {
+        aggregates[aggregates.length - 1].push({ f: fun, alias: aggregateAlias(fun, args) });
+      }
 
-			if (fun === "distinct") {
-				used_distinct = true;
-			}
+      if (fun === "distinct") {
+        used_distinct = true;
+      }
 
-			return proto;
-		};
-	};
-	var proto = {
-		groupBy: function () {
-			group_by = Array.prototype.slice.apply(arguments);
-			return this;
-		},
-		limit: function (offset, limit) {
-			if (typeof limit === "number") {
-				opts.limit = [ offset, limit ];
-			} else {
-				opts.limit = [ 0, offset ]; // offset = limit
-			}
-			return this;
-		},
-		order: function () {
-			opts.order = Utilities.standardizeOrder(Array.prototype.slice.apply(arguments));
-			return this;
-		},
-		select: function () {
-			if (arguments.length === 0) {
-				throw new ORMError('PARAM_MISMATCH', "When using append you must at least define one property");
-			}
-			if (Array.isArray(arguments[0])) {
-				opts.propertyList = opts.propertyList.concat(arguments[0]);
-			} else {
-				opts.propertyList = opts.propertyList.concat(Array.prototype.slice.apply(arguments));
-			}
-			return this;
-		},
-		as: function (alias) {
-			if (aggregates.length === 0 || (aggregates.length === 1 && aggregates[0].length === 0)) {
-				throw new ORMError('PARAM_MISMATCH', "No aggregate functions defined yet");
-			}
+      return proto;
+    };
+  };
+  var proto = {
+    groupBy: function () {
+      group_by = Array.prototype.slice.apply(arguments);
+      return this;
+    },
+    limit: function (offset, limit) {
+      if (typeof limit === "number") {
+        opts.limit = [ offset, limit ];
+      } else {
+        opts.limit = [ 0, offset ]; // offset = limit
+      }
+      return this;
+    },
+    order: function () {
+      opts.order = Utilities.standardizeOrder(Array.prototype.slice.apply(arguments));
+      return this;
+    },
+    select: function () {
+      if (arguments.length === 0) {
+        throw new ORMError('PARAM_MISMATCH', "When using append you must at least define one property");
+      }
+      if (Array.isArray(arguments[0])) {
+        opts.propertyList = opts.propertyList.concat(arguments[0]);
+      } else {
+        opts.propertyList = opts.propertyList.concat(Array.prototype.slice.apply(arguments));
+      }
+      return this;
+    },
+    as: function (alias) {
+      if (aggregates.length === 0 || (aggregates.length === 1 && aggregates[0].length === 0)) {
+        throw new ORMError('PARAM_MISMATCH', "No aggregate functions defined yet");
+      }
 
-			var len = aggregates.length;
+      var len = aggregates.length;
 
-			aggregates[len - 1][aggregates[len - 1].length - 1].alias = alias;
+      aggregates[len - 1][aggregates[len - 1].length - 1].alias = alias;
 
-			return this;
-		},
-		call: function (fun, args) {
-			if (args && args.length > 0) {
-				aggregates[aggregates.length - 1].push({ f: fun, a: args, alias: aggregateAlias(fun, args) });
-				// aggregates.push([]);
-			} else {
-				aggregates[aggregates.length - 1].push({ f: fun, alias: aggregateAlias(fun, args) });
-			}
+      return this;
+    },
+    call: function (fun, args) {
+      if (args && args.length > 0) {
+        aggregates[aggregates.length - 1].push({ f: fun, a: args, alias: aggregateAlias(fun, args) });
+        // aggregates.push([]);
+      } else {
+        aggregates[aggregates.length - 1].push({ f: fun, alias: aggregateAlias(fun, args) });
+      }
 
-			if (fun.toLowerCase() === "distinct") {
-				used_distinct = true;
-			}
+      if (fun.toLowerCase() === "distinct") {
+        used_distinct = true;
+      }
 
-			return this;
-		},
-		get: function (cb) {
-			if (typeof cb !== "function") {
-				throw new ORMError('MISSING_CALLBACK', "You must pass a callback to Model.aggregate().get()");
-			}
-			if (aggregates[aggregates.length - 1].length === 0) {
-				aggregates.length -= 1;
-			}
-			if (aggregates.length === 0) {
-				throw new ORMError('PARAM_MISMATCH', "Missing aggregate functions");
-			}
+      return this;
+    },
+    get: function (cb) {
+      if (typeof cb !== "function") {
+        throw new ORMError('MISSING_CALLBACK', "You must pass a callback to Model.aggregate().get()");
+      }
+      if (aggregates[aggregates.length - 1].length === 0) {
+        aggregates.length -= 1;
+      }
+      if (aggregates.length === 0) {
+        throw new ORMError('PARAM_MISMATCH', "Missing aggregate functions");
+      }
 
-			var query = opts.driver.getQuery().select().from(opts.table).select(opts.propertyList);
-			var i, j;
+      var query = opts.driver.getQuery().select().from(opts.table).select(opts.propertyList);
+      var i, j;
 
-			for (i = 0; i < aggregates.length; i++) {
-				for (j = 0; j < aggregates[i].length; j++) {
-					query.fun(aggregates[i][j].f, aggregates[i][j].a, aggregates[i][j].alias);
-				}
-			}
+      for (i = 0; i < aggregates.length; i++) {
+        for (j = 0; j < aggregates[i].length; j++) {
+          query.fun(aggregates[i][j].f, aggregates[i][j].a, aggregates[i][j].alias);
+        }
+      }
 
-			query.where(opts.conditions);
+      query.where(opts.conditions);
 
-			if (group_by !== null) {
-				query.groupBy.apply(query, group_by);
-			}
+      if (group_by !== null) {
+        query.groupBy.apply(query, group_by);
+      }
 
-			if (opts.order) {
-				for (i = 0; i < opts.order.length; i++) {
-					query.order(opts.order[i][0], opts.order[i][1]);
-				}
-			}
-			if (opts.limit) {
-				query.offset(opts.limit[0]).limit(opts.limit[1]);
-			}
+      if (opts.order) {
+        for (i = 0; i < opts.order.length; i++) {
+          query.order(opts.order[i][0], opts.order[i][1]);
+        }
+      }
+      if (opts.limit) {
+        query.offset(opts.limit[0]).limit(opts.limit[1]);
+      }
 
-			query = query.build();
+      query = query.build();
 
-			opts.driver.execQuery(query, function (err, data) {
-				if (err) {
-					return cb(err);
-				}
+      opts.driver.execQuery(query, function (err, data) {
+        if (err) {
+          return cb(err);
+        }
 
-				if (group_by !== null) {
-					return cb(null, data);
-				}
+        if (group_by !== null) {
+          return cb(null, data);
+        }
 
-				var items = [], i;
+        var items = [], i;
 
-				if (used_distinct && aggregates.length === 1) {
-					for (i = 0; i < data.length; i++) {
-						items.push(data[i][Object.keys(data[i]).pop()]);
-					}
+        if (used_distinct && aggregates.length === 1) {
+          for (i = 0; i < data.length; i++) {
+            items.push(data[i][Object.keys(data[i]).pop()]);
+          }
 
-					return cb(null, items);
-				}
+          return cb(null, items);
+        }
 
-				for (i = 0; i < aggregates.length; i++) {
-					for (var j = 0; j < aggregates[i].length; j++) {
-						items.push(data[0][aggregates[i][j].alias] || null);
-					}
-				}
+        for (i = 0; i < aggregates.length; i++) {
+          for (var j = 0; j < aggregates[i].length; j++) {
+            items.push(data[0][aggregates[i][j].alias] || null);
+          }
+        }
 
-				items.unshift(null);
+        items.unshift(null);
 
-				return cb.apply(null, items);
-			});
-		}
-	};
+        return cb.apply(null, items);
+      });
+    }
+  };
 
-	for (var i = 0; i < opts.driver.aggregate_functions.length; i++) {
-		addAggregate(proto, opts.driver.aggregate_functions[i], appendFunction);
-	}
+  for (var i = 0; i < opts.driver.aggregate_functions.length; i++) {
+    addAggregate(proto, opts.driver.aggregate_functions[i], appendFunction);
+  }
 
-	return proto;
+  return proto;
 }
 
 function addAggregate(proto, fun, builder) {
-	if (Array.isArray(fun)) {
-		proto[fun[0].toLowerCase()] = builder((fun[1] || fun[0]).toLowerCase());
-	} else {
-		proto[fun.toLowerCase()] = builder(fun.toLowerCase());
-	}
+  if (Array.isArray(fun)) {
+    proto[fun[0].toLowerCase()] = builder((fun[1] || fun[0]).toLowerCase());
+  } else {
+    proto[fun.toLowerCase()] = builder(fun.toLowerCase());
+  }
 }
 
 function aggregateAlias(fun, fields) {
-	return fun + (fields && fields.length ? "_" + fields.join("_") : "");
+  return fun + (fields && fields.length ? "_" + fields.join("_") : "");
 }

--- a/lib/Associations/Extend.js
+++ b/lib/Associations/Extend.js
@@ -5,232 +5,232 @@ var Singleton  = require("../Singleton");
 var util       = require("../Utilities");
 
 exports.prepare = function (db, Model, associations) {
-	Model.extendsTo = function (name, properties, opts) {
-		opts = opts || {};
+  Model.extendsTo = function (name, properties, opts) {
+    opts = opts || {};
 
-		var assocName = opts.name || ucfirst(name);
-		var association = {
-			name           : name,
-			table          : opts.table || (Model.table + '_' + name),
-			reversed       : opts.reversed,
-			autoFetch      : opts.autoFetch || false,
-			autoFetchLimit : opts.autoFetchLimit || 2,
-			field          : util.wrapFieldObject({
-												 field: opts.field, model: Model, altName: Model.table
-											 }) || util.formatField(Model, Model.table, false, false),
-			getAccessor    : opts.getAccessor || ("get" + assocName),
-			setAccessor    : opts.setAccessor || ("set" + assocName),
-			hasAccessor    : opts.hasAccessor || ("has" + assocName),
-			delAccessor    : opts.delAccessor || ("remove" + assocName)
-		};
+    var assocName = opts.name || ucfirst(name);
+    var association = {
+      name           : name,
+      table          : opts.table || (Model.table + '_' + name),
+      reversed       : opts.reversed,
+      autoFetch      : opts.autoFetch || false,
+      autoFetchLimit : opts.autoFetchLimit || 2,
+      field          : util.wrapFieldObject({
+                         field: opts.field, model: Model, altName: Model.table
+                       }) || util.formatField(Model, Model.table, false, false),
+      getAccessor    : opts.getAccessor || ("get" + assocName),
+      setAccessor    : opts.setAccessor || ("set" + assocName),
+      hasAccessor    : opts.hasAccessor || ("has" + assocName),
+      delAccessor    : opts.delAccessor || ("remove" + assocName)
+    };
 
-		var newproperties = _.cloneDeep(properties);
-		for (var k in association.field) {
-		    newproperties[k] = association.field[k];
-		}
+    var newproperties = _.cloneDeep(properties);
+    for (var k in association.field) {
+        newproperties[k] = association.field[k];
+    }
 
-		var modelOpts = _.extend(
-			_.pick(opts, 'identityCache', 'autoSave', 'cascadeRemove', 'hooks', 'methods', 'validations'),
-			{
-				id        : Object.keys(association.field),
-				extension : true,
-			}
-		);
+    var modelOpts = _.extend(
+      _.pick(opts, 'identityCache', 'autoSave', 'cascadeRemove', 'hooks', 'methods', 'validations'),
+      {
+        id        : Object.keys(association.field),
+        extension : true,
+      }
+    );
 
-		association.model = db.define(association.table, newproperties, modelOpts);
-		association.model.hasOne(Model.table, Model, { extension: true, field: association.field });
+    association.model = db.define(association.table, newproperties, modelOpts);
+    association.model.hasOne(Model.table, Model, { extension: true, field: association.field });
 
-		associations.push(association);
+    associations.push(association);
 
-		Model["findBy" + assocName] = function () {
-			var cb = null, conditions = null, options = {};
+    Model["findBy" + assocName] = function () {
+      var cb = null, conditions = null, options = {};
 
-			for (var i = 0; i < arguments.length; i++) {
-				switch (typeof arguments[i]) {
-					case "function":
-						cb = arguments[i];
-						break;
-					case "object":
-						if (conditions === null) {
-							conditions = arguments[i];
-						} else {
-							options = arguments[i];
-						}
-						break;
-				}
-			}
+      for (var i = 0; i < arguments.length; i++) {
+        switch (typeof arguments[i]) {
+          case "function":
+            cb = arguments[i];
+            break;
+          case "object":
+            if (conditions === null) {
+              conditions = arguments[i];
+            } else {
+              options = arguments[i];
+            }
+            break;
+        }
+      }
 
-			if (conditions === null) {
-				throw new ORMError(".findBy(" + assocName + ") is missing a conditions object", 'PARAM_MISMATCH');
-			}
+      if (conditions === null) {
+        throw new ORMError(".findBy(" + assocName + ") is missing a conditions object", 'PARAM_MISMATCH');
+      }
 
-			options.__merge = {
-				from  : { table: association.model.table, field: Object.keys(association.field) },
-				to    : { table: Model.table, field: Model.id },
-				where : [ association.model.table, conditions ],
-				table : Model.table
-			};
-			options.extra = [];
+      options.__merge = {
+        from  : { table: association.model.table, field: Object.keys(association.field) },
+        to    : { table: Model.table, field: Model.id },
+        where : [ association.model.table, conditions ],
+        table : Model.table
+      };
+      options.extra = [];
 
-			if (typeof cb == "function") {
-				return Model.find({}, options, cb);
-			}
-			return Model.find({}, options);
-		};
+      if (typeof cb == "function") {
+        return Model.find({}, options, cb);
+      }
+      return Model.find({}, options);
+    };
 
-		return association.model;
-	};
+    return association.model;
+  };
 };
 
 exports.extend = function (Model, Instance, Driver, associations, opts) {
-	for (var i = 0; i < associations.length; i++) {
-		extendInstance(Model, Instance, Driver, associations[i], opts);
-	}
+  for (var i = 0; i < associations.length; i++) {
+    extendInstance(Model, Instance, Driver, associations[i], opts);
+  }
 };
 
 exports.autoFetch = function (Instance, associations, opts, cb) {
-	if (associations.length === 0) {
-		return cb();
-	}
+  if (associations.length === 0) {
+    return cb();
+  }
 
-	var pending = associations.length;
-	var autoFetchDone = function autoFetchDone() {
-		pending -= 1;
+  var pending = associations.length;
+  var autoFetchDone = function autoFetchDone() {
+    pending -= 1;
 
-		if (pending === 0) {
-			return cb();
-		}
-	};
+    if (pending === 0) {
+      return cb();
+    }
+  };
 
-	for (var i = 0; i < associations.length; i++) {
-		autoFetchInstance(Instance, associations[i], opts, autoFetchDone);
-	}
+  for (var i = 0; i < associations.length; i++) {
+    autoFetchInstance(Instance, associations[i], opts, autoFetchDone);
+  }
 };
 
 function extendInstance(Model, Instance, Driver, association, opts) {
-	Object.defineProperty(Instance, association.hasAccessor, {
-		value : function (cb) {
-			if (!Instance[Model.id]) {
-			    cb(new ORMError("Instance not saved, cannot get extension", 'NOT_DEFINED', { model: Model.table }));
-			} else {
-				association.model.get(util.values(Instance, Model.id), function (err, extension) {
-					return cb(err, !err && extension ? true : false);
-				});
-			}
-			return this;
-		},
-		enumerable : false
-	});
-	Object.defineProperty(Instance, association.getAccessor, {
-		value: function (opts, cb) {
-			if (typeof opts == "function") {
-				cb = opts;
-				opts = {};
-			}
+  Object.defineProperty(Instance, association.hasAccessor, {
+    value : function (cb) {
+      if (!Instance[Model.id]) {
+          cb(new ORMError("Instance not saved, cannot get extension", 'NOT_DEFINED', { model: Model.table }));
+      } else {
+        association.model.get(util.values(Instance, Model.id), function (err, extension) {
+          return cb(err, !err && extension ? true : false);
+        });
+      }
+      return this;
+    },
+    enumerable : false
+  });
+  Object.defineProperty(Instance, association.getAccessor, {
+    value: function (opts, cb) {
+      if (typeof opts == "function") {
+        cb = opts;
+        opts = {};
+      }
 
-			if (!Instance[Model.id]) {
-			    cb(new ORMError("Instance not saved, cannot get extension", 'NOT_DEFINED', { model: Model.table }));
-			} else {
-				association.model.get(util.values(Instance, Model.id), opts, cb);
-			}
-			return this;
-		},
-		enumerable : false
-	});
-	Object.defineProperty(Instance, association.setAccessor, {
-		value : function (Extension, cb) {
-			Instance.save(function (err) {
-				if (err) {
-					return cb(err);
-				}
+      if (!Instance[Model.id]) {
+          cb(new ORMError("Instance not saved, cannot get extension", 'NOT_DEFINED', { model: Model.table }));
+      } else {
+        association.model.get(util.values(Instance, Model.id), opts, cb);
+      }
+      return this;
+    },
+    enumerable : false
+  });
+  Object.defineProperty(Instance, association.setAccessor, {
+    value : function (Extension, cb) {
+      Instance.save(function (err) {
+        if (err) {
+          return cb(err);
+        }
 
-				Instance[association.delAccessor](function (err) {
-					if (err) {
-						return cb(err);
-					}
+        Instance[association.delAccessor](function (err) {
+          if (err) {
+            return cb(err);
+          }
 
-					var fields = Object.keys(association.field);
+          var fields = Object.keys(association.field);
 
-					if (!Extension.isInstance) {
-						Extension = new association.model(Extension);
-					}
+          if (!Extension.isInstance) {
+            Extension = new association.model(Extension);
+          }
 
-					for (var i = 0; i < Model.id.length; i++) {
-						Extension[fields[i]] = Instance[Model.id[i]];
-					}
+          for (var i = 0; i < Model.id.length; i++) {
+            Extension[fields[i]] = Instance[Model.id[i]];
+          }
 
-					Extension.save(cb);
-				});
-			});
-			return this;
-		},
-		enumerable : false
-	});
-	Object.defineProperty(Instance, association.delAccessor, {
-		value : function (cb) {
-			if (!Instance[Model.id]) {
-			    cb(new ORMError("Instance not saved, cannot get extension", 'NOT_DEFINED', { model: Model.table }));
-			} else {
-				var conditions = {};
-				var fields = Object.keys(association.field);
+          Extension.save(cb);
+        });
+      });
+      return this;
+    },
+    enumerable : false
+  });
+  Object.defineProperty(Instance, association.delAccessor, {
+    value : function (cb) {
+      if (!Instance[Model.id]) {
+          cb(new ORMError("Instance not saved, cannot get extension", 'NOT_DEFINED', { model: Model.table }));
+      } else {
+        var conditions = {};
+        var fields = Object.keys(association.field);
 
-				for (var i = 0; i < Model.id.length; i++) {
-				    conditions[fields[i]] = Instance[Model.id[i]];
-				}
+        for (var i = 0; i < Model.id.length; i++) {
+            conditions[fields[i]] = Instance[Model.id[i]];
+        }
 
-				association.model.find(conditions, function (err, extensions) {
-					if (err) {
-						return cb(err);
-					}
+        association.model.find(conditions, function (err, extensions) {
+          if (err) {
+            return cb(err);
+          }
 
-					var pending = extensions.length;
+          var pending = extensions.length;
 
-					for (var i = 0; i < extensions.length; i++) {
-						Singleton.clear(extensions[i].__singleton_uid());
-						extensions[i].remove(function () {
-							if (--pending === 0) {
-								return cb();
-							}
-						});
-					}
+          for (var i = 0; i < extensions.length; i++) {
+            Singleton.clear(extensions[i].__singleton_uid());
+            extensions[i].remove(function () {
+              if (--pending === 0) {
+                return cb();
+              }
+            });
+          }
 
-					if (pending === 0) {
-						return cb();
-					}
-				});
-			}
-			return this;
-		},
-		enumerable : false
-	});
+          if (pending === 0) {
+            return cb();
+          }
+        });
+      }
+      return this;
+    },
+    enumerable : false
+  });
 }
 
 function autoFetchInstance(Instance, association, opts, cb) {
-	if (!Instance.saved()) {
-		return cb();
-	}
+  if (!Instance.saved()) {
+    return cb();
+  }
 
-	if (!opts.hasOwnProperty("autoFetchLimit") || typeof opts.autoFetchLimit == "undefined") {
-		opts.autoFetchLimit = association.autoFetchLimit;
-	}
+  if (!opts.hasOwnProperty("autoFetchLimit") || typeof opts.autoFetchLimit == "undefined") {
+    opts.autoFetchLimit = association.autoFetchLimit;
+  }
 
-	if (opts.autoFetchLimit === 0 || (!opts.autoFetch && !association.autoFetch)) {
-		return cb();
-	}
+  if (opts.autoFetchLimit === 0 || (!opts.autoFetch && !association.autoFetch)) {
+    return cb();
+  }
 
-	if (Instance.isPersisted()) {
-		Instance[association.getAccessor]({ autoFetchLimit: opts.autoFetchLimit - 1 }, function (err, Assoc) {
-			if (!err) {
-				Instance[association.name] = Assoc;
-			}
+  if (Instance.isPersisted()) {
+    Instance[association.getAccessor]({ autoFetchLimit: opts.autoFetchLimit - 1 }, function (err, Assoc) {
+      if (!err) {
+        Instance[association.name] = Assoc;
+      }
 
-			return cb();
-		});
-	} else {
-		return cb();
-	}
+      return cb();
+    });
+  } else {
+    return cb();
+  }
 }
 
 function ucfirst(text) {
-	return text[0].toUpperCase() + text.substr(1);
+  return text[0].toUpperCase() + text.substr(1);
 }

--- a/lib/Associations/Many.js
+++ b/lib/Associations/Many.js
@@ -7,504 +7,504 @@ var ORMError            = require("../Error");
 var util                = require("../Utilities");
 
 exports.prepare = function (db, Model, associations) {
-	Model.hasMany = function () {
-		var name, makeKey, mergeId, mergeAssocId;
-		var OtherModel = Model;
-		var props = null;
-		var opts = {};
+  Model.hasMany = function () {
+    var name, makeKey, mergeId, mergeAssocId;
+    var OtherModel = Model;
+    var props = null;
+    var opts = {};
 
-		for (var i = 0; i < arguments.length; i++) {
-			switch (typeof arguments[i]) {
-				case "string":
-					name = arguments[i];
-					break;
-				case "function":
-					OtherModel = arguments[i];
-					break;
-				case "object":
-					if (props === null) {
-						props = arguments[i];
-					} else {
-						opts = arguments[i];
-					}
-					break;
-			}
-		}
+    for (var i = 0; i < arguments.length; i++) {
+      switch (typeof arguments[i]) {
+        case "string":
+          name = arguments[i];
+          break;
+        case "function":
+          OtherModel = arguments[i];
+          break;
+        case "object":
+          if (props === null) {
+            props = arguments[i];
+          } else {
+            opts = arguments[i];
+          }
+          break;
+      }
+    }
 
-		if (props === null) {
-			props = {};
-		} else {
-			for (var k in props) {
-				props[k] = Property.normalize({
-					prop: props[k], name: k, customTypes: db.customTypes, settings: Model.settings
-				});
-			}
-		}
+    if (props === null) {
+      props = {};
+    } else {
+      for (var k in props) {
+        props[k] = Property.normalize({
+          prop: props[k], name: k, customTypes: db.customTypes, settings: Model.settings
+        });
+      }
+    }
 
-		makeKey = opts.key || Settings.defaults().hasMany.key;
+    makeKey = opts.key || Settings.defaults().hasMany.key;
 
-		mergeId = util.convertPropToJoinKeyProp(
-			util.wrapFieldObject({
-				field: opts.mergeId, model: Model, altName: Model.table
-			}) ||
-			util.formatField(Model, Model.table, true, opts.reversed),
-			{ makeKey: makeKey, required: true }
-		);
+    mergeId = util.convertPropToJoinKeyProp(
+      util.wrapFieldObject({
+        field: opts.mergeId, model: Model, altName: Model.table
+      }) ||
+      util.formatField(Model, Model.table, true, opts.reversed),
+      { makeKey: makeKey, required: true }
+    );
 
-		mergeAssocId = util.convertPropToJoinKeyProp(
-			util.wrapFieldObject({
-				field: opts.mergeAssocId, model: OtherModel, altName: name
-			}) ||
-			util.formatField(OtherModel, name, true, opts.reversed),
-			{ makeKey: makeKey, required: true }
-		)
+    mergeAssocId = util.convertPropToJoinKeyProp(
+      util.wrapFieldObject({
+        field: opts.mergeAssocId, model: OtherModel, altName: name
+      }) ||
+      util.formatField(OtherModel, name, true, opts.reversed),
+      { makeKey: makeKey, required: true }
+    )
 
-		var assocName = opts.name || ucfirst(name);
-		var assocTemplateName = opts.accessor || assocName;
-		var association = {
-			name           : name,
-			model          : OtherModel || Model,
-			props          : props,
-			hooks          : opts.hooks || {},
-			autoFetch      : opts.autoFetch || false,
-			autoFetchLimit : opts.autoFetchLimit || 2,
-			// I'm not sure the next key is used..
-			field          : util.wrapFieldObject({
-				                 field: opts.field, model: OtherModel, altName: Model.table
-				               }) ||
-			                 util.formatField(Model, name, true, opts.reversed),
-			mergeTable     : opts.mergeTable || (Model.table + "_" + name),
-			mergeId        : mergeId,
-			mergeAssocId   : mergeAssocId,
-			getAccessor    : opts.getAccessor || ("get" + assocTemplateName),
-			setAccessor    : opts.setAccessor || ("set" + assocTemplateName),
-			hasAccessor    : opts.hasAccessor || ("has" + assocTemplateName),
-			delAccessor    : opts.delAccessor || ("remove" + assocTemplateName),
-			addAccessor    : opts.addAccessor || ("add" + assocTemplateName)
-		};
-		associations.push(association);
+    var assocName = opts.name || ucfirst(name);
+    var assocTemplateName = opts.accessor || assocName;
+    var association = {
+      name           : name,
+      model          : OtherModel || Model,
+      props          : props,
+      hooks          : opts.hooks || {},
+      autoFetch      : opts.autoFetch || false,
+      autoFetchLimit : opts.autoFetchLimit || 2,
+      // I'm not sure the next key is used..
+      field          : util.wrapFieldObject({
+                         field: opts.field, model: OtherModel, altName: Model.table
+                       }) ||
+                       util.formatField(Model, name, true, opts.reversed),
+      mergeTable     : opts.mergeTable || (Model.table + "_" + name),
+      mergeId        : mergeId,
+      mergeAssocId   : mergeAssocId,
+      getAccessor    : opts.getAccessor || ("get" + assocTemplateName),
+      setAccessor    : opts.setAccessor || ("set" + assocTemplateName),
+      hasAccessor    : opts.hasAccessor || ("has" + assocTemplateName),
+      delAccessor    : opts.delAccessor || ("remove" + assocTemplateName),
+      addAccessor    : opts.addAccessor || ("add" + assocTemplateName)
+    };
+    associations.push(association);
 
-		if (opts.reverse) {
-			OtherModel.hasMany(opts.reverse, Model, association.props, {
-				reversed       : true,
-				association    : opts.reverseAssociation,
-				mergeTable     : association.mergeTable,
-				mergeId        : association.mergeAssocId,
-				mergeAssocId   : association.mergeId,
-				field          : association.field,
-				autoFetch      : association.autoFetch,
-				autoFetchLimit : association.autoFetchLimit
-			});
-		}
-		return this;
-	};
+    if (opts.reverse) {
+      OtherModel.hasMany(opts.reverse, Model, association.props, {
+        reversed       : true,
+        association    : opts.reverseAssociation,
+        mergeTable     : association.mergeTable,
+        mergeId        : association.mergeAssocId,
+        mergeAssocId   : association.mergeId,
+        field          : association.field,
+        autoFetch      : association.autoFetch,
+        autoFetchLimit : association.autoFetchLimit
+      });
+    }
+    return this;
+  };
 };
 
 exports.extend = function (Model, Instance, Driver, associations, opts, createInstance) {
-	for (var i = 0; i < associations.length; i++) {
-		extendInstance(Model, Instance, Driver, associations[i], opts, createInstance);
-	}
+  for (var i = 0; i < associations.length; i++) {
+    extendInstance(Model, Instance, Driver, associations[i], opts, createInstance);
+  }
 };
 
 exports.autoFetch = function (Instance, associations, opts, cb) {
-	if (associations.length === 0) {
-		return cb();
-	}
+  if (associations.length === 0) {
+    return cb();
+  }
 
-	var pending = associations.length;
-	var autoFetchDone = function autoFetchDone() {
-		pending -= 1;
+  var pending = associations.length;
+  var autoFetchDone = function autoFetchDone() {
+    pending -= 1;
 
-		if (pending === 0) {
-			return cb();
-		}
-	};
+    if (pending === 0) {
+      return cb();
+    }
+  };
 
-	for (var i = 0; i < associations.length; i++) {
-		autoFetchInstance(Instance, associations[i], opts, autoFetchDone);
-	}
+  for (var i = 0; i < associations.length; i++) {
+    autoFetchInstance(Instance, associations[i], opts, autoFetchDone);
+  }
 };
 
 function extendInstance(Model, Instance, Driver, association, opts, createInstance) {
-	if (Model.settings.get("instance.cascadeRemove")) {
-		Instance.on("beforeRemove", function () {
-			Instance[association.delAccessor]();
-		});
-	}
+  if (Model.settings.get("instance.cascadeRemove")) {
+    Instance.on("beforeRemove", function () {
+      Instance[association.delAccessor]();
+    });
+  }
 
-	function adjustForMapsTo(options) {
-		// Loop through the (cloned) association model id fields ... some of them may've been mapped to different
-		// names in the actual database - if so update to the mapped database column name
-		for(var i=0; i<options.__merge.to.field.length; i++) {
-			var idProp = association.model.properties[options.__merge.to.field[i]];
-			if(idProp && idProp.mapsTo) {
-				options.__merge.to.field[i] = idProp.mapsTo;
-			}
-		}
-	}
+  function adjustForMapsTo(options) {
+    // Loop through the (cloned) association model id fields ... some of them may've been mapped to different
+    // names in the actual database - if so update to the mapped database column name
+    for(var i=0; i<options.__merge.to.field.length; i++) {
+      var idProp = association.model.properties[options.__merge.to.field[i]];
+      if(idProp && idProp.mapsTo) {
+        options.__merge.to.field[i] = idProp.mapsTo;
+      }
+    }
+  }
 
-	Object.defineProperty(Instance, association.hasAccessor, {
-		value: function () {
-			var Instances = Array.prototype.slice.apply(arguments);
-			var cb = Instances.pop();
-			var conditions = {}, options = {};
+  Object.defineProperty(Instance, association.hasAccessor, {
+    value: function () {
+      var Instances = Array.prototype.slice.apply(arguments);
+      var cb = Instances.pop();
+      var conditions = {}, options = {};
 
-			if (Instances.length) {
-				if (Array.isArray(Instances[0])) {
-					Instances = Instances[0];
-				}
-			}
-			if (Driver.hasMany) {
-				return Driver.hasMany(Model, association).has(Instance, Instances, conditions, cb);
-			}
+      if (Instances.length) {
+        if (Array.isArray(Instances[0])) {
+          Instances = Instances[0];
+        }
+      }
+      if (Driver.hasMany) {
+        return Driver.hasMany(Model, association).has(Instance, Instances, conditions, cb);
+      }
 
-			options.autoFetchLimit = 0;
-			options.__merge = {
-				from:   { table: association.mergeTable, field: Object.keys(association.mergeAssocId) },
-				to: { table: association.model.table, field: association.model.id.slice(0) },   // clone model id
-				where:  [ association.mergeTable, {} ]
-			};
+      options.autoFetchLimit = 0;
+      options.__merge = {
+        from:   { table: association.mergeTable, field: Object.keys(association.mergeAssocId) },
+        to: { table: association.model.table, field: association.model.id.slice(0) },   // clone model id
+        where:  [ association.mergeTable, {} ]
+      };
 
-			adjustForMapsTo(options);
+      adjustForMapsTo(options);
 
-			options.extra = association.props;
-			options.extra_info = {
-				table: association.mergeTable,
-				id: util.values(Instance, Model.id),
-				id_prop: Object.keys(association.mergeId),
-				assoc_prop: Object.keys(association.mergeAssocId)
-			};
+      options.extra = association.props;
+      options.extra_info = {
+        table: association.mergeTable,
+        id: util.values(Instance, Model.id),
+        id_prop: Object.keys(association.mergeId),
+        assoc_prop: Object.keys(association.mergeAssocId)
+      };
 
-			util.populateConditions(Model, Object.keys(association.mergeId), Instance, options.__merge.where[1]);
+      util.populateConditions(Model, Object.keys(association.mergeId), Instance, options.__merge.where[1]);
 
-			for (var i = 0; i < Instances.length; i++) {
-				util.populateConditions(association.model, Object.keys(association.mergeAssocId), Instances[i], options.__merge.where[1], false);
-			}
+      for (var i = 0; i < Instances.length; i++) {
+        util.populateConditions(association.model, Object.keys(association.mergeAssocId), Instances[i], options.__merge.where[1], false);
+      }
 
-			association.model.find(conditions, options, function (err, foundItems) {
-				if (err)                  return cb(err);
-				if (_.isEmpty(Instances)) return cb(null, false);
+      association.model.find(conditions, options, function (err, foundItems) {
+        if (err)                  return cb(err);
+        if (_.isEmpty(Instances)) return cb(null, false);
 
-				var mapKeysToString = function (item) {
-					return _.map(association.model.keys, function (k) {
-						return item[k];
-					}).join(',')
-				}
+        var mapKeysToString = function (item) {
+          return _.map(association.model.keys, function (k) {
+            return item[k];
+          }).join(',')
+        }
 
-				var foundItemsIDs = _(foundItems).map(mapKeysToString).uniq().value();
-				var InstancesIDs  = _(Instances ).map(mapKeysToString).uniq().value();
+        var foundItemsIDs = _(foundItems).map(mapKeysToString).uniq().value();
+        var InstancesIDs  = _(Instances ).map(mapKeysToString).uniq().value();
 
-				var sameLength   = foundItemsIDs.length == InstancesIDs.length;
-				var sameContents = sameLength && _.isEmpty(_.difference(foundItemsIDs, InstancesIDs));
+        var sameLength   = foundItemsIDs.length == InstancesIDs.length;
+        var sameContents = sameLength && _.isEmpty(_.difference(foundItemsIDs, InstancesIDs));
 
-				return cb(null, sameContents);
-			});
-			return this;
-		},
-		enumerable: false,
-		writable: true
-	});
-	Object.defineProperty(Instance, association.getAccessor, {
-		value: function () {
-			var options    = {};
-			var conditions = null;
-			var order      = null;
-			var cb         = null;
+        return cb(null, sameContents);
+      });
+      return this;
+    },
+    enumerable: false,
+    writable: true
+  });
+  Object.defineProperty(Instance, association.getAccessor, {
+    value: function () {
+      var options    = {};
+      var conditions = null;
+      var order      = null;
+      var cb         = null;
 
-			for (var i = 0; i < arguments.length; i++) {
-				switch (typeof arguments[i]) {
-					case "function":
-						cb = arguments[i];
-						break;
-					case "object":
-						if (Array.isArray(arguments[i])) {
-							order = arguments[i];
-							order[0] = [ association.model.table, order[0] ];
-						} else {
-							if (conditions === null) {
-								conditions = arguments[i];
-							} else {
-								options = arguments[i];
-							}
-						}
-						break;
-					case "string":
-						if (arguments[i][0] == "-") {
-							order = [ [ association.model.table, arguments[i].substr(1) ], "Z" ];
-						} else {
-							order = [ [ association.model.table, arguments[i] ] ];
-						}
-						break;
-					case "number":
-						options.limit = arguments[i];
-						break;
-				}
-			}
+      for (var i = 0; i < arguments.length; i++) {
+        switch (typeof arguments[i]) {
+          case "function":
+            cb = arguments[i];
+            break;
+          case "object":
+            if (Array.isArray(arguments[i])) {
+              order = arguments[i];
+              order[0] = [ association.model.table, order[0] ];
+            } else {
+              if (conditions === null) {
+                conditions = arguments[i];
+              } else {
+                options = arguments[i];
+              }
+            }
+            break;
+          case "string":
+            if (arguments[i][0] == "-") {
+              order = [ [ association.model.table, arguments[i].substr(1) ], "Z" ];
+            } else {
+              order = [ [ association.model.table, arguments[i] ] ];
+            }
+            break;
+          case "number":
+            options.limit = arguments[i];
+            break;
+        }
+      }
 
-			if (order !== null) {
-				options.order = order;
-			}
+      if (order !== null) {
+        options.order = order;
+      }
 
-			if (conditions === null) {
-				conditions = {};
-			}
+      if (conditions === null) {
+        conditions = {};
+      }
 
-			if (Driver.hasMany) {
-				return Driver.hasMany(Model, association).get(Instance, conditions, options, createInstance, cb);
-			}
+      if (Driver.hasMany) {
+        return Driver.hasMany(Model, association).get(Instance, conditions, options, createInstance, cb);
+      }
 
-			options.__merge = {
-				from  : { table: association.mergeTable, field: Object.keys(association.mergeAssocId) },
-				to    : { table: association.model.table, field: association.model.id.slice(0) }, // clone model id
-				where : [ association.mergeTable, {} ]
-			};
+      options.__merge = {
+        from  : { table: association.mergeTable, field: Object.keys(association.mergeAssocId) },
+        to    : { table: association.model.table, field: association.model.id.slice(0) }, // clone model id
+        where : [ association.mergeTable, {} ]
+      };
 
-			adjustForMapsTo(options);
+      adjustForMapsTo(options);
 
-		  options.extra = association.props;
-		  options.extra_info = {
-			   table: association.mergeTable,
-				id: util.values(Instance, Model.id),
-				id_prop: Object.keys(association.mergeId),
-				assoc_prop: Object.keys(association.mergeAssocId)
-			};
+      options.extra = association.props;
+      options.extra_info = {
+         table: association.mergeTable,
+        id: util.values(Instance, Model.id),
+        id_prop: Object.keys(association.mergeId),
+        assoc_prop: Object.keys(association.mergeAssocId)
+      };
 
-			util.populateConditions(Model, Object.keys(association.mergeId), Instance, options.__merge.where[1]);
+      util.populateConditions(Model, Object.keys(association.mergeId), Instance, options.__merge.where[1]);
 
-			if (cb === null) {
-				return association.model.find(conditions, options);
-			}
+      if (cb === null) {
+        return association.model.find(conditions, options);
+      }
 
-			association.model.find(conditions, options, cb);
+      association.model.find(conditions, options, cb);
 
-			return this;
-		},
-		enumerable: false,
-		writable: true
-	});
-	Object.defineProperty(Instance, association.setAccessor, {
-		value: function () {
-			var items = _.flatten(arguments);
-			var cb    = _.last(items) instanceof Function ? items.pop() : noOperation;
+      return this;
+    },
+    enumerable: false,
+    writable: true
+  });
+  Object.defineProperty(Instance, association.setAccessor, {
+    value: function () {
+      var items = _.flatten(arguments);
+      var cb    = _.last(items) instanceof Function ? items.pop() : noOperation;
 
-			Instance[association.delAccessor](function (err) {
-				if (err) return cb(err);
+      Instance[association.delAccessor](function (err) {
+        if (err) return cb(err);
 
-				if (items.length) {
-					Instance[association.addAccessor](items, cb);
-				} else {
-					cb(null);
-				}
-			});
+        if (items.length) {
+          Instance[association.addAccessor](items, cb);
+        } else {
+          cb(null);
+        }
+      });
 
-			return this;
-		},
-		enumerable: false,
-		writable: true
-	});
-	Object.defineProperty(Instance, association.delAccessor, {
-		value: function () {
-			var Associations = [];
-			var cb = noOperation;
+      return this;
+    },
+    enumerable: false,
+    writable: true
+  });
+  Object.defineProperty(Instance, association.delAccessor, {
+    value: function () {
+      var Associations = [];
+      var cb = noOperation;
 
-			for (var i = 0; i < arguments.length; i++) {
-				switch (typeof arguments[i]) {
-					case "function":
-						cb = arguments[i];
-						break;
-					case "object":
-						if (Array.isArray(arguments[i])) {
-							Associations = Associations.concat(arguments[i]);
-						} else if (arguments[i].isInstance) {
-							Associations.push(arguments[i]);
-						}
-						break;
-				}
-			}
-			var conditions = {};
-			var run = function () {
-				if (Driver.hasMany) {
-					return Driver.hasMany(Model, association).del(Instance, Associations, cb);
-				}
+      for (var i = 0; i < arguments.length; i++) {
+        switch (typeof arguments[i]) {
+          case "function":
+            cb = arguments[i];
+            break;
+          case "object":
+            if (Array.isArray(arguments[i])) {
+              Associations = Associations.concat(arguments[i]);
+            } else if (arguments[i].isInstance) {
+              Associations.push(arguments[i]);
+            }
+            break;
+        }
+      }
+      var conditions = {};
+      var run = function () {
+        if (Driver.hasMany) {
+          return Driver.hasMany(Model, association).del(Instance, Associations, cb);
+        }
 
-				if (Associations.length === 0) {
-					return Driver.remove(association.mergeTable, conditions, cb);
-				}
+        if (Associations.length === 0) {
+          return Driver.remove(association.mergeTable, conditions, cb);
+        }
 
-				for (var i = 0; i < Associations.length; i++) {
-					util.populateConditions(association.model, Object.keys(association.mergeAssocId), Associations[i], conditions, false);
-				}
+        for (var i = 0; i < Associations.length; i++) {
+          util.populateConditions(association.model, Object.keys(association.mergeAssocId), Associations[i], conditions, false);
+        }
 
-				Driver.remove(association.mergeTable, conditions, cb);
-			};
+        Driver.remove(association.mergeTable, conditions, cb);
+      };
 
-			util.populateConditions(Model, Object.keys(association.mergeId), Instance, conditions);
+      util.populateConditions(Model, Object.keys(association.mergeId), Instance, conditions);
 
-			if (this.saved()) {
-				run();
-			} else {
-				this.save(function (err) {
-					if (err) {
-						return cb(err);
-					}
+      if (this.saved()) {
+        run();
+      } else {
+        this.save(function (err) {
+          if (err) {
+            return cb(err);
+          }
 
-					return run();
-				});
-			}
-			return this;
-		},
-		enumerable: false,
-		writable: true
-	});
-	Object.defineProperty(Instance, association.addAccessor, {
-		value: function () {
-			var Associations = [];
-			var opts = {};
-			var cb = noOperation;
+          return run();
+        });
+      }
+      return this;
+    },
+    enumerable: false,
+    writable: true
+  });
+  Object.defineProperty(Instance, association.addAccessor, {
+    value: function () {
+      var Associations = [];
+      var opts = {};
+      var cb = noOperation;
 
-			var run = function () {
-				var savedAssociations = [];
-				var saveNextAssociation = function () {
-					if (Associations.length === 0) {
-						return cb(null, savedAssociations);
-					}
+      var run = function () {
+        var savedAssociations = [];
+        var saveNextAssociation = function () {
+          if (Associations.length === 0) {
+            return cb(null, savedAssociations);
+          }
 
-					var Association = Associations.pop();
-					var saveAssociation = function (err) {
-						if (err) {
-							return cb(err);
-						}
+          var Association = Associations.pop();
+          var saveAssociation = function (err) {
+            if (err) {
+              return cb(err);
+            }
 
-						Association.save(function (err) {
-							if (err) {
-								return cb(err);
-							}
+            Association.save(function (err) {
+              if (err) {
+                return cb(err);
+              }
 
-							var data = {};
+              var data = {};
 
-							for (var k in opts) {
-								if (k in association.props && Driver.propertyToValue) {
-									data[k] = Driver.propertyToValue(opts[k], association.props[k]);
-								} else {
-									data[k] = opts[k];
-								}
-							}
+              for (var k in opts) {
+                if (k in association.props && Driver.propertyToValue) {
+                  data[k] = Driver.propertyToValue(opts[k], association.props[k]);
+                } else {
+                  data[k] = opts[k];
+                }
+              }
 
-							if (Driver.hasMany) {
-								return Driver.hasMany(Model, association).add(Instance, Association, data, function (err) {
-									if (err) {
-										return cb(err);
-									}
+              if (Driver.hasMany) {
+                return Driver.hasMany(Model, association).add(Instance, Association, data, function (err) {
+                  if (err) {
+                    return cb(err);
+                  }
 
-									savedAssociations.push(Association);
+                  savedAssociations.push(Association);
 
-									return saveNextAssociation();
-								});
-							}
+                  return saveNextAssociation();
+                });
+              }
 
-							util.populateConditions(Model, Object.keys(association.mergeId), Instance, data);
-							util.populateConditions(association.model, Object.keys(association.mergeAssocId), Association, data);
+              util.populateConditions(Model, Object.keys(association.mergeId), Instance, data);
+              util.populateConditions(association.model, Object.keys(association.mergeAssocId), Association, data);
 
-							Driver.insert(association.mergeTable, data, null, function (err) {
-								if (err) {
-									return cb(err);
-								}
+              Driver.insert(association.mergeTable, data, null, function (err) {
+                if (err) {
+                  return cb(err);
+                }
 
-								savedAssociations.push(Association);
+                savedAssociations.push(Association);
 
-								return saveNextAssociation();
-							});
-						});
-					};
+                return saveNextAssociation();
+              });
+            });
+          };
 
-					if (Object.keys(association.props).length) {
-						Hook.wait(Association, association.hooks.beforeSave, saveAssociation, opts);
-					} else {
-						Hook.wait(Association, association.hooks.beforeSave, saveAssociation);
-					}
-				};
+          if (Object.keys(association.props).length) {
+            Hook.wait(Association, association.hooks.beforeSave, saveAssociation, opts);
+          } else {
+            Hook.wait(Association, association.hooks.beforeSave, saveAssociation);
+          }
+        };
 
-				return saveNextAssociation();
-			};
+        return saveNextAssociation();
+      };
 
-			for (var i = 0; i < arguments.length; i++) {
-				switch (typeof arguments[i]) {
-					case "function":
-						cb = arguments[i];
-						break;
-					case "object":
-						if (Array.isArray(arguments[i])) {
-							Associations = Associations.concat(arguments[i]);
-						} else if (arguments[i].isInstance) {
-							Associations.push(arguments[i]);
-						} else {
-							opts = arguments[i];
-						}
-						break;
-				}
-			}
+      for (var i = 0; i < arguments.length; i++) {
+        switch (typeof arguments[i]) {
+          case "function":
+            cb = arguments[i];
+            break;
+          case "object":
+            if (Array.isArray(arguments[i])) {
+              Associations = Associations.concat(arguments[i]);
+            } else if (arguments[i].isInstance) {
+              Associations.push(arguments[i]);
+            } else {
+              opts = arguments[i];
+            }
+            break;
+        }
+      }
 
-			if (Associations.length === 0) {
-			    throw new ORMError("No associations defined", 'PARAM_MISMATCH', { model: Model.name });
-			}
+      if (Associations.length === 0) {
+          throw new ORMError("No associations defined", 'PARAM_MISMATCH', { model: Model.name });
+      }
 
-			if (this.saved()) {
-				run();
-			} else {
-				this.save(function (err) {
-					if (err) {
-						return cb(err);
-					}
+      if (this.saved()) {
+        run();
+      } else {
+        this.save(function (err) {
+          if (err) {
+            return cb(err);
+          }
 
-					return run();
-				});
-			}
+          return run();
+        });
+      }
 
-			return this;
-		},
-		enumerable: false,
-		writable: true
-	});
+      return this;
+    },
+    enumerable: false,
+    writable: true
+  });
 
-	Object.defineProperty(Instance, association.name, {
-		get: function () {
-			return Instance.__opts.associations[association.name].value;
-		},
-		set: function (val) {
-			Instance.__opts.associations[association.name].changed = true;
-			Instance.__opts.associations[association.name].value   = val;
-		},
-		enumerable: true
-	});
+  Object.defineProperty(Instance, association.name, {
+    get: function () {
+      return Instance.__opts.associations[association.name].value;
+    },
+    set: function (val) {
+      Instance.__opts.associations[association.name].changed = true;
+      Instance.__opts.associations[association.name].value   = val;
+    },
+    enumerable: true
+  });
 }
 
 function autoFetchInstance(Instance, association, opts, cb) {
-	if (!Instance.saved()) {
-		return cb();
-	}
+  if (!Instance.saved()) {
+    return cb();
+  }
 
-	if (!opts.hasOwnProperty("autoFetchLimit") || typeof opts.autoFetchLimit == "undefined") {
-		opts.autoFetchLimit = association.autoFetchLimit;
-	}
+  if (!opts.hasOwnProperty("autoFetchLimit") || typeof opts.autoFetchLimit == "undefined") {
+    opts.autoFetchLimit = association.autoFetchLimit;
+  }
 
-	if (opts.autoFetchLimit === 0 || (!opts.autoFetch && !association.autoFetch)) {
-		return cb();
-	}
+  if (opts.autoFetchLimit === 0 || (!opts.autoFetch && !association.autoFetch)) {
+    return cb();
+  }
 
-	Instance[association.getAccessor]({}, { autoFetchLimit: opts.autoFetchLimit - 1 }, function (err, Assoc) {
-		if (!err) {
-			// Set this way to prevent setting 'changed' status
-			Instance.__opts.associations[association.name].value = Assoc;
-		}
+  Instance[association.getAccessor]({}, { autoFetchLimit: opts.autoFetchLimit - 1 }, function (err, Assoc) {
+    if (!err) {
+      // Set this way to prevent setting 'changed' status
+      Instance.__opts.associations[association.name].value = Assoc;
+    }
 
-		return cb();
-	});
+    return cb();
+  });
 }
 
 function ucfirst(text) {
-	return text[0].toUpperCase() + text.substr(1).replace(/_([a-z])/, function (m, l) {
-		return l.toUpperCase();
-	});
+  return text[0].toUpperCase() + text.substr(1).replace(/_([a-z])/, function (m, l) {
+    return l.toUpperCase();
+  });
 }
 
 function noOperation() {

--- a/lib/Associations/One.js
+++ b/lib/Associations/One.js
@@ -4,314 +4,314 @@ var ORMError   = require("../Error");
 var Accessors  = { "get": "get", "set": "set", "has": "has", "del": "remove" };
 
 exports.prepare = function (Model, associations) {
-	Model.hasOne = function () {
-		var assocName;
-		var assocTemplateName;
-		var association = {
-			name           : Model.table,
-			model          : Model,
-			reversed       : false,
-			extension      : false,
-			autoFetch      : false,
-			autoFetchLimit : 2,
-			required       : false
-		};
+  Model.hasOne = function () {
+    var assocName;
+    var assocTemplateName;
+    var association = {
+      name           : Model.table,
+      model          : Model,
+      reversed       : false,
+      extension      : false,
+      autoFetch      : false,
+      autoFetchLimit : 2,
+      required       : false
+    };
 
-		for (var i = 0; i < arguments.length; i++) {
-			switch (typeof arguments[i]) {
-				case "string":
-					association.name = arguments[i];
-					break;
-				case "function":
-					if (arguments[i].table) {
-						association.model = arguments[i];
-					}
-					break;
-				case "object":
-					association = _.extend(association, arguments[i]);
-					break;
-			}
-		}
+    for (var i = 0; i < arguments.length; i++) {
+      switch (typeof arguments[i]) {
+        case "string":
+          association.name = arguments[i];
+          break;
+        case "function":
+          if (arguments[i].table) {
+            association.model = arguments[i];
+          }
+          break;
+        case "object":
+          association = _.extend(association, arguments[i]);
+          break;
+      }
+    }
 
-		assocName = ucfirst(association.name);
-		assocTemplateName = association.accessor || assocName;
+    assocName = ucfirst(association.name);
+    assocTemplateName = association.accessor || assocName;
 
-		if (!association.hasOwnProperty("field")) {
-			association.field = util.formatField(association.model, association.name, association.required, association.reversed);
-		} else if(!association.extension) {
-			association.field = util.wrapFieldObject({
-				field: association.field, model: Model, altName: Model.table,
-				mapsTo: association.mapsTo
-			});
-		}
+    if (!association.hasOwnProperty("field")) {
+      association.field = util.formatField(association.model, association.name, association.required, association.reversed);
+    } else if(!association.extension) {
+      association.field = util.wrapFieldObject({
+        field: association.field, model: Model, altName: Model.table,
+        mapsTo: association.mapsTo
+      });
+    }
 
-		util.convertPropToJoinKeyProp(association.field, {
-			makeKey: false, required: association.required
-		});
+    util.convertPropToJoinKeyProp(association.field, {
+      makeKey: false, required: association.required
+    });
 
-		for (var k in Accessors) {
-			if (!association.hasOwnProperty(k + "Accessor")) {
-				association[k + "Accessor"] = Accessors[k] + assocTemplateName;
-			}
-		}
+    for (var k in Accessors) {
+      if (!association.hasOwnProperty(k + "Accessor")) {
+        association[k + "Accessor"] = Accessors[k] + assocTemplateName;
+      }
+    }
 
-		associations.push(association);
-		for (k in association.field) {
-			if (!association.field.hasOwnProperty(k)) {
-				continue;
-			}
-			if (!association.reversed) {
-				Model.addProperty(
-					_.extend({}, association.field[k], { klass: 'hasOne' }),
-					false
-				);
-			}
-		}
+    associations.push(association);
+    for (k in association.field) {
+      if (!association.field.hasOwnProperty(k)) {
+        continue;
+      }
+      if (!association.reversed) {
+        Model.addProperty(
+          _.extend({}, association.field[k], { klass: 'hasOne' }),
+          false
+        );
+      }
+    }
 
-		if (association.reverse) {
-			association.model.hasOne(association.reverse, Model, {
-				reversed       : true,
-				accessor       : association.reverseAccessor,
-				reverseAccessor: undefined,
-				field          : association.field,
-				autoFetch      : association.autoFetch,
-				autoFetchLimit : association.autoFetchLimit
-			});
-		}
+    if (association.reverse) {
+      association.model.hasOne(association.reverse, Model, {
+        reversed       : true,
+        accessor       : association.reverseAccessor,
+        reverseAccessor: undefined,
+        field          : association.field,
+        autoFetch      : association.autoFetch,
+        autoFetchLimit : association.autoFetchLimit
+      });
+    }
 
-		Model["findBy" + assocTemplateName] = function () {
-			var cb = null, conditions = null, options = {};
+    Model["findBy" + assocTemplateName] = function () {
+      var cb = null, conditions = null, options = {};
 
-			for (var i = 0; i < arguments.length; i++) {
-				switch (typeof arguments[i]) {
-					case "function":
-						cb = arguments[i];
-						break;
-					case "object":
-						if (conditions === null) {
-							conditions = arguments[i];
-						} else {
-							options = arguments[i];
-						}
-						break;
-				}
-			}
+      for (var i = 0; i < arguments.length; i++) {
+        switch (typeof arguments[i]) {
+          case "function":
+            cb = arguments[i];
+            break;
+          case "object":
+            if (conditions === null) {
+              conditions = arguments[i];
+            } else {
+              options = arguments[i];
+            }
+            break;
+        }
+      }
 
-			if (conditions === null) {
-				throw new ORMError(".findBy(" + assocName + ") is missing a conditions object", 'PARAM_MISMATCH');
-			}
+      if (conditions === null) {
+        throw new ORMError(".findBy(" + assocName + ") is missing a conditions object", 'PARAM_MISMATCH');
+      }
 
-			options.__merge = {
-				from  : { table: association.model.table, field: (association.reversed ? Object.keys(association.field) : association.model.id) },
-				to    : { table: Model.table, field: (association.reversed ? association.model.id : Object.keys(association.field) ) },
-				where : [ association.model.table, conditions ],
-				table : Model.table
-			};
-			options.extra = [];
+      options.__merge = {
+        from  : { table: association.model.table, field: (association.reversed ? Object.keys(association.field) : association.model.id) },
+        to    : { table: Model.table, field: (association.reversed ? association.model.id : Object.keys(association.field) ) },
+        where : [ association.model.table, conditions ],
+        table : Model.table
+      };
+      options.extra = [];
 
-			if (typeof cb === "function") {
-				return Model.find({}, options, cb);
-			}
-			return Model.find({}, options);
-		};
+      if (typeof cb === "function") {
+        return Model.find({}, options, cb);
+      }
+      return Model.find({}, options);
+    };
 
-		return this;
-	};
+    return this;
+  };
 };
 
 exports.extend = function (Model, Instance, Driver, associations) {
-	for (var i = 0; i < associations.length; i++) {
-		extendInstance(Model, Instance, Driver, associations[i]);
-	}
+  for (var i = 0; i < associations.length; i++) {
+    extendInstance(Model, Instance, Driver, associations[i]);
+  }
 };
 
 exports.autoFetch = function (Instance, associations, opts, cb) {
-	if (associations.length === 0) {
-		return cb();
-	}
+  if (associations.length === 0) {
+    return cb();
+  }
 
-	var pending = associations.length;
-	var autoFetchDone = function autoFetchDone() {
-		pending -= 1;
+  var pending = associations.length;
+  var autoFetchDone = function autoFetchDone() {
+    pending -= 1;
 
-		if (pending === 0) {
-			return cb();
-		}
-	};
+    if (pending === 0) {
+      return cb();
+    }
+  };
 
-	for (var i = 0; i < associations.length; i++) {
-		autoFetchInstance(Instance, associations[i], opts, autoFetchDone);
-	}
+  for (var i = 0; i < associations.length; i++) {
+    autoFetchInstance(Instance, associations[i], opts, autoFetchDone);
+  }
 };
 
 function extendInstance(Model, Instance, Driver, association) {
-	Object.defineProperty(Instance, association.hasAccessor, {
-		value: function (opts, cb) {
-			if (typeof opts === "function") {
-				cb = opts;
-				opts = {};
-			}
+  Object.defineProperty(Instance, association.hasAccessor, {
+    value: function (opts, cb) {
+      if (typeof opts === "function") {
+        cb = opts;
+        opts = {};
+      }
 
-			if (util.hasValues(Instance, Object.keys(association.field))) {
-				association.model.get(util.values(Instance, Object.keys(association.field)), opts, function (err, instance) {
-					return cb(err, instance ? true : false);
-				});
-			} else {
-				cb(null, false);
-			}
+      if (util.hasValues(Instance, Object.keys(association.field))) {
+        association.model.get(util.values(Instance, Object.keys(association.field)), opts, function (err, instance) {
+          return cb(err, instance ? true : false);
+        });
+      } else {
+        cb(null, false);
+      }
 
-			return this;
-		},
-		enumerable: false,
-		writable: true
-	});
-	Object.defineProperty(Instance, association.getAccessor, {
-		value: function (opts, cb) {
-			if (typeof opts === "function") {
-				cb = opts;
-				opts = {};
-			}
+      return this;
+    },
+    enumerable: false,
+    writable: true
+  });
+  Object.defineProperty(Instance, association.getAccessor, {
+    value: function (opts, cb) {
+      if (typeof opts === "function") {
+        cb = opts;
+        opts = {};
+      }
 
-			var saveAndReturn = function (err, Assoc) {
-				if (!err) {
-					Instance[association.name] = Assoc;
-				}
+      var saveAndReturn = function (err, Assoc) {
+        if (!err) {
+          Instance[association.name] = Assoc;
+        }
 
-				return cb(err, Assoc);
-			};
+        return cb(err, Assoc);
+      };
 
-			if (association.reversed) {
-				if (util.hasValues(Instance, Model.id)) {
-					if (typeof cb !== "function") {
-						return association.model.find(util.getConditions(Model, Object.keys(association.field), Instance), opts);
-					}
-					association.model.find(util.getConditions(Model, Object.keys(association.field), Instance), opts, saveAndReturn);
-				} else {
-					cb(null);
-				}
-			} else {
-				if (Instance.isShell()) {
-					Model.get(util.values(Instance, Model.id), function (err, instance) {
-						if (err || !util.hasValues(instance, Object.keys(association.field))) {
-							return cb(null);
-						}
-						association.model.get(util.values(instance, Object.keys(association.field)), opts, saveAndReturn);
-					});
-				} else if (util.hasValues(Instance, Object.keys(association.field))) {
-					association.model.get(util.values(Instance, Object.keys(association.field)), opts, saveAndReturn);
-				} else {
-					cb(null);
-				}
-			}
+      if (association.reversed) {
+        if (util.hasValues(Instance, Model.id)) {
+          if (typeof cb !== "function") {
+            return association.model.find(util.getConditions(Model, Object.keys(association.field), Instance), opts);
+          }
+          association.model.find(util.getConditions(Model, Object.keys(association.field), Instance), opts, saveAndReturn);
+        } else {
+          cb(null);
+        }
+      } else {
+        if (Instance.isShell()) {
+          Model.get(util.values(Instance, Model.id), function (err, instance) {
+            if (err || !util.hasValues(instance, Object.keys(association.field))) {
+              return cb(null);
+            }
+            association.model.get(util.values(instance, Object.keys(association.field)), opts, saveAndReturn);
+          });
+        } else if (util.hasValues(Instance, Object.keys(association.field))) {
+          association.model.get(util.values(Instance, Object.keys(association.field)), opts, saveAndReturn);
+        } else {
+          cb(null);
+        }
+      }
 
-			return this;
-		},
-		enumerable: false,
-		writable: true
-	});
-	Object.defineProperty(Instance, association.setAccessor, {
-		value: function (OtherInstance, cb) {
-			if (association.reversed) {
-				Instance.save(function (err) {
-					if (err) {
-						return cb(err);
-					}
+      return this;
+    },
+    enumerable: false,
+    writable: true
+  });
+  Object.defineProperty(Instance, association.setAccessor, {
+    value: function (OtherInstance, cb) {
+      if (association.reversed) {
+        Instance.save(function (err) {
+          if (err) {
+            return cb(err);
+          }
 
-					if (!Array.isArray(OtherInstance)) {
-						util.populateConditions(Model, Object.keys(association.field), Instance, OtherInstance, true);
+          if (!Array.isArray(OtherInstance)) {
+            util.populateConditions(Model, Object.keys(association.field), Instance, OtherInstance, true);
 
-						return OtherInstance.save({}, { saveAssociations: false }, cb);
-					}
+            return OtherInstance.save({}, { saveAssociations: false }, cb);
+          }
 
-					var associations = _.clone(OtherInstance);
+          var associations = _.clone(OtherInstance);
 
-					var saveNext = function () {
-						if (!associations.length) {
-							return cb();
-						}
+          var saveNext = function () {
+            if (!associations.length) {
+              return cb();
+            }
 
-						var other = associations.pop();
+            var other = associations.pop();
 
-						util.populateConditions(Model, Object.keys(association.field), Instance, other, true);
+            util.populateConditions(Model, Object.keys(association.field), Instance, other, true);
 
-						other.save({}, { saveAssociations: false }, function (err) {
-							if (err) {
-								return cb(err);
-							}
+            other.save({}, { saveAssociations: false }, function (err) {
+              if (err) {
+                return cb(err);
+              }
 
-							saveNext();
-						});
-					};
+              saveNext();
+            });
+          };
 
-					return saveNext();
-				});
-			} else {
-				OtherInstance.save({}, { saveAssociations: false }, function (err) {
-					if (err) {
-						return cb(err);
-					}
+          return saveNext();
+        });
+      } else {
+        OtherInstance.save({}, { saveAssociations: false }, function (err) {
+          if (err) {
+            return cb(err);
+          }
 
-					Instance[association.name] = OtherInstance;
+          Instance[association.name] = OtherInstance;
 
-					util.populateConditions(association.model, Object.keys(association.field), OtherInstance, Instance);
+          util.populateConditions(association.model, Object.keys(association.field), OtherInstance, Instance);
 
-					return Instance.save({}, { saveAssociations: false }, cb);
-				});
-			}
+          return Instance.save({}, { saveAssociations: false }, cb);
+        });
+      }
 
-			return this;
-		},
-		enumerable: false,
-		writable: true
-	});
-	if (!association.reversed) {
-		Object.defineProperty(Instance, association.delAccessor, {
-			value: function (cb) {
-				for (var k in association.field) {
-					if (association.field.hasOwnProperty(k)) {
-						Instance[k] = null;
-					}
-				}
-				Instance.save({}, { saveAssociations: false }, function (err) {
-					if (!err) {
-						delete Instance[association.name];
-					}
+      return this;
+    },
+    enumerable: false,
+    writable: true
+  });
+  if (!association.reversed) {
+    Object.defineProperty(Instance, association.delAccessor, {
+      value: function (cb) {
+        for (var k in association.field) {
+          if (association.field.hasOwnProperty(k)) {
+            Instance[k] = null;
+          }
+        }
+        Instance.save({}, { saveAssociations: false }, function (err) {
+          if (!err) {
+            delete Instance[association.name];
+          }
 
-					return cb();
-				});
+          return cb();
+        });
 
-				return this;
-			},
-			enumerable: false,
-			writable: true
-		});
-	}
+        return this;
+      },
+      enumerable: false,
+      writable: true
+    });
+  }
 }
 
 function autoFetchInstance(Instance, association, opts, cb) {
-	if (!Instance.saved()) {
-		return cb();
-	}
+  if (!Instance.saved()) {
+    return cb();
+  }
 
-	if (!opts.hasOwnProperty("autoFetchLimit") || typeof opts.autoFetchLimit === "undefined") {
-		opts.autoFetchLimit = association.autoFetchLimit;
-	}
+  if (!opts.hasOwnProperty("autoFetchLimit") || typeof opts.autoFetchLimit === "undefined") {
+    opts.autoFetchLimit = association.autoFetchLimit;
+  }
 
-	if (opts.autoFetchLimit === 0 || (!opts.autoFetch && !association.autoFetch)) {
-		return cb();
-	}
+  if (opts.autoFetchLimit === 0 || (!opts.autoFetch && !association.autoFetch)) {
+    return cb();
+  }
 
-	// When we have a new non persisted instance for which the association field (eg owner_id)
-	// is set, we don't want to auto fetch anything, since `new Model(owner_id: 12)` takes no
-	// callback, and hence this lookup would complete at an arbitrary point in the future.
-	// The associated entity should probably be fetched when the instance is persisted.
-	if (Instance.isPersisted()) {
-		Instance[association.getAccessor]({ autoFetchLimit: opts.autoFetchLimit - 1 }, cb);
-	} else {
-		return cb();
-	}
+  // When we have a new non persisted instance for which the association field (eg owner_id)
+  // is set, we don't want to auto fetch anything, since `new Model(owner_id: 12)` takes no
+  // callback, and hence this lookup would complete at an arbitrary point in the future.
+  // The associated entity should probably be fetched when the instance is persisted.
+  if (Instance.isPersisted()) {
+    Instance[association.getAccessor]({ autoFetchLimit: opts.autoFetchLimit - 1 }, cb);
+  } else {
+    return cb();
+  }
 }
 
 function ucfirst(text) {
-	return text[0].toUpperCase() + text.substr(1);
+  return text[0].toUpperCase() + text.substr(1);
 }

--- a/lib/ChainFind.js
+++ b/lib/ChainFind.js
@@ -7,314 +7,314 @@ var Promise       = require("./Promise").Promise;
 module.exports = ChainFind;
 
 function ChainFind(Model, opts) {
-	var prepareConditions = function () {
-		return Utilities.transformPropertyNames(
-			opts.conditions, opts.properties
-		);
-	};
+  var prepareConditions = function () {
+    return Utilities.transformPropertyNames(
+      opts.conditions, opts.properties
+    );
+  };
 
-	var prepareOrder = function () {
-		return Utilities.transformOrderPropertyNames(
-			opts.order, opts.properties
-		);
-	};
+  var prepareOrder = function () {
+    return Utilities.transformOrderPropertyNames(
+      opts.order, opts.properties
+    );
+  };
 
-	var chainRun = function (done) {
-		var order, conditions;
+  var chainRun = function (done) {
+    var order, conditions;
 
-		conditions = Utilities.transformPropertyNames(
-			opts.conditions, opts.properties
-		);
-		order = Utilities.transformOrderPropertyNames(
-			opts.order, opts.properties
-		);
+    conditions = Utilities.transformPropertyNames(
+      opts.conditions, opts.properties
+    );
+    order = Utilities.transformOrderPropertyNames(
+      opts.order, opts.properties
+    );
 
-		opts.driver.find(opts.only, opts.table, conditions, {
-			limit  : opts.limit,
-			order  : order,
-			merge  : opts.merge,
-			offset : opts.offset,
-			exists : opts.exists
-		}, function (err, dataItems) {
-			if (err) {
-				return done(err);
-			}
-			if (dataItems.length === 0) {
-				return done(null, []);
-			}
-			var pending = dataItems.length;
+    opts.driver.find(opts.only, opts.table, conditions, {
+      limit  : opts.limit,
+      order  : order,
+      merge  : opts.merge,
+      offset : opts.offset,
+      exists : opts.exists
+    }, function (err, dataItems) {
+      if (err) {
+        return done(err);
+      }
+      if (dataItems.length === 0) {
+        return done(null, []);
+      }
+      var pending = dataItems.length;
 
-			var eagerLoad = function (err, items) {
-				var pending = opts.__eager.length;
-				var idMap = {};
+      var eagerLoad = function (err, items) {
+        var pending = opts.__eager.length;
+        var idMap = {};
 
-				var keys = _.map(items, function (item, index) {
-					var key = item[opts.keys[0]];
-					// Create the association arrays
-					for (var i = 0, association; association = opts.__eager[i]; i++) {
-						item[association.name] = [];
-					}
-					idMap[key] = index;
+        var keys = _.map(items, function (item, index) {
+          var key = item[opts.keys[0]];
+          // Create the association arrays
+          for (var i = 0, association; association = opts.__eager[i]; i++) {
+            item[association.name] = [];
+          }
+          idMap[key] = index;
 
-					return key;
-				});
+          return key;
+        });
 
-				async.eachSeries(opts.__eager,
-					function (association, cb) {
-						opts.driver.eagerQuery(association, opts, keys, function (err, instances) {
-							if (err) return cb(err)
+        async.eachSeries(opts.__eager,
+          function (association, cb) {
+            opts.driver.eagerQuery(association, opts, keys, function (err, instances) {
+              if (err) return cb(err)
 
-							for (var i = 0, instance; instance = instances[i]; i++) {
-								// Perform a parent lookup with $p, and initialize it as an instance.
-								items[idMap[instance.$p]][association.name].push(association.model(instance));
-							}
-							cb();
-						});
-					},
-					function (err) {
-						if (err) done(err);
-						else done(null, items);
-					}
-				);
-			};
+              for (var i = 0, instance; instance = instances[i]; i++) {
+                // Perform a parent lookup with $p, and initialize it as an instance.
+                items[idMap[instance.$p]][association.name].push(association.model(instance));
+              }
+              cb();
+            });
+          },
+          function (err) {
+            if (err) done(err);
+            else done(null, items);
+          }
+        );
+      };
 
-			async.map(dataItems, opts.newInstance, function (err, items) {
-				if (err) return done(err);
+      async.map(dataItems, opts.newInstance, function (err, items) {
+        if (err) return done(err);
 
-				var shouldEagerLoad = opts.__eager && opts.__eager.length;
-				var completeFn = shouldEagerLoad ? eagerLoad : done;
+        var shouldEagerLoad = opts.__eager && opts.__eager.length;
+        var completeFn = shouldEagerLoad ? eagerLoad : done;
 
-				return completeFn(null, items);
-			});
-		});
-	}
+        return completeFn(null, items);
+      });
+    });
+  }
 
-	var promise = null;
-	var chain = {
-		find: function () {
-			var cb = null;
+  var promise = null;
+  var chain = {
+    find: function () {
+      var cb = null;
 
-			var args = Array.prototype.slice.call(arguments);
-			opts.conditions = opts.conditions || {};
+      var args = Array.prototype.slice.call(arguments);
+      opts.conditions = opts.conditions || {};
 
-			if (typeof _.last(args) === "function") {
-			    cb = args.pop();
-			}
+      if (typeof _.last(args) === "function") {
+          cb = args.pop();
+      }
 
-			if (typeof args[0] === "object") {
-				_.extend(opts.conditions, args[0]);
-			} else if (typeof args[0] === "string") {
-				opts.conditions.__sql = opts.conditions.__sql || [];
-				opts.conditions.__sql.push(args);
-			}
+      if (typeof args[0] === "object") {
+        _.extend(opts.conditions, args[0]);
+      } else if (typeof args[0] === "string") {
+        opts.conditions.__sql = opts.conditions.__sql || [];
+        opts.conditions.__sql.push(args);
+      }
 
-			if (cb) {
-				chainRun(cb);
-			}
-			return this;
-		},
-		only: function () {
-			if (arguments.length && Array.isArray(arguments[0])) {
-				opts.only = arguments[0];
-			} else {
-				opts.only = Array.prototype.slice.apply(arguments);
-			}
-			return this;
-		},
-		omit: function () {
-			var omit = null;
+      if (cb) {
+        chainRun(cb);
+      }
+      return this;
+    },
+    only: function () {
+      if (arguments.length && Array.isArray(arguments[0])) {
+        opts.only = arguments[0];
+      } else {
+        opts.only = Array.prototype.slice.apply(arguments);
+      }
+      return this;
+    },
+    omit: function () {
+      var omit = null;
 
-			if (arguments.length && Array.isArray(arguments[0])) {
-				omit = arguments[0];
-			} else {
-				omit = Array.prototype.slice.apply(arguments);
-			}
-			this.only(_.difference(Object.keys(opts.properties), omit));
-			return this;
-		},
-		limit: function (limit) {
-			opts.limit = limit;
-			return this;
-		},
-		skip: function (offset) {
-			return this.offset(offset);
-		},
-		offset: function (offset) {
-			opts.offset = offset;
-			return this;
-		},
-		order: function (property, order) {
-			if (!Array.isArray(opts.order)) {
-				opts.order = [];
-			}
-			if (property[0] === "-") {
-				opts.order.push([ property.substr(1), "Z" ]);
-			} else {
-				opts.order.push([ property, (order && order.toUpperCase() === "Z" ? "Z" : "A") ]);
-			}
-			return this;
-		},
-		orderRaw: function (str, args) {
-			if (!Array.isArray(opts.order)) {
-				opts.order = [];
-			}
-			opts.order.push([ str, args || [] ]);
-			return this;
-		},
-		count: function (cb) {
-			opts.driver.count(opts.table, prepareConditions(), {
-				merge  : opts.merge
-			}, function (err, data) {
-				if (err || data.length === 0) {
-					return cb(err);
-				}
-				return cb(null, data[0].c);
-			});
-			return this;
-		},
-		remove: function (cb) {
-			var keys = _.map(opts.keyProperties, 'mapsTo');
+      if (arguments.length && Array.isArray(arguments[0])) {
+        omit = arguments[0];
+      } else {
+        omit = Array.prototype.slice.apply(arguments);
+      }
+      this.only(_.difference(Object.keys(opts.properties), omit));
+      return this;
+    },
+    limit: function (limit) {
+      opts.limit = limit;
+      return this;
+    },
+    skip: function (offset) {
+      return this.offset(offset);
+    },
+    offset: function (offset) {
+      opts.offset = offset;
+      return this;
+    },
+    order: function (property, order) {
+      if (!Array.isArray(opts.order)) {
+        opts.order = [];
+      }
+      if (property[0] === "-") {
+        opts.order.push([ property.substr(1), "Z" ]);
+      } else {
+        opts.order.push([ property, (order && order.toUpperCase() === "Z" ? "Z" : "A") ]);
+      }
+      return this;
+    },
+    orderRaw: function (str, args) {
+      if (!Array.isArray(opts.order)) {
+        opts.order = [];
+      }
+      opts.order.push([ str, args || [] ]);
+      return this;
+    },
+    count: function (cb) {
+      opts.driver.count(opts.table, prepareConditions(), {
+        merge  : opts.merge
+      }, function (err, data) {
+        if (err || data.length === 0) {
+          return cb(err);
+        }
+        return cb(null, data[0].c);
+      });
+      return this;
+    },
+    remove: function (cb) {
+      var keys = _.map(opts.keyProperties, 'mapsTo');
 
-			opts.driver.find(keys, opts.table, prepareConditions(), {
-				limit  : opts.limit,
-				order  : prepareOrder(),
-				merge  : opts.merge,
-				offset : opts.offset,
-				exists : opts.exists
-			}, function (err, data) {
-				if (err) {
-					return cb(err);
-				}
-				if (data.length === 0) {
-					return cb(null);
-				}
+      opts.driver.find(keys, opts.table, prepareConditions(), {
+        limit  : opts.limit,
+        order  : prepareOrder(),
+        merge  : opts.merge,
+        offset : opts.offset,
+        exists : opts.exists
+      }, function (err, data) {
+        if (err) {
+          return cb(err);
+        }
+        if (data.length === 0) {
+          return cb(null);
+        }
 
-				var ids = [], conditions = {};
-				var or;
+        var ids = [], conditions = {};
+        var or;
 
-				conditions.or = [];
+        conditions.or = [];
 
-				for (var i = 0; i < data.length; i++) {
-					or = {};
-					for (var j = 0; j < opts.keys.length; j++) {
-						or[keys[j]] = data[i][keys[j]];
-					}
-					conditions.or.push(or);
-				}
+        for (var i = 0; i < data.length; i++) {
+          or = {};
+          for (var j = 0; j < opts.keys.length; j++) {
+            or[keys[j]] = data[i][keys[j]];
+          }
+          conditions.or.push(or);
+        }
 
-				return opts.driver.remove(opts.table, conditions, cb);
-			});
-			return this;
-		},
-		first: function (cb) {
-			return this.run(function (err, items) {
-				return cb(err, items && items.length > 0 ? items[0] : null);
-			});
-		},
-		last: function (cb) {
-			return this.run(function (err, items) {
-				return cb(err, items && items.length > 0 ? items[items.length - 1] : null);
-			});
-		},
-		each: function (cb) {
-			return new ChainInstance(this, cb);
-		},
-		run: function (cb) {
-			chainRun(cb);
-			return this;
-		},
-		success: function (cb) {
-			if (!promise) {
-				promise = new Promise();
-				promise.handle(this.all);
-			}
-			return promise.success(cb);
-		},
-		fail: function (cb) {
-			if (!promise) {
-				promise = new Promise();
-				promise.handle(this.all);
-			}
-			return promise.fail(cb);
-		},
-		eager: function () {
-			// This will allow params such as ("abc", "def") or (["abc", "def"])
-			var associations = _.flatten(arguments);
+        return opts.driver.remove(opts.table, conditions, cb);
+      });
+      return this;
+    },
+    first: function (cb) {
+      return this.run(function (err, items) {
+        return cb(err, items && items.length > 0 ? items[0] : null);
+      });
+    },
+    last: function (cb) {
+      return this.run(function (err, items) {
+        return cb(err, items && items.length > 0 ? items[items.length - 1] : null);
+      });
+    },
+    each: function (cb) {
+      return new ChainInstance(this, cb);
+    },
+    run: function (cb) {
+      chainRun(cb);
+      return this;
+    },
+    success: function (cb) {
+      if (!promise) {
+        promise = new Promise();
+        promise.handle(this.all);
+      }
+      return promise.success(cb);
+    },
+    fail: function (cb) {
+      if (!promise) {
+        promise = new Promise();
+        promise.handle(this.all);
+      }
+      return promise.fail(cb);
+    },
+    eager: function () {
+      // This will allow params such as ("abc", "def") or (["abc", "def"])
+      var associations = _.flatten(arguments);
 
-			// TODO: Implement eager loading for Mongo and delete this.
-			if (opts.driver.config.protocol == "mongodb:") {
-				throw new Error("MongoDB does not currently support eager loading");
-			}
+      // TODO: Implement eager loading for Mongo and delete this.
+      if (opts.driver.config.protocol == "mongodb:") {
+        throw new Error("MongoDB does not currently support eager loading");
+      }
 
-			opts.__eager = _.filter(opts.associations, function (association) {
-				return ~associations.indexOf(association.name);
-			});
+      opts.__eager = _.filter(opts.associations, function (association) {
+        return ~associations.indexOf(association.name);
+      });
 
-			return this;
-		}
-	};
-	chain.all = chain.where = chain.find;
+      return this;
+    }
+  };
+  chain.all = chain.where = chain.find;
 
-	if (opts.associations) {
-		for (var i = 0; i < opts.associations.length; i++) {
-			addChainMethod(chain, opts.associations[i], opts);
-		}
-	}
-	for (var k in Model) {
-		if ([
-			"hasOne", "hasMany",
-			"drop", "sync", "get", "clear", "create",
-			"exists", "settings", "aggregate"
-		].indexOf(k) >= 0) {
-			continue;
-		}
-		if (typeof Model[k] !== "function" || chain[k]) {
-			continue;
-		}
+  if (opts.associations) {
+    for (var i = 0; i < opts.associations.length; i++) {
+      addChainMethod(chain, opts.associations[i], opts);
+    }
+  }
+  for (var k in Model) {
+    if ([
+      "hasOne", "hasMany",
+      "drop", "sync", "get", "clear", "create",
+      "exists", "settings", "aggregate"
+    ].indexOf(k) >= 0) {
+      continue;
+    }
+    if (typeof Model[k] !== "function" || chain[k]) {
+      continue;
+    }
 
-		chain[k] = Model[k];
-	}
-	chain.model   = Model;
-	chain.options = opts;
+    chain[k] = Model[k];
+  }
+  chain.model   = Model;
+  chain.options = opts;
 
-	return chain;
+  return chain;
 }
 
 function addChainMethod(chain, association, opts) {
-	chain[association.hasAccessor] = function (value) {
-		if (!opts.exists) {
-			opts.exists = [];
-		}
-		var conditions = {};
+  chain[association.hasAccessor] = function (value) {
+    if (!opts.exists) {
+      opts.exists = [];
+    }
+    var conditions = {};
 
-		var assocIds = Object.keys(association.mergeAssocId);
-		var ids = association.model.id;
-		function mergeConditions(source) {
-			for (var i = 0; i < assocIds.length; i++) {
-				if (typeof conditions[assocIds[i]] === "undefined") {
-					conditions[assocIds[i]] = source[ids[i]];
-				} else if (Array.isArray(conditions[assocIds[i]])) {
-					conditions[assocIds[i]].push(source[ids[i]]);
-				} else {
-					conditions[assocIds[i]] = [ conditions[assocIds[i]], source[ids[i]] ];
-				}
-			}
-		}
+    var assocIds = Object.keys(association.mergeAssocId);
+    var ids = association.model.id;
+    function mergeConditions(source) {
+      for (var i = 0; i < assocIds.length; i++) {
+        if (typeof conditions[assocIds[i]] === "undefined") {
+          conditions[assocIds[i]] = source[ids[i]];
+        } else if (Array.isArray(conditions[assocIds[i]])) {
+          conditions[assocIds[i]].push(source[ids[i]]);
+        } else {
+          conditions[assocIds[i]] = [ conditions[assocIds[i]], source[ids[i]] ];
+        }
+      }
+    }
 
-		if (Array.isArray(value)) {
-			for (var i = 0; i < value.length; i++) {
-				mergeConditions(value[i]);
-			}
-		} else {
-			mergeConditions(value);
-		}
+    if (Array.isArray(value)) {
+      for (var i = 0; i < value.length; i++) {
+        mergeConditions(value[i]);
+      }
+    } else {
+      mergeConditions(value);
+    }
 
-		opts.exists.push({
-			table      : association.mergeTable,
-			link       : [ Object.keys(association.mergeId), association.model.id ],
-			conditions : conditions
-		});
+    opts.exists.push({
+      table      : association.mergeTable,
+      link       : [ Object.keys(association.mergeId), association.model.id ],
+      conditions : conditions
+    });
 
-		return chain;
-	};
+    return chain;
+  };
 }

--- a/lib/ChainInstance.js
+++ b/lib/ChainInstance.js
@@ -1,89 +1,89 @@
 module.exports = ChainInstance;
 
 function ChainInstance(chain, cb) {
-	var instances = null;
-	var loading   = false;
-	var queue     = [];
+  var instances = null;
+  var loading   = false;
+  var queue     = [];
 
-	var load = function () {
-		loading = true;
-		chain.run(function (err, items) {
-			instances = items;
+  var load = function () {
+    loading = true;
+    chain.run(function (err, items) {
+      instances = items;
 
-			return next();
-		});
-	};
-	var promise = function(hwd, next) {
-		return function () {
-			if (!loading) {
-				load();
-			}
+      return next();
+    });
+  };
+  var promise = function(hwd, next) {
+    return function () {
+      if (!loading) {
+        load();
+      }
 
-			queue.push({ hwd: hwd, args: arguments });
+      queue.push({ hwd: hwd, args: arguments });
 
-			return calls;
-		};
-	};
-	var next = function () {
-		if (queue.length === 0) return;
+      return calls;
+    };
+  };
+  var next = function () {
+    if (queue.length === 0) return;
 
-		var item = queue.shift();
+    var item = queue.shift();
 
-		item.hwd.apply(calls, item.args);
-	};
-	var calls = {
-		filter: promise(function (cb) {
-			instances = instances.filter(cb);
+    item.hwd.apply(calls, item.args);
+  };
+  var calls = {
+    filter: promise(function (cb) {
+      instances = instances.filter(cb);
 
-			return next();
-		}),
-		forEach: promise(function (cb) {
-			instances.forEach(cb);
+      return next();
+    }),
+    forEach: promise(function (cb) {
+      instances.forEach(cb);
 
-			return next();
-		}),
-		sort: promise(function (cb) {
-			instances.sort(cb);
+      return next();
+    }),
+    sort: promise(function (cb) {
+      instances.sort(cb);
 
-			return next();
-		}),
-		count: promise(function (cb) {
-			cb(instances.length);
+      return next();
+    }),
+    count: promise(function (cb) {
+      cb(instances.length);
 
-			return next();
-		}),
-		get: promise(function (cb) {
-			cb(instances);
+      return next();
+    }),
+    get: promise(function (cb) {
+      cb(instances);
 
-			return next();
-		}),
-		save: promise(function (cb) {
-			var saveNext = function (i) {
-				if (i >= instances.length) {
-					if (typeof cb === "function") {
-						cb();
-					}
-					return next();
-				}
+      return next();
+    }),
+    save: promise(function (cb) {
+      var saveNext = function (i) {
+        if (i >= instances.length) {
+          if (typeof cb === "function") {
+            cb();
+          }
+          return next();
+        }
 
-				return instances[i].save(function (err) {
-					if (err) {
-						if (typeof cb === "function") {
-							cb(err);
-						}
-						return next();
-					}
+        return instances[i].save(function (err) {
+          if (err) {
+            if (typeof cb === "function") {
+              cb(err);
+            }
+            return next();
+          }
 
-					return saveNext(i + 1);
-				});
-			};
+          return saveNext(i + 1);
+        });
+      };
 
-			return saveNext(0);
-		})
-	};
+      return saveNext(0);
+    })
+  };
 
-	if (typeof cb === "function") {
-		return calls.forEach(cb);
-	}
-	return calls;
+  if (typeof cb === "function") {
+    return calls.forEach(cb);
+  }
+  return calls;
 }

--- a/lib/Debug.js
+++ b/lib/Debug.js
@@ -2,14 +2,14 @@ var util = require("util");
 var tty  = require("tty");
 
 exports.sql = function (driver, sql) {
-	var fmt;
+  var fmt;
 
-	if (tty.isatty(process.stdout)) {
-		fmt = "\033[32;1m(orm/%s) \033[34m%s\033[0m\n";
-		sql = sql.replace(/`(.+?)`/g, function (m) { return "\033[31m" + m + "\033[34m"; });
-	} else {
-		fmt = "[SQL/%s] %s\n";
-	}
+  if (tty.isatty(process.stdout)) {
+    fmt = "\033[32;1m(orm/%s) \033[34m%s\033[0m\n";
+    sql = sql.replace(/`(.+?)`/g, function (m) { return "\033[31m" + m + "\033[34m"; });
+  } else {
+    fmt = "[SQL/%s] %s\n";
+  }
 
-	process.stdout.write(util.format(fmt, driver, sql));
+  process.stdout.write(util.format(fmt, driver, sql));
 };

--- a/lib/Drivers/DDL/SQL.js
+++ b/lib/Drivers/DDL/SQL.js
@@ -2,59 +2,59 @@ var _    = require("lodash");
 var Sync = require("sql-ddl-sync").Sync;
 
 exports.sync = function (opts, cb) {
-	var sync = new Sync({
-		driver  : this,
-		debug   : false//function (text) { console.log(text); }
-	});
+  var sync = new Sync({
+    driver  : this,
+    debug   : false//function (text) { console.log(text); }
+  });
 
-	var setIndex = function (p, v, k) {
-		v.index = true;
-		p[k] = v;
-	};
-	var props = {};
+  var setIndex = function (p, v, k) {
+    v.index = true;
+    p[k] = v;
+  };
+  var props = {};
 
-	if (this.customTypes) {
-		for (var k in this.customTypes) {
-			sync.defineType(k, this.customTypes[k]);
-		}
-	}
+  if (this.customTypes) {
+    for (var k in this.customTypes) {
+      sync.defineType(k, this.customTypes[k]);
+    }
+  }
 
-	sync.defineCollection(opts.table, opts.allProperties);
+  sync.defineCollection(opts.table, opts.allProperties);
 
-	for (var i = 0; i < opts.many_associations.length; i++) {
-		props = {};
+  for (var i = 0; i < opts.many_associations.length; i++) {
+    props = {};
 
-		_.merge(props, opts.many_associations[i].mergeId);
-		_.merge(props, opts.many_associations[i].mergeAssocId);
-		props = _.transform(props, setIndex);
-		_.merge(props, opts.many_associations[i].props);
+    _.merge(props, opts.many_associations[i].mergeId);
+    _.merge(props, opts.many_associations[i].mergeAssocId);
+    props = _.transform(props, setIndex);
+    _.merge(props, opts.many_associations[i].props);
 
-		sync.defineCollection(opts.many_associations[i].mergeTable, props);
-	}
+    sync.defineCollection(opts.many_associations[i].mergeTable, props);
+  }
 
-	sync.sync(cb);
+  sync.sync(cb);
 
-	return this;
+  return this;
 };
 
 exports.drop = function (opts, cb) {
-	var i, queries = [], pending;
+  var i, queries = [], pending;
 
-	queries.push("DROP TABLE IF EXISTS " + this.query.escapeId(opts.table));
+  queries.push("DROP TABLE IF EXISTS " + this.query.escapeId(opts.table));
 
-	for (i = 0; i < opts.many_associations.length; i++) {
-		queries.push("DROP TABLE IF EXISTS " + this.query.escapeId(opts.many_associations[i].mergeTable));
-	}
+  for (i = 0; i < opts.many_associations.length; i++) {
+    queries.push("DROP TABLE IF EXISTS " + this.query.escapeId(opts.many_associations[i].mergeTable));
+  }
 
-	pending = queries.length;
+  pending = queries.length;
 
-	for (i = 0; i < queries.length; i++) {
-		this.execQuery(queries[i], function (err) {
-			if (--pending === 0) {
-				return cb(err);
-			}
-		});
-	}
+  for (i = 0; i < queries.length; i++) {
+    this.execQuery(queries[i], function (err) {
+      if (--pending === 0) {
+        return cb(err);
+      }
+    });
+  }
 
-	return this;
+  return this;
 };

--- a/lib/Drivers/DML/_shared.js
+++ b/lib/Drivers/DML/_shared.js
@@ -1,30 +1,30 @@
 
 module.exports = {
-	execQuery: function () {
-		if (arguments.length == 2) {
-			var query = arguments[0];
-			var cb    = arguments[1];
-		} else if (arguments.length == 3) {
-			var query = this.query.escape(arguments[0], arguments[1]);
-			var cb    = arguments[2];
-		}
-		return this.execSimpleQuery(query, cb);
-	},
-	eagerQuery: function (association, opts, keys, cb) {
-		var desiredKey = Object.keys(association.field);
-		var assocKey = Object.keys(association.mergeAssocId);
+  execQuery: function () {
+    if (arguments.length == 2) {
+      var query = arguments[0];
+      var cb    = arguments[1];
+    } else if (arguments.length == 3) {
+      var query = this.query.escape(arguments[0], arguments[1]);
+      var cb    = arguments[2];
+    }
+    return this.execSimpleQuery(query, cb);
+  },
+  eagerQuery: function (association, opts, keys, cb) {
+    var desiredKey = Object.keys(association.field);
+    var assocKey = Object.keys(association.mergeAssocId);
 
-		var where = {};
-		where[desiredKey] = keys;
+    var where = {};
+    where[desiredKey] = keys;
 
-		var query = this.query.select()
-			.from(association.model.table)
-			.select(opts.only)
-			.from(association.mergeTable, assocKey, opts.keys)
-			.select(desiredKey).as("$p")
-			.where(association.mergeTable, where)
-			.build();
+    var query = this.query.select()
+      .from(association.model.table)
+      .select(opts.only)
+      .from(association.mergeTable, assocKey, opts.keys)
+      .select(desiredKey).as("$p")
+      .where(association.mergeTable, where)
+      .build();
 
-		this.execSimpleQuery(query, cb);
-	}
+    this.execSimpleQuery(query, cb);
+  }
 };

--- a/lib/Drivers/DML/mongodb.js
+++ b/lib/Drivers/DML/mongodb.js
@@ -6,438 +6,438 @@ var _         = require('lodash');
 exports.Driver = Driver;
 
 function Driver(config, connection, opts) {
-	this.client = new mongodb.MongoClient();
-	this.db     = null;
-	this.config = config || {};
-	this.opts   = opts;
+  this.client = new mongodb.MongoClient();
+  this.db     = null;
+  this.config = config || {};
+  this.opts   = opts;
 
-	if (!this.config.timezone) {
-		this.config.timezone = "local";
-	}
+  if (!this.config.timezone) {
+    this.config.timezone = "local";
+  }
 
-	this.opts.settings.set("properties.primary_key", "_id");
-	this.opts.settings.set("properties.association_key", function (name, field) {
-		return name + "_" + field.replace(/^_+/, '');
-	});
+  this.opts.settings.set("properties.primary_key", "_id");
+  this.opts.settings.set("properties.association_key", function (name, field) {
+    return name + "_" + field.replace(/^_+/, '');
+  });
 }
 
 Driver.prototype.sync = function (opts, cb) {
-	this.db.createCollection(opts.table, function (err, collection) {
-		if (err) {
-			return cb(err);
-		}
+  this.db.createCollection(opts.table, function (err, collection) {
+    if (err) {
+      return cb(err);
+    }
 
-		var indexes = [], pending;
+    var indexes = [], pending;
 
-		for (var i = 0; i < opts.one_associations.length; i++) {
-			if (opts.one_associations[i].extension) continue;
-			if (opts.one_associations[i].reversed) continue;
+    for (var i = 0; i < opts.one_associations.length; i++) {
+      if (opts.one_associations[i].extension) continue;
+      if (opts.one_associations[i].reversed) continue;
 
-			for (var k in opts.one_associations[i].field) {
-				indexes.push(k);
-			}
-		}
+      for (var k in opts.one_associations[i].field) {
+        indexes.push(k);
+      }
+    }
 
-		for (i = 0; i < opts.many_associations.length; i++) {
-			if (opts.many_associations[i].reversed) continue;
+    for (i = 0; i < opts.many_associations.length; i++) {
+      if (opts.many_associations[i].reversed) continue;
 
-			indexes.push(opts.many_associations[i].name);
-		}
+      indexes.push(opts.many_associations[i].name);
+    }
 
-		pending = indexes.length;
+    pending = indexes.length;
 
-		for (i = 0; i < indexes.length; i++) {
-			collection.createIndex(indexes[i], function () {
-				if (--pending === 0) {
-					return cb();
-				}
-			});
-		}
+    for (i = 0; i < indexes.length; i++) {
+      collection.createIndex(indexes[i], function () {
+        if (--pending === 0) {
+          return cb();
+        }
+      });
+    }
 
-		if (pending === 0) {
-			return cb();
-		}
-	});
+    if (pending === 0) {
+      return cb();
+    }
+  });
 };
 
 Driver.prototype.drop = function (opts, cb) {
-	return this.db.collection(opts.table).drop(function () {
-		if (typeof cb == "function") {
-			return cb();
-		}
-	});
+  return this.db.collection(opts.table).drop(function () {
+    if (typeof cb == "function") {
+      return cb();
+    }
+  });
 };
 
 Driver.prototype.ping = function (cb) {
-	return process.nextTick(cb);
+  return process.nextTick(cb);
 };
 
 Driver.prototype.on = function (ev, cb) {
-	// if (ev == "error") {
-	// 	this.db.on("error", cb);
-	// 	this.db.on("unhandledError", cb);
-	// }
-	return this;
+  // if (ev == "error") {
+  //   this.db.on("error", cb);
+  //   this.db.on("unhandledError", cb);
+  // }
+  return this;
 };
 
 Driver.prototype.connect = function (cb) {
-	this.client.connect(this.config.href, function (err, db) {
-		if (err) {
-			return cb(err);
-		}
+  this.client.connect(this.config.href, function (err, db) {
+    if (err) {
+      return cb(err);
+    }
 
-		this.db = db;
+    this.db = db;
 
-		return cb();
-	}.bind(this));
+    return cb();
+  }.bind(this));
 };
 
 Driver.prototype.close = function (cb) {
-	if (this.db) {
-		this.db.close();
-	}
-	if (typeof cb == "function") {
-		cb();
-	}
-	return;
+  if (this.db) {
+    this.db.close();
+  }
+  if (typeof cb == "function") {
+    cb();
+  }
+  return;
 };
 
 Driver.prototype.find = function (fields, table, conditions, opts, cb) {
-	var collection = this.db.collection(table);
+  var collection = this.db.collection(table);
 
-	convertToDB(conditions, this.config.timezone);
+  convertToDB(conditions, this.config.timezone);
 
-	var cursor = (fields ? collection.find(conditions, fields) : collection.find(conditions));
+  var cursor = (fields ? collection.find(conditions, fields) : collection.find(conditions));
 
-	if (opts.order) {
-		var orders = [];
+  if (opts.order) {
+    var orders = [];
 
-		for (var i = 0; i < opts.order.length; i++) {
-			orders.push([ opts.order[i][0], (opts.order[i][1] == 'Z' ? 'desc' : 'asc') ]);
-		}
-		cursor.sort(orders);
-	}
-	if (opts.offset) {
-		cursor.skip(opts.offset);
-	}
-	if (opts.limit) {
-		cursor.limit(opts.limit);
-	}
+    for (var i = 0; i < opts.order.length; i++) {
+      orders.push([ opts.order[i][0], (opts.order[i][1] == 'Z' ? 'desc' : 'asc') ]);
+    }
+    cursor.sort(orders);
+  }
+  if (opts.offset) {
+    cursor.skip(opts.offset);
+  }
+  if (opts.limit) {
+    cursor.limit(opts.limit);
+  }
 
-	return cursor.toArray(function (err, docs) {
-		if (err) {
-			throw err;
-			return cb(err);
-		}
+  return cursor.toArray(function (err, docs) {
+    if (err) {
+      throw err;
+      return cb(err);
+    }
 
-		var pending = 0;
+    var pending = 0;
 
-		for (var i = 0; i < docs.length; i++) {
-			convertFromDB(docs[i], this.config.timezone);
-			if (opts.extra && opts.extra[docs[i]._id]) {
-				docs[i] = _.merge(docs[i], _.omit(opts.extra[docs[i]._id], '_id'));
-			}
-			if (opts.createInstance) {
-				pending += 1;
+    for (var i = 0; i < docs.length; i++) {
+      convertFromDB(docs[i], this.config.timezone);
+      if (opts.extra && opts.extra[docs[i]._id]) {
+        docs[i] = _.merge(docs[i], _.omit(opts.extra[docs[i]._id], '_id'));
+      }
+      if (opts.createInstance) {
+        pending += 1;
 
-				docs[i] = opts.createInstance(docs[i], {
-					extra : opts.extra_props
-				}, function () {
-					if (--pending === 0) {
-						return cb(null, docs);
-					}
-				});
-			}
-		}
+        docs[i] = opts.createInstance(docs[i], {
+          extra : opts.extra_props
+        }, function () {
+          if (--pending === 0) {
+            return cb(null, docs);
+          }
+        });
+      }
+    }
 
-		if (pending === 0) {
-			return cb(null, docs);
-		}
-	}.bind(this));
+    if (pending === 0) {
+      return cb(null, docs);
+    }
+  }.bind(this));
 };
 
 Driver.prototype.count = function (table, conditions, opts, cb) {
-	var collection = this.db.collection(table);
+  var collection = this.db.collection(table);
 
-	convertToDB(conditions, this.config.timezone);
+  convertToDB(conditions, this.config.timezone);
 
-	var cursor     = collection.find(conditions);
+  var cursor     = collection.find(conditions);
 
-	if (opts.order) {
-		var orders = [];
+  if (opts.order) {
+    var orders = [];
 
-		for (var i = 0; i < opts.order.length; i++) {
-			orders.push([ opts.order[i][0], (opts.order[i][1] == 'Z' ? 'desc' : 'asc') ]);
-		}
-		cursor.sort(orders);
-	}
-	if (opts.offset) {
-		cursor.skip(opts.offset);
-	}
-	if (opts.limit) {
-		cursor.limit(opts.limit);
-	}
+    for (var i = 0; i < opts.order.length; i++) {
+      orders.push([ opts.order[i][0], (opts.order[i][1] == 'Z' ? 'desc' : 'asc') ]);
+    }
+    cursor.sort(orders);
+  }
+  if (opts.offset) {
+    cursor.skip(opts.offset);
+  }
+  if (opts.limit) {
+    cursor.limit(opts.limit);
+  }
 
-	return cursor.count(true, function (err, count) {
-		if (err) return cb(err);
+  return cursor.count(true, function (err, count) {
+    if (err) return cb(err);
 
-		return cb(null, [{ c : count }]);
-	});
+    return cb(null, [{ c : count }]);
+  });
 };
 
 Driver.prototype.insert = function (table, data, keyProperties, cb) {
-	convertToDB(data, this.config.timezone);
+  convertToDB(data, this.config.timezone);
 
-	return this.db.collection(table).insert(
-		data,
-		{
-			w : 1
-		},
-		function (err, docs) {
-			if (err) return cb(err);
+  return this.db.collection(table).insert(
+    data,
+    {
+      w : 1
+    },
+    function (err, docs) {
+      if (err) return cb(err);
 
-			var i, ids = {}, prop;
+      var i, ids = {}, prop;
 
-			if (keyProperties && docs.length) {
-				for (i = 0; i < keyProperties.length; i++) {
-					prop = keyProperties[i];
+      if (keyProperties && docs.length) {
+        for (i = 0; i < keyProperties.length; i++) {
+          prop = keyProperties[i];
 
-					if (prop.mapsTo in docs[0]) {
-						ids[prop.name] = docs[0][prop.mapsTo];
-					}
-				}
-				convertFromDB(ids, this.config.timezone);
-			}
+          if (prop.mapsTo in docs[0]) {
+            ids[prop.name] = docs[0][prop.mapsTo];
+          }
+        }
+        convertFromDB(ids, this.config.timezone);
+      }
 
-			return cb(null, ids);
-		}.bind(this)
-	);
+      return cb(null, ids);
+    }.bind(this)
+  );
 };
 
 Driver.prototype.hasMany = function (Model, association) {
-	var db = this.db.collection(Model.table);
-	var driver = this;
+  var db = this.db.collection(Model.table);
+  var driver = this;
 
-	return {
-		has: function (Instance, Associations, conditions, cb) {
-			return db.find({
-				_id : new mongodb.ObjectID(Instance[Model.id])
-			}, [ association.name ]).toArray(function (err, docs) {
-				if (err) return cb(err);
-				if (!docs.length) return cb(new Error("Not found"));
-				if (!Array.isArray(docs[0][association.name])) return cb(null, false);
-				if (!docs[0][association.name].length) return cb(null, false);
+  return {
+    has: function (Instance, Associations, conditions, cb) {
+      return db.find({
+        _id : new mongodb.ObjectID(Instance[Model.id])
+      }, [ association.name ]).toArray(function (err, docs) {
+        if (err) return cb(err);
+        if (!docs.length) return cb(new Error("Not found"));
+        if (!Array.isArray(docs[0][association.name])) return cb(null, false);
+        if (!docs[0][association.name].length) return cb(null, false);
 
-				var found;
+        var found;
 
-				for (var i = 0; i < Associations.length; i++) {
-					found = false;
-					for (var j = 0; j < docs[0][association.name].length; j++) {
-						if (docs[0][association.name][j]._id == Associations[i][association.model.id]) {
-							found = true;
-							break;
-						}
-					}
-					if (!found) {
-						return cb(null, false);
-					}
-				}
+        for (var i = 0; i < Associations.length; i++) {
+          found = false;
+          for (var j = 0; j < docs[0][association.name].length; j++) {
+            if (docs[0][association.name][j]._id == Associations[i][association.model.id]) {
+              found = true;
+              break;
+            }
+          }
+          if (!found) {
+            return cb(null, false);
+          }
+        }
 
-				return cb(null, true);
-			});
-		},
-		get: function (Instance, conditions, options, createInstance, cb) {
-			return db.find({
-				_id : new mongodb.ObjectID(Instance[Model.id])
-			}, [ association.name ]).toArray(function (err, docs) {
-				if (err) return cb(err);
-				if (!docs.length) return cb(new Error("Not found"));
+        return cb(null, true);
+      });
+    },
+    get: function (Instance, conditions, options, createInstance, cb) {
+      return db.find({
+        _id : new mongodb.ObjectID(Instance[Model.id])
+      }, [ association.name ]).toArray(function (err, docs) {
+        if (err) return cb(err);
+        if (!docs.length) return cb(new Error("Not found"));
 
-				if (!docs[0][association.name]) {
-					return cb(null, []);
-				}
+        if (!docs[0][association.name]) {
+          return cb(null, []);
+        }
 
-				var extra = {}
-				conditions._id = { $in: [] };
+        var extra = {}
+        conditions._id = { $in: [] };
 
-				for (var i = 0; i < docs[0][association.name].length; i++) {
-					conditions._id.$in.push(new mongodb.ObjectID(docs[0][association.name][i]._id));
-					extra[docs[0][association.name][i]._id] = docs[0][association.name][i];
-				}
+        for (var i = 0; i < docs[0][association.name].length; i++) {
+          conditions._id.$in.push(new mongodb.ObjectID(docs[0][association.name][i]._id));
+          extra[docs[0][association.name][i]._id] = docs[0][association.name][i];
+        }
 
-				if (options.order) {
-					options.order[0] = options.order[0][1];
-				}
+        if (options.order) {
+          options.order[0] = options.order[0][1];
+        }
 
-				return association.model.find(conditions, options, function (e,docs) {
-					var i, len;
-					for (i = 0, len = docs.length; i < len; i++) {
-						if (extra.hasOwnProperty(docs[i][association.model.id])) {
-							docs[i].extra = extra[docs[i][association.model.id]];
-						}
-					}
-					cb(e, docs);
-				});
-			});
-		},
-		add: function (Instance, Association, data, cb) {
-			var push = {};
-			push[association.name] = { _id : Association[association.model.id] };
+        return association.model.find(conditions, options, function (e,docs) {
+          var i, len;
+          for (i = 0, len = docs.length; i < len; i++) {
+            if (extra.hasOwnProperty(docs[i][association.model.id])) {
+              docs[i].extra = extra[docs[i][association.model.id]];
+            }
+          }
+          cb(e, docs);
+        });
+      });
+    },
+    add: function (Instance, Association, data, cb) {
+      var push = {};
+      push[association.name] = { _id : Association[association.model.id] };
 
-			for (var k in data) {
-				push[association.name][k] = data[k];
-			}
+      for (var k in data) {
+        push[association.name][k] = data[k];
+      }
 
-			return db.update({
-				_id    : new mongodb.ObjectID(Instance[Model.id])
-			}, {
-				$push  : push
-			}, {
-				safe   : true,
-				upsert : true
-			}, cb);
-		},
-		del: function (Instance, Associations, cb) {
-			if (Associations.length === 0) {
-				var unset = {};
-				unset[association.name] = 1;
+      return db.update({
+        _id    : new mongodb.ObjectID(Instance[Model.id])
+      }, {
+        $push  : push
+      }, {
+        safe   : true,
+        upsert : true
+      }, cb);
+    },
+    del: function (Instance, Associations, cb) {
+      if (Associations.length === 0) {
+        var unset = {};
+        unset[association.name] = 1;
 
-				return db.update({
-					_id    : new mongodb.ObjectID(Instance[Model.id])
-				}, {
-					$unset : unset
-				}, {
-					safe   : true,
-					upsert : true
-				}, cb);
-			}
+        return db.update({
+          _id    : new mongodb.ObjectID(Instance[Model.id])
+        }, {
+          $unset : unset
+        }, {
+          safe   : true,
+          upsert : true
+        }, cb);
+      }
 
-			var pull = {};
-			pull[association.name] = [];
+      var pull = {};
+      pull[association.name] = [];
 
-			for (var i = 0; i < Associations.length; i++) {
-				var props = {_id: Associations[i][association.model.id]};
-				
-				if (Associations[i].extra !== undefined) {
-					props = _.merge(props, _.pick(Associations[i].extra, _.keys(association.props)));
-				}
-				
-				pull[association.name].push(props);
-			}
+      for (var i = 0; i < Associations.length; i++) {
+        var props = {_id: Associations[i][association.model.id]};
 
-			return db.update({
-				_id      : new mongodb.ObjectID(Instance[Model.id])
-			}, {
-				$pullAll : pull
-			}, {
-				safe     : true,
-				upsert   : true
-			}, cb);
-		}
-	};
+        if (Associations[i].extra !== undefined) {
+          props = _.merge(props, _.pick(Associations[i].extra, _.keys(association.props)));
+        }
+
+        pull[association.name].push(props);
+      }
+
+      return db.update({
+        _id      : new mongodb.ObjectID(Instance[Model.id])
+      }, {
+        $pullAll : pull
+      }, {
+        safe     : true,
+        upsert   : true
+      }, cb);
+    }
+  };
 };
 
 Driver.prototype.update = function (table, changes, conditions, cb) {
-	convertToDB(changes, this.config.timezone);
-	convertToDB(conditions, this.config.timezone);
+  convertToDB(changes, this.config.timezone);
+  convertToDB(conditions, this.config.timezone);
 
-	return this.db.collection(table).update(
-		conditions,
-		{
-			$set   : changes
-		},
-		{
-			safe   : true,
-			upsert : true
-		},
-		cb
-	);
+  return this.db.collection(table).update(
+    conditions,
+    {
+      $set   : changes
+    },
+    {
+      safe   : true,
+      upsert : true
+    },
+    cb
+  );
 };
 
 Driver.prototype.remove = function (table, conditions, cb) {
-	convertToDB(conditions, this.config.timezone);
+  convertToDB(conditions, this.config.timezone);
 
-	return this.db.collection(table).remove(conditions, cb);
+  return this.db.collection(table).remove(conditions, cb);
 };
 
 Driver.prototype.clear = function (table, cb) {
-	return this.db.collection(table).remove(cb);
+  return this.db.collection(table).remove(cb);
 };
 
 function convertToDB(obj, timeZone) {
-	for (var k in obj) {
-		if ([ 'and', 'or', 'not' ].indexOf(k) >= 0) {
-			for (var j = 0; j < obj[k].length; j++) {
-				convertToDB(obj[k][j], timeZone);
-			}
-			obj['$' + k] = obj[k];
-			delete obj[k];
-			continue;
-		}
-		if (Array.isArray(obj[k]) && k[0] != '$') {
-			for (var i = 0; i < obj[k].length; i++) {
-				obj[k][i] = convertToDBVal(k, obj[k][i], timeZone);
-			}
+  for (var k in obj) {
+    if ([ 'and', 'or', 'not' ].indexOf(k) >= 0) {
+      for (var j = 0; j < obj[k].length; j++) {
+        convertToDB(obj[k][j], timeZone);
+      }
+      obj['$' + k] = obj[k];
+      delete obj[k];
+      continue;
+    }
+    if (Array.isArray(obj[k]) && k[0] != '$') {
+      for (var i = 0; i < obj[k].length; i++) {
+        obj[k][i] = convertToDBVal(k, obj[k][i], timeZone);
+      }
 
-			obj[k] = { $in: obj[k] };
-			continue;
-		}
+      obj[k] = { $in: obj[k] };
+      continue;
+    }
 
-		obj[k] = convertToDBVal(k, obj[k], timeZone);
-	}
+    obj[k] = convertToDBVal(k, obj[k], timeZone);
+  }
 }
 
 function convertFromDB(obj, timezone) {
-	for (var k in obj) {
-		if (obj[k] instanceof mongodb.ObjectID) {
-			obj[k] = obj[k].toString();
-			continue;
-		}
-		if (obj[k] instanceof mongodb.Binary) {
-			obj[k] = new Buffer(obj[k].value(), "binary");
-			continue;
-		}
-	}
+  for (var k in obj) {
+    if (obj[k] instanceof mongodb.ObjectID) {
+      obj[k] = obj[k].toString();
+      continue;
+    }
+    if (obj[k] instanceof mongodb.Binary) {
+      obj[k] = new Buffer(obj[k].value(), "binary");
+      continue;
+    }
+  }
 }
 
 function convertToDBVal(key, value, timezone) {
-	if (value && typeof value.sql_comparator == "function") {
-		var val       = (key != "_id" ? value.val : new mongodb.ObjectID(value.val));
-		var comp      = value.sql_comparator();
-		var condition = {};
+  if (value && typeof value.sql_comparator == "function") {
+    var val       = (key != "_id" ? value.val : new mongodb.ObjectID(value.val));
+    var comp      = value.sql_comparator();
+    var condition = {};
 
-		switch (comp) {
-			case "gt":
-			case "gte":
-			case "lt":
-			case "lte":
-			case "ne":
-				condition["$" + comp] = val;
-				break;
-			case "eq":
-				condition = val;
-				break;
-			case "between":
-				condition["$min"] = value.from;
-				condition["$max"] = value.to;
-				break;
-			case "like":
-				condition["$regex"] = value.expr.replace("%", ".*");
-				break;
-		}
+    switch (comp) {
+      case "gt":
+      case "gte":
+      case "lt":
+      case "lte":
+      case "ne":
+        condition["$" + comp] = val;
+        break;
+      case "eq":
+        condition = val;
+        break;
+      case "between":
+        condition["$min"] = value.from;
+        condition["$max"] = value.to;
+        break;
+      case "like":
+        condition["$regex"] = value.expr.replace("%", ".*");
+        break;
+    }
 
-		return condition;
-	}
+    return condition;
+  }
 
-	if (Buffer.isBuffer(value)) {
-		return new mongodb.Binary(value);
-	}
+  if (Buffer.isBuffer(value)) {
+    return new mongodb.Binary(value);
+  }
 
-	if (key == "_id" && typeof value == "string") {
-		value = new mongodb.ObjectID(value);
-	}
+  if (key == "_id" && typeof value == "string") {
+    value = new mongodb.ObjectID(value);
+  }
 
-	return value;
+  return value;
 }
 
 Object.defineProperty(Driver.prototype, "isSql", {

--- a/lib/Drivers/DML/mysql.js
+++ b/lib/Drivers/DML/mysql.js
@@ -7,286 +7,286 @@ var DDL     = require("../DDL/SQL");
 exports.Driver = Driver;
 
 function Driver(config, connection, opts) {
-	this.dialect = 'mysql';
-	this.config = config || {};
-	this.opts   = opts || {};
-	this.customTypes = {};
+  this.dialect = 'mysql';
+  this.config = config || {};
+  this.opts   = opts || {};
+  this.customTypes = {};
 
-	if (!this.config.timezone) {
-		this.config.timezone = "local";
-	}
+  if (!this.config.timezone) {
+    this.config.timezone = "local";
+  }
 
-	this.query  = new Query({ dialect: this.dialect, timezone: this.config.timezone });
+  this.query  = new Query({ dialect: this.dialect, timezone: this.config.timezone });
 
-	this.reconnect(null, connection);
+  this.reconnect(null, connection);
 
-	this.aggregate_functions = [ "ABS", "CEIL", "FLOOR", "ROUND",
-	                             "AVG", "MIN", "MAX",
-	                             "LOG", "LOG2", "LOG10", "EXP", "POWER",
-	                             "ACOS", "ASIN", "ATAN", "COS", "SIN", "TAN",
-	                             "CONV", [ "RANDOM", "RAND" ], "RADIANS", "DEGREES",
-	                             "SUM", "COUNT",
-	                             "DISTINCT"];
+  this.aggregate_functions = [ "ABS", "CEIL", "FLOOR", "ROUND",
+                               "AVG", "MIN", "MAX",
+                               "LOG", "LOG2", "LOG10", "EXP", "POWER",
+                               "ACOS", "ASIN", "ATAN", "COS", "SIN", "TAN",
+                               "CONV", [ "RANDOM", "RAND" ], "RADIANS", "DEGREES",
+                               "SUM", "COUNT",
+                               "DISTINCT"];
 }
 
 _.extend(Driver.prototype, shared, DDL);
 
 Driver.prototype.ping = function (cb) {
-	this.db.ping(cb);
-	return this;
+  this.db.ping(cb);
+  return this;
 };
 
 Driver.prototype.on = function (ev, cb) {
-	if (ev == "error") {
-		this.db.on("error", cb);
-		this.db.on("unhandledError", cb);
-	}
-	return this;
+  if (ev == "error") {
+    this.db.on("error", cb);
+    this.db.on("unhandledError", cb);
+  }
+  return this;
 };
 
 Driver.prototype.connect = function (cb) {
-	if (this.opts.pool) {
-		return this.db.pool.getConnection(function (err, con) {
-			if (!err) {
-				if (con.release) {
-					con.release();
-				} else {
-					con.end();
-				}
-			}
-			return cb(err);
-		});
-	}
-	this.db.connect(cb);
+  if (this.opts.pool) {
+    return this.db.pool.getConnection(function (err, con) {
+      if (!err) {
+        if (con.release) {
+          con.release();
+        } else {
+          con.end();
+        }
+      }
+      return cb(err);
+    });
+  }
+  this.db.connect(cb);
 };
 
 Driver.prototype.reconnect = function (cb, connection) {
-	var connOpts = this.config.href || this.config;
+  var connOpts = this.config.href || this.config;
 
-	// Prevent noisy mysql driver output
-	if (typeof connOpts == 'object') {
-		connOpts = _.omit(connOpts, 'debug');
-	}
-	if (typeof connOpts == 'string') {
-		connOpts = connOpts.replace("debug=true", "debug=false");
-	}
+  // Prevent noisy mysql driver output
+  if (typeof connOpts == 'object') {
+    connOpts = _.omit(connOpts, 'debug');
+  }
+  if (typeof connOpts == 'string') {
+    connOpts = connOpts.replace("debug=true", "debug=false");
+  }
 
-	this.db = (connection ? connection : mysql.createConnection(connOpts));
-	if (this.opts.pool) {
-		this.db.pool = (connection ? connection : mysql.createPool(connOpts));
-	}
-	if (typeof cb == "function") {
-		this.connect(cb);
-	}
+  this.db = (connection ? connection : mysql.createConnection(connOpts));
+  if (this.opts.pool) {
+    this.db.pool = (connection ? connection : mysql.createPool(connOpts));
+  }
+  if (typeof cb == "function") {
+    this.connect(cb);
+  }
 };
 
 Driver.prototype.close = function (cb) {
-	if (this.opts.pool) {
-		this.db.pool.end(cb);
-	} else {
-		this.db.end(cb);
-	}
+  if (this.opts.pool) {
+    this.db.pool.end(cb);
+  } else {
+    this.db.end(cb);
+  }
 };
 
 Driver.prototype.getQuery = function () {
-	return this.query;
+  return this.query;
 };
 
 Driver.prototype.execSimpleQuery = function (query, cb) {
-	if (this.opts.debug) {
-		require("../../Debug").sql('mysql', query);
-	}
-	if (this.opts.pool) {
-		this.poolQuery(query, cb);
-	} else {
-		this.db.query(query, cb);
-	}
+  if (this.opts.debug) {
+    require("../../Debug").sql('mysql', query);
+  }
+  if (this.opts.pool) {
+    this.poolQuery(query, cb);
+  } else {
+    this.db.query(query, cb);
+  }
 };
 
 Driver.prototype.find = function (fields, table, conditions, opts, cb) {
-	var q = this.query.select()
-	                  .from(table).select(fields);
+  var q = this.query.select()
+                    .from(table).select(fields);
 
-	if (opts.offset) {
-		q.offset(opts.offset);
-	}
-	if (typeof opts.limit == "number") {
-		q.limit(opts.limit);
-	} else if (opts.offset) {
-		// OFFSET cannot be used without LIMIT so we use the biggest BIGINT number possible
-		q.limit('18446744073709551615');
-	}
-	if (opts.order) {
-		for (var i = 0; i < opts.order.length; i++) {
-			q.order(opts.order[i][0], opts.order[i][1]);
-		}
-	}
+  if (opts.offset) {
+    q.offset(opts.offset);
+  }
+  if (typeof opts.limit == "number") {
+    q.limit(opts.limit);
+  } else if (opts.offset) {
+    // OFFSET cannot be used without LIMIT so we use the biggest BIGINT number possible
+    q.limit('18446744073709551615');
+  }
+  if (opts.order) {
+    for (var i = 0; i < opts.order.length; i++) {
+      q.order(opts.order[i][0], opts.order[i][1]);
+    }
+  }
 
-	if (opts.merge) {
-		q.from(opts.merge.from.table, opts.merge.from.field, opts.merge.to.field).select(opts.merge.select);
-		if (opts.merge.where && Object.keys(opts.merge.where[1]).length) {
-			q = q.where(opts.merge.where[0], opts.merge.where[1], opts.merge.table || null, conditions);
-		} else {
-			q = q.where(opts.merge.table || null, conditions);
-		}
-	} else {
-		q = q.where(conditions);
-	}
+  if (opts.merge) {
+    q.from(opts.merge.from.table, opts.merge.from.field, opts.merge.to.field).select(opts.merge.select);
+    if (opts.merge.where && Object.keys(opts.merge.where[1]).length) {
+      q = q.where(opts.merge.where[0], opts.merge.where[1], opts.merge.table || null, conditions);
+    } else {
+      q = q.where(opts.merge.table || null, conditions);
+    }
+  } else {
+    q = q.where(conditions);
+  }
 
-	if (opts.exists) {
-		for (var k in opts.exists) {
-			q.whereExists(opts.exists[k].table, table, opts.exists[k].link, opts.exists[k].conditions);
-		}
-	}
+  if (opts.exists) {
+    for (var k in opts.exists) {
+      q.whereExists(opts.exists[k].table, table, opts.exists[k].link, opts.exists[k].conditions);
+    }
+  }
 
-	q = q.build();
+  q = q.build();
 
-	this.execSimpleQuery(q, cb);
+  this.execSimpleQuery(q, cb);
 };
 
 Driver.prototype.count = function (table, conditions, opts, cb) {
-	var q = this.query.select()
-	                  .from(table)
-	                  .count(null, 'c');
+  var q = this.query.select()
+                    .from(table)
+                    .count(null, 'c');
 
-	if (opts.merge) {
-		q.from(opts.merge.from.table, opts.merge.from.field, opts.merge.to.field);
-		if (opts.merge.where && Object.keys(opts.merge.where[1]).length) {
-			q = q.where(opts.merge.where[0], opts.merge.where[1], conditions);
-		} else {
-			q = q.where(conditions);
-		}
-	} else {
-		q = q.where(conditions);
-	}
+  if (opts.merge) {
+    q.from(opts.merge.from.table, opts.merge.from.field, opts.merge.to.field);
+    if (opts.merge.where && Object.keys(opts.merge.where[1]).length) {
+      q = q.where(opts.merge.where[0], opts.merge.where[1], conditions);
+    } else {
+      q = q.where(conditions);
+    }
+  } else {
+    q = q.where(conditions);
+  }
 
-	if (opts.exists) {
-		for (var k in opts.exists) {
-			q.whereExists(opts.exists[k].table, table, opts.exists[k].link, opts.exists[k].conditions);
-		}
-	}
+  if (opts.exists) {
+    for (var k in opts.exists) {
+      q.whereExists(opts.exists[k].table, table, opts.exists[k].link, opts.exists[k].conditions);
+    }
+  }
 
-	q = q.build();
+  q = q.build();
 
-	this.execSimpleQuery(q, cb);
+  this.execSimpleQuery(q, cb);
 };
 
 Driver.prototype.insert = function (table, data, keyProperties, cb) {
-	var q = this.query.insert()
-	                  .into(table)
-	                  .set(data)
-	                  .build();
+  var q = this.query.insert()
+                    .into(table)
+                    .set(data)
+                    .build();
 
-	this.execSimpleQuery(q, function (err, info) {
-		if (err) return cb(err);
+  this.execSimpleQuery(q, function (err, info) {
+    if (err) return cb(err);
 
-		var i, ids = {}, prop;
+    var i, ids = {}, prop;
 
-		if (keyProperties) {
-			if (keyProperties.length == 1 && info.hasOwnProperty("insertId") && info.insertId !== 0 ) {
-				ids[keyProperties[0].name] = info.insertId;
-			} else {
-				for(i = 0; i < keyProperties.length; i++) {
-					prop = keyProperties[i];
-					ids[prop.name] = data[prop.mapsTo];
-				}
-			}
-		}
-		return cb(null, ids);
-	});
+    if (keyProperties) {
+      if (keyProperties.length == 1 && info.hasOwnProperty("insertId") && info.insertId !== 0 ) {
+        ids[keyProperties[0].name] = info.insertId;
+      } else {
+        for(i = 0; i < keyProperties.length; i++) {
+          prop = keyProperties[i];
+          ids[prop.name] = data[prop.mapsTo];
+        }
+      }
+    }
+    return cb(null, ids);
+  });
 };
 
 Driver.prototype.update = function (table, changes, conditions, cb) {
-	var q = this.query.update()
-	                  .into(table)
-	                  .set(changes)
-	                  .where(conditions)
-	                  .build();
+  var q = this.query.update()
+                    .into(table)
+                    .set(changes)
+                    .where(conditions)
+                    .build();
 
-	this.execSimpleQuery(q, cb);
+  this.execSimpleQuery(q, cb);
 };
 
 Driver.prototype.remove = function (table, conditions, cb) {
-	var q = this.query.remove()
-	                  .from(table)
-	                  .where(conditions)
-	                  .build();
+  var q = this.query.remove()
+                    .from(table)
+                    .where(conditions)
+                    .build();
 
-	this.execSimpleQuery(q, cb);
+  this.execSimpleQuery(q, cb);
 };
 
 Driver.prototype.clear = function (table, cb) {
-	var q = "TRUNCATE TABLE " + this.query.escapeId(table);
+  var q = "TRUNCATE TABLE " + this.query.escapeId(table);
 
-	this.execSimpleQuery(q, cb);
+  this.execSimpleQuery(q, cb);
 };
 
 Driver.prototype.poolQuery = function (query, cb) {
-	this.db.pool.getConnection(function (err, con) {
-		if (err) {
-			return cb(err);
-		}
+  this.db.pool.getConnection(function (err, con) {
+    if (err) {
+      return cb(err);
+    }
 
-		con.query(query, function (err, data) {
-			if (con.release) {
-				con.release();
-			} else {
-				con.end();
-			}
+    con.query(query, function (err, data) {
+      if (con.release) {
+        con.release();
+      } else {
+        con.end();
+      }
 
-			return cb(err, data);
-		});
-	});
+      return cb(err, data);
+    });
+  });
 };
 
 Driver.prototype.valueToProperty = function (value, property) {
-	var customType;
+  var customType;
 
-	switch (property.type) {
-		case "boolean":
-			value = !!value;
-			break;
-		case "object":
-			if (typeof value == "object" && !Buffer.isBuffer(value)) {
-				break;
-			}
-			try {
-				value = JSON.parse(value);
-			} catch (e) {
-				value = null;
-			}
-			break;
-		default:
-			customType = this.customTypes[property.type];
-			if(customType && 'valueToProperty' in customType) {
-				value = customType.valueToProperty(value);
-			}
-	}
-	return value;
+  switch (property.type) {
+    case "boolean":
+      value = !!value;
+      break;
+    case "object":
+      if (typeof value == "object" && !Buffer.isBuffer(value)) {
+        break;
+      }
+      try {
+        value = JSON.parse(value);
+      } catch (e) {
+        value = null;
+      }
+      break;
+    default:
+      customType = this.customTypes[property.type];
+      if(customType && 'valueToProperty' in customType) {
+        value = customType.valueToProperty(value);
+      }
+  }
+  return value;
 };
 
 Driver.prototype.propertyToValue = function (value, property) {
-	var customType;
+  var customType;
 
-	switch (property.type) {
-		case "boolean":
-			value = (value) ? 1 : 0;
-			break;
-		case "object":
-			if (value !== null) {
-				value = JSON.stringify(value);
-			}
-			break;
-		case "point":
-			return function() { return 'POINT(' + value.x + ', ' + value.y + ')'; };
-			break;
-		default:
-			customType = this.customTypes[property.type];
-			if(customType && 'propertyToValue' in customType) {
-				value = customType.propertyToValue(value);
-			}
-	}
-	return value;
+  switch (property.type) {
+    case "boolean":
+      value = (value) ? 1 : 0;
+      break;
+    case "object":
+      if (value !== null) {
+        value = JSON.stringify(value);
+      }
+      break;
+    case "point":
+      return function() { return 'POINT(' + value.x + ', ' + value.y + ')'; };
+      break;
+    default:
+      customType = this.customTypes[property.type];
+      if(customType && 'propertyToValue' in customType) {
+        value = customType.propertyToValue(value);
+      }
+  }
+  return value;
 };
 
 Object.defineProperty(Driver.prototype, "isSql", {

--- a/lib/Drivers/DML/postgres.js
+++ b/lib/Drivers/DML/postgres.js
@@ -7,343 +7,343 @@ var DDL     = require("../DDL/SQL");
 exports.Driver = Driver;
 
 var switchableFunctions = {
-	pool: {
-		connect: function (cb) {
-			this.db.connect(this.config, function (err, client, done) {
-				if (!err) {
-					done();
-				}
-				cb(err);
-			});
-		},
-		execSimpleQuery: function (query, cb) {
-			if (this.opts.debug) {
-				require("../../Debug").sql('postgres', query);
-			}
-			this.db.connect(this.config, function (err, client, done) {
-				if (err) {
-					return cb(err);
-				}
+  pool: {
+    connect: function (cb) {
+      this.db.connect(this.config, function (err, client, done) {
+        if (!err) {
+          done();
+        }
+        cb(err);
+      });
+    },
+    execSimpleQuery: function (query, cb) {
+      if (this.opts.debug) {
+        require("../../Debug").sql('postgres', query);
+      }
+      this.db.connect(this.config, function (err, client, done) {
+        if (err) {
+          return cb(err);
+        }
 
-				client.query(query, function (err, result) {
-					done();
+        client.query(query, function (err, result) {
+          done();
 
-					if (err) {
-						cb(err);
-					} else {
-						cb(null, result.rows);
-					}
-				});
-			});
-			return this;
-		},
-		on: function(ev, cb) {
-			// Because `pg` is the same for all instances of this driver
-			// we can't keep adding listeners since they are never removed.
-			return this;
-		}
-	},
-	client: {
-		connect: function (cb) {
-			this.db.connect(cb);
-		},
-		execSimpleQuery: function (query, cb) {
-			if (this.opts.debug) {
-				require("../../Debug").sql('postgres', query);
-			}
-			this.db.query(query, function (err, result) {
-				if (err) {
-					cb(err);
-				} else {
-					cb(null, result.rows);
-				}
-			});
-			return this;
-		},
-		on: function(ev, cb) {
-			if (ev == "error") {
-				this.db.on("error", cb);
-			}
-			return this;
-		}
-	}
+          if (err) {
+            cb(err);
+          } else {
+            cb(null, result.rows);
+          }
+        });
+      });
+      return this;
+    },
+    on: function(ev, cb) {
+      // Because `pg` is the same for all instances of this driver
+      // we can't keep adding listeners since they are never removed.
+      return this;
+    }
+  },
+  client: {
+    connect: function (cb) {
+      this.db.connect(cb);
+    },
+    execSimpleQuery: function (query, cb) {
+      if (this.opts.debug) {
+        require("../../Debug").sql('postgres', query);
+      }
+      this.db.query(query, function (err, result) {
+        if (err) {
+          cb(err);
+        } else {
+          cb(null, result.rows);
+        }
+      });
+      return this;
+    },
+    on: function(ev, cb) {
+      if (ev == "error") {
+        this.db.on("error", cb);
+      }
+      return this;
+    }
+  }
 };
 
 function Driver(config, connection, opts) {
-	var functions = switchableFunctions.client;
+  var functions = switchableFunctions.client;
 
-	this.dialect = 'postgresql';
-	this.config = config || {};
-	this.opts   = opts || {};
+  this.dialect = 'postgresql';
+  this.config = config || {};
+  this.opts   = opts || {};
 
-	if (!this.config.timezone) {
-		this.config.timezone = "local";
-	}
+  if (!this.config.timezone) {
+    this.config.timezone = "local";
+  }
 
-	this.query  = new Query({ dialect: this.dialect, timezone: this.config.timezone });
-	this.customTypes = {};
+  this.query  = new Query({ dialect: this.dialect, timezone: this.config.timezone });
+  this.customTypes = {};
 
-	if (connection) {
-		this.db = connection;
-	} else {
-		if (this.config.query && this.config.query.ssl) {
-			config.ssl = true;
-			this.config = _.extend(this.config, config);
-		// } else {
-		// 	this.config = _.extend(this.config, config);
-		// 	this.config = config.href || config;
-		}
+  if (connection) {
+    this.db = connection;
+  } else {
+    if (this.config.query && this.config.query.ssl) {
+      config.ssl = true;
+      this.config = _.extend(this.config, config);
+    // } else {
+    //   this.config = _.extend(this.config, config);
+    //   this.config = config.href || config;
+    }
 
-		pg.types.setTypeParser(20, Number);
+    pg.types.setTypeParser(20, Number);
 
-		if (opts.pool) {
-			functions = switchableFunctions.pool;
-			this.db = pg;
-		} else {
-			this.db = new pg.Client(this.config);
-		}
-	}
+    if (opts.pool) {
+      functions = switchableFunctions.pool;
+      this.db = pg;
+    } else {
+      this.db = new pg.Client(this.config);
+    }
+  }
 
-	_.extend(this.constructor.prototype, functions);
+  _.extend(this.constructor.prototype, functions);
 
-	this.aggregate_functions = [
-		"ABS", "CEIL", "FLOOR", "ROUND",
-		"AVG", "MIN", "MAX",
-		"LOG", "EXP", "POWER",
-		"ACOS", "ASIN", "ATAN", "COS", "SIN", "TAN",
-		"RANDOM", "RADIANS", "DEGREES",
-		"SUM", "COUNT",
-		"DISTINCT"
-	];
+  this.aggregate_functions = [
+    "ABS", "CEIL", "FLOOR", "ROUND",
+    "AVG", "MIN", "MAX",
+    "LOG", "EXP", "POWER",
+    "ACOS", "ASIN", "ATAN", "COS", "SIN", "TAN",
+    "RANDOM", "RADIANS", "DEGREES",
+    "SUM", "COUNT",
+    "DISTINCT"
+  ];
 }
 
 _.extend(Driver.prototype, shared, DDL);
 
 Driver.prototype.ping = function (cb) {
-	this.execSimpleQuery("SELECT * FROM pg_stat_activity LIMIT 1", function () {
-		return cb();
-	});
-	return this;
+  this.execSimpleQuery("SELECT * FROM pg_stat_activity LIMIT 1", function () {
+    return cb();
+  });
+  return this;
 };
 
 Driver.prototype.close = function (cb) {
-	this.db.end();
+  this.db.end();
 
-	if (typeof cb == "function") cb();
+  if (typeof cb == "function") cb();
 
-	return;
+  return;
 };
 
 Driver.prototype.getQuery = function () {
-	return this.query;
+  return this.query;
 };
 
 Driver.prototype.find = function (fields, table, conditions, opts, cb) {
-	var q = this.query.select().from(table).select(fields);
+  var q = this.query.select().from(table).select(fields);
 
-	if (opts.offset) {
-		q.offset(opts.offset);
-	}
-	if (typeof opts.limit == "number") {
-		q.limit(opts.limit);
-	}
-	if (opts.order) {
-		for (var i = 0; i < opts.order.length; i++) {
-			q.order(opts.order[i][0], opts.order[i][1]);
-		}
-	}
+  if (opts.offset) {
+    q.offset(opts.offset);
+  }
+  if (typeof opts.limit == "number") {
+    q.limit(opts.limit);
+  }
+  if (opts.order) {
+    for (var i = 0; i < opts.order.length; i++) {
+      q.order(opts.order[i][0], opts.order[i][1]);
+    }
+  }
 
-	if (opts.merge) {
-		q.from(opts.merge.from.table, opts.merge.from.field, opts.merge.to.field).select(opts.merge.select);
-		if (opts.merge.where && Object.keys(opts.merge.where[1]).length) {
-			q = q.where(opts.merge.where[0], opts.merge.where[1], opts.merge.table || null, conditions);
-		} else {
-			q = q.where(opts.merge.table || null, conditions);
-		}
-	} else {
-		q = q.where(conditions);
-	}
+  if (opts.merge) {
+    q.from(opts.merge.from.table, opts.merge.from.field, opts.merge.to.field).select(opts.merge.select);
+    if (opts.merge.where && Object.keys(opts.merge.where[1]).length) {
+      q = q.where(opts.merge.where[0], opts.merge.where[1], opts.merge.table || null, conditions);
+    } else {
+      q = q.where(opts.merge.table || null, conditions);
+    }
+  } else {
+    q = q.where(conditions);
+  }
 
-	if (opts.exists) {
-		for (var k in opts.exists) {
-			q.whereExists(opts.exists[k].table, table, opts.exists[k].link, opts.exists[k].conditions);
-		}
-	}
+  if (opts.exists) {
+    for (var k in opts.exists) {
+      q.whereExists(opts.exists[k].table, table, opts.exists[k].link, opts.exists[k].conditions);
+    }
+  }
 
-	q = q.build();
+  q = q.build();
 
-	this.execSimpleQuery(q, cb);
+  this.execSimpleQuery(q, cb);
 };
 
 Driver.prototype.count = function (table, conditions, opts, cb) {
-	var q = this.query.select().from(table).count(null, 'c');
+  var q = this.query.select().from(table).count(null, 'c');
 
-	if (opts.merge) {
-		q.from(opts.merge.from.table, opts.merge.from.field, opts.merge.to.field);
-		if (opts.merge.where && Object.keys(opts.merge.where[1]).length) {
-			q = q.where(opts.merge.where[0], opts.merge.where[1], conditions);
-		} else {
-			q = q.where(conditions);
-		}
-	} else {
-		q = q.where(conditions);
-	}
+  if (opts.merge) {
+    q.from(opts.merge.from.table, opts.merge.from.field, opts.merge.to.field);
+    if (opts.merge.where && Object.keys(opts.merge.where[1]).length) {
+      q = q.where(opts.merge.where[0], opts.merge.where[1], conditions);
+    } else {
+      q = q.where(conditions);
+    }
+  } else {
+    q = q.where(conditions);
+  }
 
-	if (opts.exists) {
-		for (var k in opts.exists) {
-			q.whereExists(opts.exists[k].table, table, opts.exists[k].link, opts.exists[k].conditions);
-		}
-	}
+  if (opts.exists) {
+    for (var k in opts.exists) {
+      q.whereExists(opts.exists[k].table, table, opts.exists[k].link, opts.exists[k].conditions);
+    }
+  }
 
-	q = q.build();
+  q = q.build();
 
-	this.execSimpleQuery(q, cb);
+  this.execSimpleQuery(q, cb);
 };
 
 Driver.prototype.insert = function (table, data, keyProperties, cb) {
-	var q = this.query.insert().into(table).set(data).build();
+  var q = this.query.insert().into(table).set(data).build();
 
-	this.execSimpleQuery(q + " RETURNING *", function (err, results) {
-		if (err) {
-			return cb(err);
-		}
+  this.execSimpleQuery(q + " RETURNING *", function (err, results) {
+    if (err) {
+      return cb(err);
+    }
 
-		var i, ids = {}, prop;
+    var i, ids = {}, prop;
 
-		if (keyProperties) {
-			for (i = 0; i < keyProperties.length; i++) {
-				prop = keyProperties[i];
+    if (keyProperties) {
+      for (i = 0; i < keyProperties.length; i++) {
+        prop = keyProperties[i];
                                 // Zero is a valid value for an ID column
-				ids[prop.name] = results[0][prop.mapsTo] !== undefined ? results[0][prop.mapsTo] : null;
-			}
-		}
-		return cb(null, ids);
-	});
+        ids[prop.name] = results[0][prop.mapsTo] !== undefined ? results[0][prop.mapsTo] : null;
+      }
+    }
+    return cb(null, ids);
+  });
 };
 
 Driver.prototype.update = function (table, changes, conditions, cb) {
-	var q = this.query.update().into(table).set(changes).where(conditions).build();
+  var q = this.query.update().into(table).set(changes).where(conditions).build();
 
-	this.execSimpleQuery(q, cb);
+  this.execSimpleQuery(q, cb);
 };
 
 Driver.prototype.remove = function (table, conditions, cb) {
-	var q = this.query.remove().from(table).where(conditions).build();
+  var q = this.query.remove().from(table).where(conditions).build();
 
-	this.execSimpleQuery(q, cb);
+  this.execSimpleQuery(q, cb);
 };
 
 Driver.prototype.clear = function (table, cb) {
-	var q = "TRUNCATE TABLE " + this.query.escapeId(table);
+  var q = "TRUNCATE TABLE " + this.query.escapeId(table);
 
-	this.execSimpleQuery(q, cb);
+  this.execSimpleQuery(q, cb);
 };
 
 Driver.prototype.valueToProperty = function (value, property) {
-	var customType, v;
+  var customType, v;
 
-	switch (property.type) {
-		case "object":
-			if (typeof value == "object" && !Buffer.isBuffer(value)) {
-				break;
-			}
-			try {
-				value = JSON.parse(value);
-			} catch (e) {
-				value = null;
-			}
-			break;
-		case "point":
-			if (typeof value == "string") {
-				var m = value.match(/\((\-?[\d\.]+)[\s,]+(\-?[\d\.]+)\)/);
+  switch (property.type) {
+    case "object":
+      if (typeof value == "object" && !Buffer.isBuffer(value)) {
+        break;
+      }
+      try {
+        value = JSON.parse(value);
+      } catch (e) {
+        value = null;
+      }
+      break;
+    case "point":
+      if (typeof value == "string") {
+        var m = value.match(/\((\-?[\d\.]+)[\s,]+(\-?[\d\.]+)\)/);
 
-				if (m) {
-					value = { x : parseFloat(m[1], 10) , y : parseFloat(m[2], 10) };
-				}
-			}
-			break;
-		case "date":
-			if (_.isDate(value) && this.config.timezone && this.config.timezone != 'local') {
-				var tz = convertTimezone(this.config.timezone);
+        if (m) {
+          value = { x : parseFloat(m[1], 10) , y : parseFloat(m[2], 10) };
+        }
+      }
+      break;
+    case "date":
+      if (_.isDate(value) && this.config.timezone && this.config.timezone != 'local') {
+        var tz = convertTimezone(this.config.timezone);
 
-				// shift local to UTC
-				value.setTime(value.getTime() - (value.getTimezoneOffset() * 60000));
+        // shift local to UTC
+        value.setTime(value.getTime() - (value.getTimezoneOffset() * 60000));
 
-				if (tz !== false) {
-					// shift UTC to timezone
-					value.setTime(value.getTime() - (tz * 60000));
-				}
-			}
-			break;
-		case "number":
-			if (typeof value == 'string') {
-				switch (value.trim()) {
-					case 'Infinity':
-					case '-Infinity':
-					case 'NaN':
-						value = Number(value);
-						break;
-					default:
-						v = parseFloat(value);
-						if (Number.isFinite(v)) {
-							value = v;
-						}
-				}
-			}
-			break;
-		case "integer":
-			if (typeof value == 'string') {
-				v = parseInt(value);
+        if (tz !== false) {
+          // shift UTC to timezone
+          value.setTime(value.getTime() - (tz * 60000));
+        }
+      }
+      break;
+    case "number":
+      if (typeof value == 'string') {
+        switch (value.trim()) {
+          case 'Infinity':
+          case '-Infinity':
+          case 'NaN':
+            value = Number(value);
+            break;
+          default:
+            v = parseFloat(value);
+            if (Number.isFinite(v)) {
+              value = v;
+            }
+        }
+      }
+      break;
+    case "integer":
+      if (typeof value == 'string') {
+        v = parseInt(value);
 
-				if (Number.isFinite(v)) {
-					value = v;
-				}
-			}
-			break;
-		default:
-			customType = this.customTypes[property.type];
+        if (Number.isFinite(v)) {
+          value = v;
+        }
+      }
+      break;
+    default:
+      customType = this.customTypes[property.type];
 
-			if (customType && 'valueToProperty' in customType) {
-				value = customType.valueToProperty(value);
-			}
-	}
-	return value;
+      if (customType && 'valueToProperty' in customType) {
+        value = customType.valueToProperty(value);
+      }
+  }
+  return value;
 };
 
 Driver.prototype.propertyToValue = function (value, property) {
-	var customType;
+  var customType;
 
-	switch (property.type) {
-		case "object":
-			if (value !== null && !Buffer.isBuffer(value)) {
-				value = new Buffer(JSON.stringify(value));
-			}
-			break;
-		case "date":
-			if (_.isDate(value) && this.config.timezone && this.config.timezone != 'local') {
-				var tz = convertTimezone(this.config.timezone);
+  switch (property.type) {
+    case "object":
+      if (value !== null && !Buffer.isBuffer(value)) {
+        value = new Buffer(JSON.stringify(value));
+      }
+      break;
+    case "date":
+      if (_.isDate(value) && this.config.timezone && this.config.timezone != 'local') {
+        var tz = convertTimezone(this.config.timezone);
 
-				// shift local to UTC
-				value.setTime(value.getTime() + (value.getTimezoneOffset() * 60000));
-				if (tz !== false) {
-					// shift UTC to timezone
-					value.setTime(value.getTime() + (tz * 60000));
-				}
-			}
-			break;
-		case "point":
-			return function () {
-				return "POINT(" + value.x + ', ' + value.y + ")";
-			};
-			break;
-		default:
-			customType = this.customTypes[property.type];
+        // shift local to UTC
+        value.setTime(value.getTime() + (value.getTimezoneOffset() * 60000));
+        if (tz !== false) {
+          // shift UTC to timezone
+          value.setTime(value.getTime() + (tz * 60000));
+        }
+      }
+      break;
+    case "point":
+      return function () {
+        return "POINT(" + value.x + ', ' + value.y + ")";
+      };
+      break;
+    default:
+      customType = this.customTypes[property.type];
 
-			if (customType && 'propertyToValue' in customType) {
-				value = customType.propertyToValue(value);
-			}
-	}
-	return value;
+      if (customType && 'propertyToValue' in customType) {
+        value = customType.propertyToValue(value);
+      }
+  }
+  return value;
 };
 
 Object.defineProperty(Driver.prototype, "isSql", {
@@ -351,14 +351,14 @@ Object.defineProperty(Driver.prototype, "isSql", {
 });
 
 function convertTimezone(tz) {
-	if (tz == "Z") {
-		return 0;
-	}
+  if (tz == "Z") {
+    return 0;
+  }
 
-	var m = tz.match(/([\+\-\s])(\d\d):?(\d\d)?/);
+  var m = tz.match(/([\+\-\s])(\d\d):?(\d\d)?/);
 
-	if (m) {
-		return (m[1] == '-' ? -1 : 1) * (parseInt(m[2], 10) + ((m[3] ? parseInt(m[3], 10) : 0) / 60)) * 60;
-	}
-	return false;
+  if (m) {
+    return (m[1] == '-' ? -1 : 1) * (parseInt(m[2], 10) + ((m[3] ? parseInt(m[3], 10) : 0) / 60)) * 60;
+  }
+  return false;
 }

--- a/lib/Drivers/DML/redshift.js
+++ b/lib/Drivers/DML/redshift.js
@@ -4,41 +4,41 @@ var postgres = require("./postgres");
 exports.Driver = Driver;
 
 function Driver(config, connection, opts) {
-	postgres.Driver.call(this, config, connection, opts);
+  postgres.Driver.call(this, config, connection, opts);
 }
 
 util.inherits(Driver, postgres.Driver);
 
 Driver.prototype.insert = function (table, data, keyProperties, cb) {
-	var q = this.query.insert()
-	                  .into(table)
-	                  .set(data)
-	                  .build();
+  var q = this.query.insert()
+                    .into(table)
+                    .set(data)
+                    .build();
 
-	if (this.opts.debug) {
-		require("../../Debug").sql('postgres', q);
-	}
-	this.execQuery(q, function (err, result) {
-		if (err)            return cb(err);
-		if (!keyProperties) return cb(null);
+  if (this.opts.debug) {
+    require("../../Debug").sql('postgres', q);
+  }
+  this.execQuery(q, function (err, result) {
+    if (err)            return cb(err);
+    if (!keyProperties) return cb(null);
 
-		var i, ids = {}, prop;
+    var i, ids = {}, prop;
 
-		if (keyNames.length == 1) {
-			this.execQuery("SELECT LASTVAL() AS id", function (err, results) {
-				if (err) return cb(err);
+    if (keyNames.length == 1) {
+      this.execQuery("SELECT LASTVAL() AS id", function (err, results) {
+        if (err) return cb(err);
 
-				ids[keyProperties[0].name] = results[0].id || null;
-				return cb(null, ids);
-			});
-		} else {
-			for(i = 0; i < keyProperties.length; i++) {
-				prop = keyProperties[i];
+        ids[keyProperties[0].name] = results[0].id || null;
+        return cb(null, ids);
+      });
+    } else {
+      for(i = 0; i < keyProperties.length; i++) {
+        prop = keyProperties[i];
                                 // Zero is a valid value for an ID column
-				ids[prop.name] = data[prop.mapsTo] !== undefined ? data[prop.mapsTo] : null;
-			}
+        ids[prop.name] = data[prop.mapsTo] !== undefined ? data[prop.mapsTo] : null;
+      }
 
-			return cb(null, ids);
-		}
-	}.bind(this));
+      return cb(null, ids);
+    }
+  }.bind(this));
 };

--- a/lib/Drivers/DML/sqlite.js
+++ b/lib/Drivers/DML/sqlite.js
@@ -8,349 +8,349 @@ var DDL     = require("../DDL/SQL");
 exports.Driver = Driver;
 
 function Driver(config, connection, opts) {
-	this.dialect = 'sqlite';
-	this.config = config || {};
-	this.opts   = opts || {};
+  this.dialect = 'sqlite';
+  this.config = config || {};
+  this.opts   = opts || {};
 
-	if (!this.config.timezone) {
-		this.config.timezone = "local";
-	}
+  if (!this.config.timezone) {
+    this.config.timezone = "local";
+  }
 
-	this.query  = new Query({ dialect: this.dialect, timezone: this.config.timezone });
-	this.customTypes = {};
+  this.query  = new Query({ dialect: this.dialect, timezone: this.config.timezone });
+  this.customTypes = {};
 
-	if (connection) {
-		this.db = connection;
-	} else {
-		// on Windows, paths have a drive letter which is parsed by
-		// url.parse() as the hostname. If host is defined, assume
-		// it's the drive letter and add ":"
-		if (process.platform == "win32" && config.host && config.host.match(/^[a-z]$/i)) {
-			this.db = new sqlite3.Database(decodeURIComponent((config.host ? config.host + ":" : "") + (config.pathname || "")) || ':memory:');
-		} else {
-			this.db = new sqlite3.Database(decodeURIComponent((config.host ? config.host : "") + (config.pathname || "")) || ':memory:');
-		}
+  if (connection) {
+    this.db = connection;
+  } else {
+    // on Windows, paths have a drive letter which is parsed by
+    // url.parse() as the hostname. If host is defined, assume
+    // it's the drive letter and add ":"
+    if (process.platform == "win32" && config.host && config.host.match(/^[a-z]$/i)) {
+      this.db = new sqlite3.Database(decodeURIComponent((config.host ? config.host + ":" : "") + (config.pathname || "")) || ':memory:');
+    } else {
+      this.db = new sqlite3.Database(decodeURIComponent((config.host ? config.host : "") + (config.pathname || "")) || ':memory:');
+    }
 
-	}
+  }
 
-	this.aggregate_functions = [ "ABS", "ROUND",
-	                             "AVG", "MIN", "MAX",
-	                             "RANDOM",
-	                             "SUM", "COUNT",
-	                             "DISTINCT" ];
+  this.aggregate_functions = [ "ABS", "ROUND",
+                               "AVG", "MIN", "MAX",
+                               "RANDOM",
+                               "SUM", "COUNT",
+                               "DISTINCT" ];
 }
 
 _.extend(Driver.prototype, shared, DDL);
 
 Driver.prototype.ping = function (cb) {
-	process.nextTick(cb);
-	return this;
+  process.nextTick(cb);
+  return this;
 };
 
 Driver.prototype.on = function (ev, cb) {
-	if (ev == "error") {
-		this.db.on("error", cb);
-	}
-	return this;
+  if (ev == "error") {
+    this.db.on("error", cb);
+  }
+  return this;
 };
 
 Driver.prototype.connect = function (cb) {
-	process.nextTick(cb);
+  process.nextTick(cb);
 };
 
 Driver.prototype.close = function (cb) {
-	this.db.close();
-	if (typeof cb == "function") process.nextTick(cb);
+  this.db.close();
+  if (typeof cb == "function") process.nextTick(cb);
 };
 
 Driver.prototype.getQuery = function () {
-	return this.query;
+  return this.query;
 };
 
 Driver.prototype.execSimpleQuery = function (query, cb) {
-	if (this.opts.debug) {
-		require("../../Debug").sql('sqlite', query);
-	}
-	this.db.all(query, cb);
+  if (this.opts.debug) {
+    require("../../Debug").sql('sqlite', query);
+  }
+  this.db.all(query, cb);
 };
 
 Driver.prototype.find = function (fields, table, conditions, opts, cb) {
-	var q = this.query.select()
-	                  .from(table).select(fields);
+  var q = this.query.select()
+                    .from(table).select(fields);
 
-	if (opts.offset) {
-		q.offset(opts.offset);
-	}
-	if (typeof opts.limit == "number") {
-		q.limit(opts.limit);
-	} else if (opts.offset) {
-		// OFFSET cannot be used without LIMIT so we use the biggest INTEGER number possible
-		q.limit('9223372036854775807');
-	}
-	if (opts.order) {
-		for (var i = 0; i < opts.order.length; i++) {
-			q.order(opts.order[i][0], opts.order[i][1]);
-		}
-	}
+  if (opts.offset) {
+    q.offset(opts.offset);
+  }
+  if (typeof opts.limit == "number") {
+    q.limit(opts.limit);
+  } else if (opts.offset) {
+    // OFFSET cannot be used without LIMIT so we use the biggest INTEGER number possible
+    q.limit('9223372036854775807');
+  }
+  if (opts.order) {
+    for (var i = 0; i < opts.order.length; i++) {
+      q.order(opts.order[i][0], opts.order[i][1]);
+    }
+  }
 
-	if (opts.merge) {
-		q.from(opts.merge.from.table, opts.merge.from.field, opts.merge.to.field).select(opts.merge.select);
-		if (opts.merge.where && Object.keys(opts.merge.where[1]).length) {
-			q = q.where(opts.merge.where[0], opts.merge.where[1], opts.merge.table || null, conditions);
-		} else {
-			q = q.where(opts.merge.table || null, conditions);
-		}
-	} else {
-		q = q.where(conditions);
-	}
+  if (opts.merge) {
+    q.from(opts.merge.from.table, opts.merge.from.field, opts.merge.to.field).select(opts.merge.select);
+    if (opts.merge.where && Object.keys(opts.merge.where[1]).length) {
+      q = q.where(opts.merge.where[0], opts.merge.where[1], opts.merge.table || null, conditions);
+    } else {
+      q = q.where(opts.merge.table || null, conditions);
+    }
+  } else {
+    q = q.where(conditions);
+  }
 
-	if (opts.exists) {
-		for (var k in opts.exists) {
-			q.whereExists(opts.exists[k].table, table, opts.exists[k].link, opts.exists[k].conditions);
-		}
-	}
+  if (opts.exists) {
+    for (var k in opts.exists) {
+      q.whereExists(opts.exists[k].table, table, opts.exists[k].link, opts.exists[k].conditions);
+    }
+  }
 
-	q = q.build();
+  q = q.build();
 
-	if (this.opts.debug) {
-		require("../../Debug").sql('sqlite', q);
-	}
-	this.db.all(q, cb);
+  if (this.opts.debug) {
+    require("../../Debug").sql('sqlite', q);
+  }
+  this.db.all(q, cb);
 };
 
 Driver.prototype.count = function (table, conditions, opts, cb) {
-	var q = this.query.select()
-	                  .from(table)
-	                  .count(null, 'c');
+  var q = this.query.select()
+                    .from(table)
+                    .count(null, 'c');
 
-	if (opts.merge) {
-		q.from(opts.merge.from.table, opts.merge.from.field, opts.merge.to.field);
-		if (opts.merge.where && Object.keys(opts.merge.where[1]).length) {
-			q = q.where(opts.merge.where[0], opts.merge.where[1], conditions);
-		} else {
-			q = q.where(conditions);
-		}
-	} else {
-		q = q.where(conditions);
-	}
+  if (opts.merge) {
+    q.from(opts.merge.from.table, opts.merge.from.field, opts.merge.to.field);
+    if (opts.merge.where && Object.keys(opts.merge.where[1]).length) {
+      q = q.where(opts.merge.where[0], opts.merge.where[1], conditions);
+    } else {
+      q = q.where(conditions);
+    }
+  } else {
+    q = q.where(conditions);
+  }
 
-	if (opts.exists) {
-		for (var k in opts.exists) {
-			q.whereExists(opts.exists[k].table, table, opts.exists[k].link, opts.exists[k].conditions);
-		}
-	}
+  if (opts.exists) {
+    for (var k in opts.exists) {
+      q.whereExists(opts.exists[k].table, table, opts.exists[k].link, opts.exists[k].conditions);
+    }
+  }
 
-	q = q.build();
+  q = q.build();
 
-	if (this.opts.debug) {
-		require("../../Debug").sql('sqlite', q);
-	}
-	this.db.all(q, cb);
+  if (this.opts.debug) {
+    require("../../Debug").sql('sqlite', q);
+  }
+  this.db.all(q, cb);
 };
 
 Driver.prototype.insert = function (table, data, keyProperties, cb) {
-	var q = this.query.insert()
-	                  .into(table)
-	                  .set(data)
-	                  .build();
+  var q = this.query.insert()
+                    .into(table)
+                    .set(data)
+                    .build();
 
-	if (this.opts.debug) {
-		require("../../Debug").sql('sqlite', q);
-	}
+  if (this.opts.debug) {
+    require("../../Debug").sql('sqlite', q);
+  }
 
 
-	this.db.all(q, function (err, info) {
-		if (err)            return cb(err);
-		if (!keyProperties) return cb(null);
+  this.db.all(q, function (err, info) {
+    if (err)            return cb(err);
+    if (!keyProperties) return cb(null);
 
-		var i, ids = {}, prop;
+    var i, ids = {}, prop;
 
-		if (keyProperties.length == 1 && keyProperties[0].type == 'serial') {
-			this.db.get("SELECT last_insert_rowid() AS last_row_id", function (err, row) {
-				if (err) return cb(err);
+    if (keyProperties.length == 1 && keyProperties[0].type == 'serial') {
+      this.db.get("SELECT last_insert_rowid() AS last_row_id", function (err, row) {
+        if (err) return cb(err);
 
-				ids[keyProperties[0].name] = row.last_row_id;
+        ids[keyProperties[0].name] = row.last_row_id;
 
-				return cb(null, ids);
-			});
-		} else {
-			for (i = 0; i < keyProperties.length; i++) {
-				prop = keyProperties[i];
+        return cb(null, ids);
+      });
+    } else {
+      for (i = 0; i < keyProperties.length; i++) {
+        prop = keyProperties[i];
                                 // Zero is a valid value for an ID column
-				ids[prop.name] = data[prop.mapsTo] !== undefined ? data[prop.mapsTo] : null;
-			}
-			return cb(null, ids);
-		}
-	}.bind(this));
+        ids[prop.name] = data[prop.mapsTo] !== undefined ? data[prop.mapsTo] : null;
+      }
+      return cb(null, ids);
+    }
+  }.bind(this));
 };
 
 Driver.prototype.update = function (table, changes, conditions, cb) {
-	var q = this.query.update()
-	                  .into(table)
-	                  .set(changes)
-	                  .where(conditions)
-	                  .build();
+  var q = this.query.update()
+                    .into(table)
+                    .set(changes)
+                    .where(conditions)
+                    .build();
 
-	if (this.opts.debug) {
-		require("../../Debug").sql('sqlite', q);
-	}
-	this.db.all(q, cb);
+  if (this.opts.debug) {
+    require("../../Debug").sql('sqlite', q);
+  }
+  this.db.all(q, cb);
 };
 
 Driver.prototype.remove = function (table, conditions, cb) {
-	var q = this.query.remove()
-	                  .from(table)
-	                  .where(conditions)
-	                  .build();
+  var q = this.query.remove()
+                    .from(table)
+                    .where(conditions)
+                    .build();
 
-	if (this.opts.debug) {
-		require("../../Debug").sql('sqlite', q);
-	}
-	this.db.all(q, cb);
+  if (this.opts.debug) {
+    require("../../Debug").sql('sqlite', q);
+  }
+  this.db.all(q, cb);
 };
 
 Driver.prototype.clear = function (table, cb) {
-	var debug = this.opts.debug;
+  var debug = this.opts.debug;
 
-	this.execQuery("DELETE FROM ??", [table], function (err) {
-		if (err) return cb(err);
+  this.execQuery("DELETE FROM ??", [table], function (err) {
+    if (err) return cb(err);
 
-		this.execQuery("DELETE FROM ?? WHERE NAME = ?", ['sqlite_sequence', table], cb);
-	}.bind(this));
+    this.execQuery("DELETE FROM ?? WHERE NAME = ?", ['sqlite_sequence', table], cb);
+  }.bind(this));
 };
 
 Driver.prototype.valueToProperty = function (value, property) {
-	var v, customType;
+  var v, customType;
 
-	switch (property.type) {
-		case "boolean":
-			value = !!value;
-			break;
-		case "object":
-			if (typeof value == "object" && !Buffer.isBuffer(value)) {
-				break;
-			}
-			try {
-				value = JSON.parse(value);
-			} catch (e) {
-				value = null;
-			}
-			break;
-		case "number":
-			if (typeof value == 'string') {
-				switch (value.trim()) {
-					case 'Infinity':
-					case '-Infinity':
-					case 'NaN':
-						value = Number(value);
-						break;
-					default:
-						v = parseFloat(value);
-						if (Number.isFinite(v)) {
-							value = v;
-						}
-				}
-			}
-			break;
-		case "integer":
-			if (typeof value == 'string') {
-				v = parseInt(value);
+  switch (property.type) {
+    case "boolean":
+      value = !!value;
+      break;
+    case "object":
+      if (typeof value == "object" && !Buffer.isBuffer(value)) {
+        break;
+      }
+      try {
+        value = JSON.parse(value);
+      } catch (e) {
+        value = null;
+      }
+      break;
+    case "number":
+      if (typeof value == 'string') {
+        switch (value.trim()) {
+          case 'Infinity':
+          case '-Infinity':
+          case 'NaN':
+            value = Number(value);
+            break;
+          default:
+            v = parseFloat(value);
+            if (Number.isFinite(v)) {
+              value = v;
+            }
+        }
+      }
+      break;
+    case "integer":
+      if (typeof value == 'string') {
+        v = parseInt(value);
 
-				if (Number.isFinite(v)) {
-					value = v;
-				}
-			}
-			break;
-		case "date":
-			if (typeof value == 'string') {
-				if (value.indexOf('Z', value.length - 1) === -1) {
-					value = new Date(value + 'Z');
-				} else {
-					value = new Date(value);
-				}
+        if (Number.isFinite(v)) {
+          value = v;
+        }
+      }
+      break;
+    case "date":
+      if (typeof value == 'string') {
+        if (value.indexOf('Z', value.length - 1) === -1) {
+          value = new Date(value + 'Z');
+        } else {
+          value = new Date(value);
+        }
 
-				if (this.config.timezone && this.config.timezone != 'local') {
-					var tz = convertTimezone(this.config.timezone);
+        if (this.config.timezone && this.config.timezone != 'local') {
+          var tz = convertTimezone(this.config.timezone);
 
-					// shift local to UTC
-					value.setTime(value.getTime() - (value.getTimezoneOffset() * 60000));
-					if (tz !== false) {
-						// shift UTC to timezone
-						value.setTime(value.getTime() - (tz * 60000));
-					}
-				}
-			}
-			break;
-		default:
-			customType = this.customTypes[property.type];
-			if(customType && 'valueToProperty' in customType) {
-				value = customType.valueToProperty(value);
-			}
-	}
-	return value;
+          // shift local to UTC
+          value.setTime(value.getTime() - (value.getTimezoneOffset() * 60000));
+          if (tz !== false) {
+            // shift UTC to timezone
+            value.setTime(value.getTime() - (tz * 60000));
+          }
+        }
+      }
+      break;
+    default:
+      customType = this.customTypes[property.type];
+      if(customType && 'valueToProperty' in customType) {
+        value = customType.valueToProperty(value);
+      }
+  }
+  return value;
 };
 
 Driver.prototype.propertyToValue = function (value, property) {
-	var customType;
+  var customType;
 
-	switch (property.type) {
-		case "boolean":
-			value = (value) ? 1 : 0;
-			break;
-		case "object":
-			if (value !== null) {
-				value = JSON.stringify(value);
-			}
-			break;
-		case "date":
-			if (this.config.query && this.config.query.strdates) {
-				if (value instanceof Date) {
-					var year = value.getUTCFullYear();
-					var month = value.getUTCMonth() + 1;
-					if (month < 10) {
-						month = '0' + month;
-					}
-					var date = value.getUTCDate();
-					if (date < 10) {
-						date = '0' + date;
-					}
-					var strdate = year + '-' + month + '-' + date;
-					if (property.time === false) {
-						value = strdate;
-						break;
-					}
+  switch (property.type) {
+    case "boolean":
+      value = (value) ? 1 : 0;
+      break;
+    case "object":
+      if (value !== null) {
+        value = JSON.stringify(value);
+      }
+      break;
+    case "date":
+      if (this.config.query && this.config.query.strdates) {
+        if (value instanceof Date) {
+          var year = value.getUTCFullYear();
+          var month = value.getUTCMonth() + 1;
+          if (month < 10) {
+            month = '0' + month;
+          }
+          var date = value.getUTCDate();
+          if (date < 10) {
+            date = '0' + date;
+          }
+          var strdate = year + '-' + month + '-' + date;
+          if (property.time === false) {
+            value = strdate;
+            break;
+          }
 
-					var hours = value.getUTCHours();
-					if (hours < 10) {
-						hours = '0' + hours;
-					}
-					var minutes = value.getUTCMinutes();
-					if (minutes < 10) {
-						minutes = '0' + minutes;
-					}
-					var seconds = value.getUTCSeconds();
-					if (seconds < 10) {
-						seconds = '0' + seconds;
-					}
-					var millis = value.getUTCMilliseconds();
-					if (millis < 10) {
-						millis = '0' + millis;
-					}
-					if (millis < 100) {
-						millis = '0' + millis;
-					}
-					strdate += ' ' + hours + ':' + minutes + ':' + seconds + '.' + millis + '000';
-					value = strdate;
-				}
-			}
-			break;
-		default:
-			customType = this.customTypes[property.type];
-			if(customType && 'propertyToValue' in customType) {
-				value = customType.propertyToValue(value);
-			}
-	}
-	return value;
+          var hours = value.getUTCHours();
+          if (hours < 10) {
+            hours = '0' + hours;
+          }
+          var minutes = value.getUTCMinutes();
+          if (minutes < 10) {
+            minutes = '0' + minutes;
+          }
+          var seconds = value.getUTCSeconds();
+          if (seconds < 10) {
+            seconds = '0' + seconds;
+          }
+          var millis = value.getUTCMilliseconds();
+          if (millis < 10) {
+            millis = '0' + millis;
+          }
+          if (millis < 100) {
+            millis = '0' + millis;
+          }
+          strdate += ' ' + hours + ':' + minutes + ':' + seconds + '.' + millis + '000';
+          value = strdate;
+        }
+      }
+      break;
+    default:
+      customType = this.customTypes[property.type];
+      if(customType && 'propertyToValue' in customType) {
+        value = customType.propertyToValue(value);
+      }
+  }
+  return value;
 };
 
 Object.defineProperty(Driver.prototype, "isSql", {
@@ -358,11 +358,11 @@ Object.defineProperty(Driver.prototype, "isSql", {
 });
 
 function convertTimezone(tz) {
-	if (tz == "Z") return 0;
+  if (tz == "Z") return 0;
 
-	var m = tz.match(/([\+\-\s])(\d\d):?(\d\d)?/);
-	if (m) {
-		return (m[1] == '-' ? -1 : 1) * (parseInt(m[2], 10) + ((m[3] ? parseInt(m[3], 10) : 0) / 60)) * 60;
-	}
-	return false;
+  var m = tz.match(/([\+\-\s])(\d\d):?(\d\d)?/);
+  if (m) {
+    return (m[1] == '-' ? -1 : 1) * (parseInt(m[2], 10) + ((m[3] ? parseInt(m[3], 10) : 0) / 60)) * 60;
+  }
+  return false;
 }

--- a/lib/Drivers/aliases.js
+++ b/lib/Drivers/aliases.js
@@ -1,6 +1,6 @@
 module.exports = {
-	postgresql : "postgres",
-	pg         : "postgres",
+  postgresql : "postgres",
+  pg         : "postgres",
 
-	mongo      : "mongodb"
+  mongo      : "mongodb"
 };

--- a/lib/Error.js
+++ b/lib/Error.js
@@ -15,16 +15,16 @@ function ORMError(message, code, extras) {
 
   this.message = message;
   if (code) {
-  	this.code = codes[code];
+    this.code = codes[code];
     this.literalCode = code;
     if (!this.code) {
-  		throw new Error("Invalid error code: " +  code);
-  	}
+      throw new Error("Invalid error code: " +  code);
+    }
   }
   if (extras) {
-  	for(var k in extras) {
-  		this[k] = extras[k];
-  	}
+    for(var k in extras) {
+      this[k] = extras[k];
+    }
   }
 }
 

--- a/lib/Express.js
+++ b/lib/Express.js
@@ -5,71 +5,71 @@ var _pending = 0;
 var _queue   = [];
 
 module.exports = function (uri, opts) {
-	opts = opts || {};
+  opts = opts || {};
 
-	_pending += 1;
+  _pending += 1;
 
-	orm.connect(uri, function (err, db) {
-		if (err) {
-			if (typeof opts.error === "function") {
-				opts.error(err);
-			} else {
-				throw err;
-			}
+  orm.connect(uri, function (err, db) {
+    if (err) {
+      if (typeof opts.error === "function") {
+        opts.error(err);
+      } else {
+        throw err;
+      }
 
-			return checkRequestQueue();
-		}
+      return checkRequestQueue();
+    }
 
-		if (Array.isArray(_db)) {
-			_db.push(db);
-		} else if (_db !== null) {
-			_db = [ _db, db ];
-		} else {
-			_db = db;
-		}
+    if (Array.isArray(_db)) {
+      _db.push(db);
+    } else if (_db !== null) {
+      _db = [ _db, db ];
+    } else {
+      _db = db;
+    }
 
-		if (typeof opts.define === "function") {
-			if (opts.define.length > 2) {
-				return opts.define(db, _models, function () {
-					return checkRequestQueue();
-				});
-			}
+    if (typeof opts.define === "function") {
+      if (opts.define.length > 2) {
+        return opts.define(db, _models, function () {
+          return checkRequestQueue();
+        });
+      }
 
-			opts.define(db, _models);
-		}
+      opts.define(db, _models);
+    }
 
-		return checkRequestQueue();
-	});
+    return checkRequestQueue();
+  });
 
-	return function ORM_ExpressMiddleware(req, res, next) {
-		if (!req.hasOwnProperty("models")) {
-			req.models = _models;
-			req.db     = _db;
-		}
+  return function ORM_ExpressMiddleware(req, res, next) {
+    if (!req.hasOwnProperty("models")) {
+      req.models = _models;
+      req.db     = _db;
+    }
 
-		if (next === undefined && typeof res === 'function')
-		{
-			next = res;
-		}
+    if (next === undefined && typeof res === 'function')
+    {
+      next = res;
+    }
 
-		if (_pending > 0) {
-			_queue.push(next);
-			return;
-		}
+    if (_pending > 0) {
+      _queue.push(next);
+      return;
+    }
 
-		return next();
-	};
+    return next();
+  };
 };
 
 function checkRequestQueue() {
-	_pending -= 1;
+  _pending -= 1;
 
-	if (_pending > 0) return;
-	if (_queue.length === 0) return;
+  if (_pending > 0) return;
+  if (_queue.length === 0) return;
 
-	for (var i = 0; i < _queue.length; i++) {
-		_queue[i]();
-	}
+  for (var i = 0; i < _queue.length; i++) {
+    _queue[i]();
+  }
 
-	_queue.length = 0;
+  _queue.length = 0;
 }

--- a/lib/Hook.js
+++ b/lib/Hook.js
@@ -1,28 +1,28 @@
 exports.trigger = function () {
-	var args = Array.prototype.slice.apply(arguments);
-	var self = args.shift();
-	var cb   = args.shift();
+  var args = Array.prototype.slice.apply(arguments);
+  var self = args.shift();
+  var cb   = args.shift();
 
-	if (typeof cb === "function") {
-		cb.apply(self, args);
-	}
+  if (typeof cb === "function") {
+    cb.apply(self, args);
+  }
 };
 
 exports.wait = function () {
-	var args = Array.prototype.slice.apply(arguments);
-	var self = args.shift();
-	var cb   = args.shift();
-	var next = args.shift();
+  var args = Array.prototype.slice.apply(arguments);
+  var self = args.shift();
+  var cb   = args.shift();
+  var next = args.shift();
 
-	args.push(next);
+  args.push(next);
 
-	if (typeof cb === "function") {
-		cb.apply(self, args);
+  if (typeof cb === "function") {
+    cb.apply(self, args);
 
-		if (cb.length < args.length) {
-			return next();
-		}
-	} else {
-		return next();
-	}
+    if (cb.length < args.length) {
+      return next();
+    }
+  } else {
+    return next();
+  }
 };

--- a/lib/Instance.js
+++ b/lib/Instance.js
@@ -6,755 +6,755 @@ var enforce   = require("enforce");
 exports.Instance = Instance;
 
 function Instance(Model, opts) {
-	opts = opts || {};
-	opts.data = opts.data || {};
-	opts.extra = opts.extra || {};
-	opts.keys = opts.keys || "id";
-	opts.changes = (opts.is_new ? Object.keys(opts.data) : []);
-	opts.extrachanges = [];
-	opts.associations = {};
-	opts.originalKeyValues = {};
-
-	var instance_saving = false;
-	var events = {};
-	var instance = {};
-	var emitEvent = function () {
-		var args = Array.prototype.slice.apply(arguments);
-		var event = args.shift();
-
-		if (!events.hasOwnProperty(event)) return;
-
-		events[event].map(function (cb) {
-			cb.apply(instance, args);
-		});
-	};
-	var rememberKeys = function () {
-		var i, prop;
-
-		for(i = 0; i < opts.keyProperties.length; i++) {
-			prop = opts.keyProperties[i];
-			opts.originalKeyValues[prop.name] = opts.data[prop.name];
-		}
-	};
-	var shouldSaveAssocs = function (saveOptions) {
-		if (Model.settings.get("instance.saveAssociationsByDefault")) {
-			return saveOptions.saveAssociations !== false;
-		} else {
-			return !!saveOptions.saveAssociations;
-		}
-	};
-	var handleValidations = function (cb) {
-		var pending = [], errors = [], required, alwaysValidate;
-
-		Hook.wait(instance, opts.hooks.beforeValidation, function (err) {
-		    var k, i;
-			if (err) {
-				return saveError(cb, err);
-			}
-
-			var checks = new enforce.Enforce({
-				returnAllErrors : Model.settings.get("instance.returnAllErrors")
-			});
-
-			for (k in opts.validations) {
-				required = false;
-
-				if (Model.allProperties[k]) {
-					required = Model.allProperties[k].required;
-					alwaysValidate = Model.allProperties[k].alwaysValidate;
-				} else {
-					for (i = 0; i < opts.one_associations.length; i++) {
-						if (opts.one_associations[i].field === k) {
-							required = opts.one_associations[i].required;
-							break;
-						}
-					}
-				}
-				if (!alwaysValidate && !required && instance[k] == null) {
-					continue; // avoid validating if property is not required and is "empty"
-				}
-				for (i = 0; i < opts.validations[k].length; i++) {
-					checks.add(k, opts.validations[k][i]);
-				}
-			}
-
-			checks.context("instance", instance);
-			checks.context("model", Model);
-			checks.context("driver", opts.driver);
-
-			return checks.check(instance, cb);
-		});
-	};
-	var saveError = function (cb, err) {
-		instance_saving = false;
-
-		emitEvent("save", err, instance);
-
-		Hook.trigger(instance, opts.hooks.afterSave, false);
-
-		if (typeof cb === "function") {
-			cb(err, instance);
-		}
-	};
-	var saveInstance = function (saveOptions, cb) {
-		// what this condition means:
-		// - If the instance is in state mode
-		// - AND it's not an association that is asking it to save
-		//   -> return has already saved
-		if (instance_saving && saveOptions.saveAssociations !== false) {
-			return cb(null, instance);
-		}
-		instance_saving = true;
-
-		handleValidations(function (err) {
-			if (err) {
-				return saveError(cb, err);
-			}
-
-			if (opts.is_new) {
-				waitHooks([ "beforeCreate", "beforeSave" ], function (err) {
-					if (err) {
-						return saveError(cb, err);
-					}
-
-					return saveNew(saveOptions, getInstanceData(), cb);
-				});
-			} else {
-				waitHooks([ "beforeSave" ], function (err) {
-					if (err) {
-						return saveError(cb, err);
-					}
-
-					return savePersisted(saveOptions, getInstanceData(), cb);
-				});
-			}
-		});
-	};
-	var runAfterSaveActions = function (cb, create, err) {
-		instance_saving = false;
-
-		emitEvent("save", err, instance);
-
-		if (create) {
-			Hook.trigger(instance, opts.hooks.afterCreate, !err);
-		}
-		Hook.trigger(instance, opts.hooks.afterSave, !err);
-
-		cb();
-	};
-	var getInstanceData = function () {
-		var data = {}, prop;
-		for (var k in opts.data) {
-			if (!opts.data.hasOwnProperty(k)) continue;
-			prop = Model.allProperties[k];
-
-			if (prop) {
-				if (opts.data[k] == null &&  (prop.type == 'serial' || typeof prop.defaultValue == 'function')) {
-					continue;
-				}
-
-				if (opts.driver.propertyToValue) {
-					data[k] = opts.driver.propertyToValue(opts.data[k], prop);
-				} else {
-					data[k] = opts.data[k];
-				}
-			} else {
-				data[k] = opts.data[k];
-			}
-		}
-
-		return data;
-	};
-	var waitHooks = function (hooks, next) {
-		var nextHook = function () {
-			if (hooks.length === 0) {
-				return next();
-			}
-			Hook.wait(instance, opts.hooks[hooks.shift()], function (err) {
-				if (err) {
-					return next(err);
-				}
-
-				return nextHook();
-			});
-		};
-
-		return nextHook();
-	};
-	var saveNew = function (saveOptions, data, cb) {
-		var i, prop;
-
-		var finish = function (err) {
-			runAfterSaveActions(function () {
-				if (err) return cb(err);
-				saveInstanceExtra(cb);
-			}, true);
-		}
-
-		data = Utilities.transformPropertyNames(data, Model.allProperties);
-
-		opts.driver.insert(opts.table, data, opts.keyProperties, function (save_err, info) {
-			if (save_err) {
-				return saveError(cb, save_err);
-			}
-
-			opts.changes.length = 0;
-
-			for (i = 0; i < opts.keyProperties.length; i++) {
-				prop = opts.keyProperties[i];
-				opts.data[prop.name] = info.hasOwnProperty(prop.name) ? info[prop.name] : data[prop.name];
-			}
-			opts.is_new = false;
-			rememberKeys();
-
-			if (!shouldSaveAssocs(saveOptions)) {
-				return finish();
-			}
-
-			return saveAssociations(finish);
-		});
-	};
-	var savePersisted = function (saveOptions, data, cb) {
-		var changes = {}, conditions = {}, i, prop;
-
-		var next = function (saved) {
-			var finish = function () {
-				saveInstanceExtra(cb);
-			}
-
-			if(!saved && !shouldSaveAssocs(saveOptions)) {
-				finish();
-			} else {
-				if (!shouldSaveAssocs(saveOptions)) {
-					runAfterSaveActions(function () {
-						finish();
-					}, false);
-				} else {
-					saveAssociations(function (err, assocSaved) {
-						if (saved || assocSaved) {
-							runAfterSaveActions(function () {
-								if (err) return cb(err);
-								finish();
-							}, false, err);
-						} else {
-							finish();
-						}
-					});
-				}
-			}
-		}
-
-		if (opts.changes.length === 0) {
-			next(false);
-		} else {
-			for (i = 0; i < opts.changes.length; i++) {
-				changes[opts.changes[i]] = data[opts.changes[i]];
-			}
-			for (i = 0; i < opts.keyProperties.length; i++) {
-				prop = opts.keyProperties[i];
-				conditions[prop.mapsTo] = opts.originalKeyValues[prop.name];
-			}
-			changes = Utilities.transformPropertyNames(changes, Model.allProperties);
-
-			opts.driver.update(opts.table, changes, conditions, function (err) {
-				if (err) {
-					return saveError(cb, err);
-				}
-				opts.changes.length = 0;
-				rememberKeys();
-
-				next(true);
-			});
-		}
-	};
-	var saveAssociations = function (cb) {
-		var pending = 1, errored = false, i, j;
-		var saveAssociation = function (accessor, instances) {
-			pending += 1;
-
-			instance[accessor](instances, function (err) {
-				if (err) {
-					if (errored) return;
-
-					errored = true;
-					return cb(err, true);
-				}
-
-				if (--pending === 0) {
-					return cb(null, true);
-				}
-			});
-		};
-
-		var _saveOneAssociation = function (assoc) {
-			if (!instance[assoc.name] || typeof instance[assoc.name] !== "object") return;
-			if (assoc.reversed) {
-				// reversed hasOne associations should behave like hasMany
-				if (!Array.isArray(instance[assoc.name])) {
-					instance[assoc.name] = [ instance[assoc.name] ];
-				}
-				for (var i = 0; i < instance[assoc.name].length; i++) {
-					if (!instance[assoc.name][i].isInstance) {
-						instance[assoc.name][i] = new assoc.model(instance[assoc.name][i]);
-					}
-					saveAssociation(assoc.setAccessor, instance[assoc.name][i]);
-				}
-				return;
-			}
-			if (!instance[assoc.name].isInstance) {
-			  instance[assoc.name] = new assoc.model(instance[assoc.name]);
-			}
-
-			saveAssociation(assoc.setAccessor, instance[assoc.name]);
-		};
-
-		for (i = 0; i < opts.one_associations.length; i++) {
-			_saveOneAssociation(opts.one_associations[i]);
-		}
-
-
-		var _saveManyAssociation = function (assoc) {
-			var assocVal = instance[assoc.name];
-
-			if (!Array.isArray(assocVal)) return;
-			if (!opts.associations[assoc.name].changed) return;
-
-			for (j = 0; j < assocVal.length; j++) {
-				if (!assocVal[j].isInstance) {
-					assocVal[j] = new assoc.model(assocVal[j]);
-				}
-			}
-
-			saveAssociation(assoc.setAccessor, assocVal);
-		};
-
-		for (i = 0; i < opts.many_associations.length; i++) {
-			_saveManyAssociation(opts.many_associations[i]);
-		}
-
-		if (--pending === 0) {
-			return cb(null, false);
-		}
-	};
-	var saveInstanceExtra = function (cb) {
-		if (opts.extrachanges.length === 0) {
-			if (cb) return cb(null, instance);
-			else return;
-		}
-
-		var data = {};
-		var conditions = {};
-
-		for (var i = 0; i < opts.extrachanges.length; i++) {
-			if (!opts.data.hasOwnProperty(opts.extrachanges[i])) continue;
-
-			if (opts.extra[opts.extrachanges[i]]) {
-				data[opts.extrachanges[i]] = opts.data[opts.extrachanges[i]];
-				if (opts.driver.propertyToValue) {
-					data[opts.extrachanges[i]] = opts.driver.propertyToValue(data[opts.extrachanges[i]], opts.extra[opts.extrachanges[i]]);
-				}
-			} else {
-				data[opts.extrachanges[i]] = opts.data[opts.extrachanges[i]];
-			}
-		}
-
-		for (i = 0; i < opts.extra_info.id.length; i++) {
-			conditions[opts.extra_info.id_prop[i]] = opts.extra_info.id[i];
-			conditions[opts.extra_info.assoc_prop[i]] = opts.data[opts.keys[i]];
-		}
-
-		opts.driver.update(opts.extra_info.table, data, conditions, function (err) {
-			return cb(err);
-		});
-	};
-	var removeInstance = function (cb) {
-		if (opts.is_new) {
-			return cb(null);
-		}
-
-		var conditions = {};
-		for (var i = 0; i < opts.keys.length; i++) {
-		    conditions[opts.keys[i]] = opts.data[opts.keys[i]];
-		}
-
-		Hook.wait(instance, opts.hooks.beforeRemove, function (err) {
-			if (err) {
-				emitEvent("remove", err, instance);
-				if (typeof cb === "function") {
-					cb(err, instance);
-				}
-				return;
-			}
-
-			emitEvent("beforeRemove", instance);
-
-			opts.driver.remove(opts.table, conditions, function (err, data) {
-				Hook.trigger(instance, opts.hooks.afterRemove, !err);
-
-				emitEvent("remove", err, instance);
-
-				if (typeof cb === "function") {
-					cb(err, instance);
-				}
-
-				instance = undefined;
-			});
-		});
-	};
-	var saveInstanceProperty = function (key, value) {
-		var changes = {}, conditions = {};
-		changes[key] = value;
-
-		if (Model.properties[key]) {
-			if (opts.driver.propertyToValue) {
-				changes[key] = opts.driver.propertyToValue(changes[key], Model.properties[key]);
-			}
-		}
-
-		for (var i = 0; i < opts.keys.length; i++) {
-			conditions[opts.keys[i]] = opts.data[opts.keys[i]];
-		}
-
-		Hook.wait(instance, opts.hooks.beforeSave, function (err) {
-			if (err) {
-				Hook.trigger(instance, opts.hooks.afterSave, false);
-				emitEvent("save", err, instance);
-				return;
-			}
-
-			opts.driver.update(opts.table, changes, conditions, function (err) {
-				if (!err) {
-					opts.data[key] = value;
-				}
-				Hook.trigger(instance, opts.hooks.afterSave, !err);
-				emitEvent("save", err, instance);
-			});
-		});
-	};
-	var setInstanceProperty = function (key, value) {
-		var prop = Model.allProperties[key] || opts.extra[key];
-
-		if (prop) {
-			if ('valueToProperty' in opts.driver) {
-				value = opts.driver.valueToProperty(value, prop);
-			}
-			if (opts.data[key] !== value) {
-				opts.data[key] = value;
-				return true;
-			}
-		}
-		return false;
-	}
-
-	// ('data.a.b', 5) => opts.data.a.b = 5
-	var setPropertyByPath = function (path, value) {
-		if (typeof path == 'string') {
-			path = path.split('.');
-		} else if (!Array.isArray(path)) {
-			return;
-		}
-
-		var propName = path.shift();
-		var prop = Model.allProperties[propName] || opts.extra[propName];
-		var currKey, currObj;
-
-		if (!prop) {
-			return;
-		}
-		if (path.length == 0) {
-			instance[propName] = value;
-			return;
-		}
-		currObj = instance[propName];
-
-		while(currObj && path.length > 0 ) {
-			currKey = path.shift();
-
-			if (path.length > 0) {
-				currObj = currObj[currKey];
-			} else if (currObj[currKey] !== value) {
-				currObj[currKey] = value;
-				opts.changes.push(propName);
-			}
-		}
-	}
-
-	var addInstanceProperty = function (key) {
-		var defaultValue = null;
-		var prop = Model.allProperties[key];
-
-		// This code was first added, and then commented out in a later commit.
-		// Its presence doesn't affect tests, so I'm just gonna log if it ever gets called.
-		// If someone complains about noise, we know it does something, and figure it out then.
-		if (instance.hasOwnProperty(key)) console.log("Overwriting instance property");
-
-		if (key in opts.data) {
-			defaultValue = opts.data[key];
-		} else if (prop && 'defaultValue' in prop) {
-			defaultValue = prop.defaultValue;
-		}
-
-		setInstanceProperty(key, defaultValue);
-
-		Object.defineProperty(instance, key, {
-			get: function () {
-				return opts.data[key];
-			},
-			set: function (val) {
-				if (prop.key === true) {
-					if (prop.type == 'serial' && opts.data[key] != null) {
-						return;
-					} else {
-						opts.originalKeyValues[prop.name] = opts.data[prop.name];
-					}
-				}
-
-				if (!setInstanceProperty(key, val)) {
-					return;
-				}
-
-				if (opts.autoSave) {
-					saveInstanceProperty(key, val);
-				} else if (opts.changes.indexOf(key) === -1) {
-					opts.changes.push(key);
-				}
-			},
-			enumerable: !(prop && !prop.enumerable)
-		});
-	};
-	var addInstanceExtraProperty = function (key) {
-		if (!instance.hasOwnProperty("extra")) {
-			instance.extra = {};
-		}
-		Object.defineProperty(instance.extra, key, {
-			get: function () {
-				return opts.data[key];
-			},
-			set: function (val) {
-				setInstanceProperty(key, val);
-
-				/*if (opts.autoSave) {
-					saveInstanceProperty(key, val);
-				}*/if (opts.extrachanges.indexOf(key) === -1) {
-					opts.extrachanges.push(key);
-				}
-			},
-			enumerable: true
-		});
-	};
-
-	var i, k;
-
-	for (k in Model.allProperties) {
-		addInstanceProperty(k);
-	}
-	for (k in opts.extra) {
-		addInstanceProperty(k);
-	}
-
-	for (k in opts.methods) {
-		Object.defineProperty(instance, k, {
-			value      : opts.methods[k].bind(instance),
-			enumerable : false,
-			writable  : true
-		});
-	}
-
-	for (k in opts.extra) {
-		addInstanceExtraProperty(k);
-	}
-
-	Object.defineProperty(instance, "on", {
-		value: function (event, cb) {
-			if (!events.hasOwnProperty(event)) {
-				events[event] = [];
-			}
-			events[event].push(cb);
-
-			return this;
-		},
-		enumerable: false,
-		writable: true
-	});
-	Object.defineProperty(instance, "save", {
-		value: function () {
-			var arg = null, objCount = 0;
-			var data = {}, saveOptions = {}, cb = null;
-
-			while (arguments.length > 0) {
-				arg = Array.prototype.shift.call(arguments);
-
-				switch (typeof arg) {
-					case 'object':
-						switch (objCount) {
-							case 0:
-								data = arg;
-								break;
-							case 1:
-								saveOptions = arg;
-								break;
-						}
-						objCount++;
-						break;
-					case 'function':
-						cb = arg;
-						break;
-					default:
-					    var err = new Error("Unknown parameter type '" + (typeof arg) + "' in Instance.save()");
-					    err.model = Model.table;
-					    throw err;
-				}
-			}
-
-			for (var k in data) {
-				if (data.hasOwnProperty(k)) {
-					this[k] = data[k];
-				}
-			}
-
-			saveInstance(saveOptions, function (err) {
-				if (!cb) return;
-				if (err) return cb(err);
-
-				return cb(null, instance);
-			});
-
-			return this;
-		},
-		enumerable: false,
-		writable: true
-	});
-	Object.defineProperty(instance, "saved", {
-		value: function () {
-			return opts.changes.length === 0;
-		},
-		enumerable: false,
-		writable: true
-	});
-	Object.defineProperty(instance, "remove", {
-		value: function (cb) {
-			removeInstance(cb);
-
-			return this;
-		},
-		enumerable: false,
-		writable: true
-	});
-	Object.defineProperty(instance, "set", {
-		value: setPropertyByPath,
-		enumerable: false,
-		writable: true
-	});
-	Object.defineProperty(instance, "markAsDirty", {
-		value: function (propName) {
-			if (propName != undefined) {
-				opts.changes.push(propName);
-			}
-		},
-		enumerable: false,
-		writable: true
-	});
-	Object.defineProperty(instance, "dirtyProperties", {
-		get: function () { return opts.changes; },
-		enumerable: false
-	});
-	Object.defineProperty(instance, "isInstance", {
-		value: true,
-		enumerable: false
-	});
-	Object.defineProperty(instance, "isPersisted", {
-		value: function () {
-			return !opts.is_new;
-		},
-		enumerable: false,
-		writable: true
-	});
-	Object.defineProperty(instance, "isShell", {
-		value: function () {
-			return opts.isShell;
-		},
-		enumerable: false
-	});
-	Object.defineProperty(instance, "validate", {
-		value: function (cb) {
-			handleValidations(function (errors) {
-				cb(null, errors || false);
-			});
-		},
-		enumerable: false,
-		writable: true
-	});
-	Object.defineProperty(instance, "__singleton_uid", {
-		value: function (cb) {
-			return opts.uid;
-		},
-		enumerable: false
-	});
-	Object.defineProperty(instance, "__opts", {
-		value: opts,
-		enumerable: false
-	});
-	Object.defineProperty(instance, "model", {
-		value: function (cb) {
-			return Model;
-		},
-		enumerable: false
-	});
-
-	for (i = 0; i < opts.keyProperties.length; i++) {
-		var prop = opts.keyProperties[i];
-
-		if (!(prop.name in opts.data)) {
-			opts.changes = Object.keys(opts.data);
-			break;
-		}
-	}
-	rememberKeys();
-
-	opts.setupAssociations(instance);
-
-	for (i = 0; i < opts.one_associations.length; i++) {
-		var asc = opts.one_associations[i];
-
-		if (!asc.reversed && !asc.extension) {
-			for (k in asc.field) {
-				if (!opts.data.hasOwnProperty(k)) {
-					addInstanceProperty(k);
-				}
-			}
-		}
-
-		if (asc.name in opts.data) {
-			var d = opts.data[asc.name];
-			var mapper = function (obj) {
-				return obj.isInstance ? obj : new asc.model(obj);
-			};
-
-			if (Array.isArray(d)) {
-				instance[asc.name] = d.map(mapper);
-			} else {
-				instance[asc.name] = mapper(d);
-			}
-			delete opts.data[asc.name];
-		}
-	}
-	for (i = 0; i < opts.many_associations.length; i++) {
-		var aName = opts.many_associations[i].name;
-		opts.associations[aName] = {
-			changed: false, data: opts.many_associations[i]
-		};
-
-		if (Array.isArray(opts.data[aName])) {
-			instance[aName] = opts.data[aName];
-			delete opts.data[aName];
-		}
-	}
-
-	Hook.wait(instance, opts.hooks.afterLoad, function (err) {
-		process.nextTick(function () {
-			emitEvent("ready", err);
-		});
-	});
-
-	return instance;
+  opts = opts || {};
+  opts.data = opts.data || {};
+  opts.extra = opts.extra || {};
+  opts.keys = opts.keys || "id";
+  opts.changes = (opts.is_new ? Object.keys(opts.data) : []);
+  opts.extrachanges = [];
+  opts.associations = {};
+  opts.originalKeyValues = {};
+
+  var instance_saving = false;
+  var events = {};
+  var instance = {};
+  var emitEvent = function () {
+    var args = Array.prototype.slice.apply(arguments);
+    var event = args.shift();
+
+    if (!events.hasOwnProperty(event)) return;
+
+    events[event].map(function (cb) {
+      cb.apply(instance, args);
+    });
+  };
+  var rememberKeys = function () {
+    var i, prop;
+
+    for(i = 0; i < opts.keyProperties.length; i++) {
+      prop = opts.keyProperties[i];
+      opts.originalKeyValues[prop.name] = opts.data[prop.name];
+    }
+  };
+  var shouldSaveAssocs = function (saveOptions) {
+    if (Model.settings.get("instance.saveAssociationsByDefault")) {
+      return saveOptions.saveAssociations !== false;
+    } else {
+      return !!saveOptions.saveAssociations;
+    }
+  };
+  var handleValidations = function (cb) {
+    var pending = [], errors = [], required, alwaysValidate;
+
+    Hook.wait(instance, opts.hooks.beforeValidation, function (err) {
+        var k, i;
+      if (err) {
+        return saveError(cb, err);
+      }
+
+      var checks = new enforce.Enforce({
+        returnAllErrors : Model.settings.get("instance.returnAllErrors")
+      });
+
+      for (k in opts.validations) {
+        required = false;
+
+        if (Model.allProperties[k]) {
+          required = Model.allProperties[k].required;
+          alwaysValidate = Model.allProperties[k].alwaysValidate;
+        } else {
+          for (i = 0; i < opts.one_associations.length; i++) {
+            if (opts.one_associations[i].field === k) {
+              required = opts.one_associations[i].required;
+              break;
+            }
+          }
+        }
+        if (!alwaysValidate && !required && instance[k] == null) {
+          continue; // avoid validating if property is not required and is "empty"
+        }
+        for (i = 0; i < opts.validations[k].length; i++) {
+          checks.add(k, opts.validations[k][i]);
+        }
+      }
+
+      checks.context("instance", instance);
+      checks.context("model", Model);
+      checks.context("driver", opts.driver);
+
+      return checks.check(instance, cb);
+    });
+  };
+  var saveError = function (cb, err) {
+    instance_saving = false;
+
+    emitEvent("save", err, instance);
+
+    Hook.trigger(instance, opts.hooks.afterSave, false);
+
+    if (typeof cb === "function") {
+      cb(err, instance);
+    }
+  };
+  var saveInstance = function (saveOptions, cb) {
+    // what this condition means:
+    // - If the instance is in state mode
+    // - AND it's not an association that is asking it to save
+    //   -> return has already saved
+    if (instance_saving && saveOptions.saveAssociations !== false) {
+      return cb(null, instance);
+    }
+    instance_saving = true;
+
+    handleValidations(function (err) {
+      if (err) {
+        return saveError(cb, err);
+      }
+
+      if (opts.is_new) {
+        waitHooks([ "beforeCreate", "beforeSave" ], function (err) {
+          if (err) {
+            return saveError(cb, err);
+          }
+
+          return saveNew(saveOptions, getInstanceData(), cb);
+        });
+      } else {
+        waitHooks([ "beforeSave" ], function (err) {
+          if (err) {
+            return saveError(cb, err);
+          }
+
+          return savePersisted(saveOptions, getInstanceData(), cb);
+        });
+      }
+    });
+  };
+  var runAfterSaveActions = function (cb, create, err) {
+    instance_saving = false;
+
+    emitEvent("save", err, instance);
+
+    if (create) {
+      Hook.trigger(instance, opts.hooks.afterCreate, !err);
+    }
+    Hook.trigger(instance, opts.hooks.afterSave, !err);
+
+    cb();
+  };
+  var getInstanceData = function () {
+    var data = {}, prop;
+    for (var k in opts.data) {
+      if (!opts.data.hasOwnProperty(k)) continue;
+      prop = Model.allProperties[k];
+
+      if (prop) {
+        if (opts.data[k] == null &&  (prop.type == 'serial' || typeof prop.defaultValue == 'function')) {
+          continue;
+        }
+
+        if (opts.driver.propertyToValue) {
+          data[k] = opts.driver.propertyToValue(opts.data[k], prop);
+        } else {
+          data[k] = opts.data[k];
+        }
+      } else {
+        data[k] = opts.data[k];
+      }
+    }
+
+    return data;
+  };
+  var waitHooks = function (hooks, next) {
+    var nextHook = function () {
+      if (hooks.length === 0) {
+        return next();
+      }
+      Hook.wait(instance, opts.hooks[hooks.shift()], function (err) {
+        if (err) {
+          return next(err);
+        }
+
+        return nextHook();
+      });
+    };
+
+    return nextHook();
+  };
+  var saveNew = function (saveOptions, data, cb) {
+    var i, prop;
+
+    var finish = function (err) {
+      runAfterSaveActions(function () {
+        if (err) return cb(err);
+        saveInstanceExtra(cb);
+      }, true);
+    }
+
+    data = Utilities.transformPropertyNames(data, Model.allProperties);
+
+    opts.driver.insert(opts.table, data, opts.keyProperties, function (save_err, info) {
+      if (save_err) {
+        return saveError(cb, save_err);
+      }
+
+      opts.changes.length = 0;
+
+      for (i = 0; i < opts.keyProperties.length; i++) {
+        prop = opts.keyProperties[i];
+        opts.data[prop.name] = info.hasOwnProperty(prop.name) ? info[prop.name] : data[prop.name];
+      }
+      opts.is_new = false;
+      rememberKeys();
+
+      if (!shouldSaveAssocs(saveOptions)) {
+        return finish();
+      }
+
+      return saveAssociations(finish);
+    });
+  };
+  var savePersisted = function (saveOptions, data, cb) {
+    var changes = {}, conditions = {}, i, prop;
+
+    var next = function (saved) {
+      var finish = function () {
+        saveInstanceExtra(cb);
+      }
+
+      if(!saved && !shouldSaveAssocs(saveOptions)) {
+        finish();
+      } else {
+        if (!shouldSaveAssocs(saveOptions)) {
+          runAfterSaveActions(function () {
+            finish();
+          }, false);
+        } else {
+          saveAssociations(function (err, assocSaved) {
+            if (saved || assocSaved) {
+              runAfterSaveActions(function () {
+                if (err) return cb(err);
+                finish();
+              }, false, err);
+            } else {
+              finish();
+            }
+          });
+        }
+      }
+    }
+
+    if (opts.changes.length === 0) {
+      next(false);
+    } else {
+      for (i = 0; i < opts.changes.length; i++) {
+        changes[opts.changes[i]] = data[opts.changes[i]];
+      }
+      for (i = 0; i < opts.keyProperties.length; i++) {
+        prop = opts.keyProperties[i];
+        conditions[prop.mapsTo] = opts.originalKeyValues[prop.name];
+      }
+      changes = Utilities.transformPropertyNames(changes, Model.allProperties);
+
+      opts.driver.update(opts.table, changes, conditions, function (err) {
+        if (err) {
+          return saveError(cb, err);
+        }
+        opts.changes.length = 0;
+        rememberKeys();
+
+        next(true);
+      });
+    }
+  };
+  var saveAssociations = function (cb) {
+    var pending = 1, errored = false, i, j;
+    var saveAssociation = function (accessor, instances) {
+      pending += 1;
+
+      instance[accessor](instances, function (err) {
+        if (err) {
+          if (errored) return;
+
+          errored = true;
+          return cb(err, true);
+        }
+
+        if (--pending === 0) {
+          return cb(null, true);
+        }
+      });
+    };
+
+    var _saveOneAssociation = function (assoc) {
+      if (!instance[assoc.name] || typeof instance[assoc.name] !== "object") return;
+      if (assoc.reversed) {
+        // reversed hasOne associations should behave like hasMany
+        if (!Array.isArray(instance[assoc.name])) {
+          instance[assoc.name] = [ instance[assoc.name] ];
+        }
+        for (var i = 0; i < instance[assoc.name].length; i++) {
+          if (!instance[assoc.name][i].isInstance) {
+            instance[assoc.name][i] = new assoc.model(instance[assoc.name][i]);
+          }
+          saveAssociation(assoc.setAccessor, instance[assoc.name][i]);
+        }
+        return;
+      }
+      if (!instance[assoc.name].isInstance) {
+        instance[assoc.name] = new assoc.model(instance[assoc.name]);
+      }
+
+      saveAssociation(assoc.setAccessor, instance[assoc.name]);
+    };
+
+    for (i = 0; i < opts.one_associations.length; i++) {
+      _saveOneAssociation(opts.one_associations[i]);
+    }
+
+
+    var _saveManyAssociation = function (assoc) {
+      var assocVal = instance[assoc.name];
+
+      if (!Array.isArray(assocVal)) return;
+      if (!opts.associations[assoc.name].changed) return;
+
+      for (j = 0; j < assocVal.length; j++) {
+        if (!assocVal[j].isInstance) {
+          assocVal[j] = new assoc.model(assocVal[j]);
+        }
+      }
+
+      saveAssociation(assoc.setAccessor, assocVal);
+    };
+
+    for (i = 0; i < opts.many_associations.length; i++) {
+      _saveManyAssociation(opts.many_associations[i]);
+    }
+
+    if (--pending === 0) {
+      return cb(null, false);
+    }
+  };
+  var saveInstanceExtra = function (cb) {
+    if (opts.extrachanges.length === 0) {
+      if (cb) return cb(null, instance);
+      else return;
+    }
+
+    var data = {};
+    var conditions = {};
+
+    for (var i = 0; i < opts.extrachanges.length; i++) {
+      if (!opts.data.hasOwnProperty(opts.extrachanges[i])) continue;
+
+      if (opts.extra[opts.extrachanges[i]]) {
+        data[opts.extrachanges[i]] = opts.data[opts.extrachanges[i]];
+        if (opts.driver.propertyToValue) {
+          data[opts.extrachanges[i]] = opts.driver.propertyToValue(data[opts.extrachanges[i]], opts.extra[opts.extrachanges[i]]);
+        }
+      } else {
+        data[opts.extrachanges[i]] = opts.data[opts.extrachanges[i]];
+      }
+    }
+
+    for (i = 0; i < opts.extra_info.id.length; i++) {
+      conditions[opts.extra_info.id_prop[i]] = opts.extra_info.id[i];
+      conditions[opts.extra_info.assoc_prop[i]] = opts.data[opts.keys[i]];
+    }
+
+    opts.driver.update(opts.extra_info.table, data, conditions, function (err) {
+      return cb(err);
+    });
+  };
+  var removeInstance = function (cb) {
+    if (opts.is_new) {
+      return cb(null);
+    }
+
+    var conditions = {};
+    for (var i = 0; i < opts.keys.length; i++) {
+        conditions[opts.keys[i]] = opts.data[opts.keys[i]];
+    }
+
+    Hook.wait(instance, opts.hooks.beforeRemove, function (err) {
+      if (err) {
+        emitEvent("remove", err, instance);
+        if (typeof cb === "function") {
+          cb(err, instance);
+        }
+        return;
+      }
+
+      emitEvent("beforeRemove", instance);
+
+      opts.driver.remove(opts.table, conditions, function (err, data) {
+        Hook.trigger(instance, opts.hooks.afterRemove, !err);
+
+        emitEvent("remove", err, instance);
+
+        if (typeof cb === "function") {
+          cb(err, instance);
+        }
+
+        instance = undefined;
+      });
+    });
+  };
+  var saveInstanceProperty = function (key, value) {
+    var changes = {}, conditions = {};
+    changes[key] = value;
+
+    if (Model.properties[key]) {
+      if (opts.driver.propertyToValue) {
+        changes[key] = opts.driver.propertyToValue(changes[key], Model.properties[key]);
+      }
+    }
+
+    for (var i = 0; i < opts.keys.length; i++) {
+      conditions[opts.keys[i]] = opts.data[opts.keys[i]];
+    }
+
+    Hook.wait(instance, opts.hooks.beforeSave, function (err) {
+      if (err) {
+        Hook.trigger(instance, opts.hooks.afterSave, false);
+        emitEvent("save", err, instance);
+        return;
+      }
+
+      opts.driver.update(opts.table, changes, conditions, function (err) {
+        if (!err) {
+          opts.data[key] = value;
+        }
+        Hook.trigger(instance, opts.hooks.afterSave, !err);
+        emitEvent("save", err, instance);
+      });
+    });
+  };
+  var setInstanceProperty = function (key, value) {
+    var prop = Model.allProperties[key] || opts.extra[key];
+
+    if (prop) {
+      if ('valueToProperty' in opts.driver) {
+        value = opts.driver.valueToProperty(value, prop);
+      }
+      if (opts.data[key] !== value) {
+        opts.data[key] = value;
+        return true;
+      }
+    }
+    return false;
+  }
+
+  // ('data.a.b', 5) => opts.data.a.b = 5
+  var setPropertyByPath = function (path, value) {
+    if (typeof path == 'string') {
+      path = path.split('.');
+    } else if (!Array.isArray(path)) {
+      return;
+    }
+
+    var propName = path.shift();
+    var prop = Model.allProperties[propName] || opts.extra[propName];
+    var currKey, currObj;
+
+    if (!prop) {
+      return;
+    }
+    if (path.length == 0) {
+      instance[propName] = value;
+      return;
+    }
+    currObj = instance[propName];
+
+    while(currObj && path.length > 0 ) {
+      currKey = path.shift();
+
+      if (path.length > 0) {
+        currObj = currObj[currKey];
+      } else if (currObj[currKey] !== value) {
+        currObj[currKey] = value;
+        opts.changes.push(propName);
+      }
+    }
+  }
+
+  var addInstanceProperty = function (key) {
+    var defaultValue = null;
+    var prop = Model.allProperties[key];
+
+    // This code was first added, and then commented out in a later commit.
+    // Its presence doesn't affect tests, so I'm just gonna log if it ever gets called.
+    // If someone complains about noise, we know it does something, and figure it out then.
+    if (instance.hasOwnProperty(key)) console.log("Overwriting instance property");
+
+    if (key in opts.data) {
+      defaultValue = opts.data[key];
+    } else if (prop && 'defaultValue' in prop) {
+      defaultValue = prop.defaultValue;
+    }
+
+    setInstanceProperty(key, defaultValue);
+
+    Object.defineProperty(instance, key, {
+      get: function () {
+        return opts.data[key];
+      },
+      set: function (val) {
+        if (prop.key === true) {
+          if (prop.type == 'serial' && opts.data[key] != null) {
+            return;
+          } else {
+            opts.originalKeyValues[prop.name] = opts.data[prop.name];
+          }
+        }
+
+        if (!setInstanceProperty(key, val)) {
+          return;
+        }
+
+        if (opts.autoSave) {
+          saveInstanceProperty(key, val);
+        } else if (opts.changes.indexOf(key) === -1) {
+          opts.changes.push(key);
+        }
+      },
+      enumerable: !(prop && !prop.enumerable)
+    });
+  };
+  var addInstanceExtraProperty = function (key) {
+    if (!instance.hasOwnProperty("extra")) {
+      instance.extra = {};
+    }
+    Object.defineProperty(instance.extra, key, {
+      get: function () {
+        return opts.data[key];
+      },
+      set: function (val) {
+        setInstanceProperty(key, val);
+
+        /*if (opts.autoSave) {
+          saveInstanceProperty(key, val);
+        }*/if (opts.extrachanges.indexOf(key) === -1) {
+          opts.extrachanges.push(key);
+        }
+      },
+      enumerable: true
+    });
+  };
+
+  var i, k;
+
+  for (k in Model.allProperties) {
+    addInstanceProperty(k);
+  }
+  for (k in opts.extra) {
+    addInstanceProperty(k);
+  }
+
+  for (k in opts.methods) {
+    Object.defineProperty(instance, k, {
+      value      : opts.methods[k].bind(instance),
+      enumerable : false,
+      writable  : true
+    });
+  }
+
+  for (k in opts.extra) {
+    addInstanceExtraProperty(k);
+  }
+
+  Object.defineProperty(instance, "on", {
+    value: function (event, cb) {
+      if (!events.hasOwnProperty(event)) {
+        events[event] = [];
+      }
+      events[event].push(cb);
+
+      return this;
+    },
+    enumerable: false,
+    writable: true
+  });
+  Object.defineProperty(instance, "save", {
+    value: function () {
+      var arg = null, objCount = 0;
+      var data = {}, saveOptions = {}, cb = null;
+
+      while (arguments.length > 0) {
+        arg = Array.prototype.shift.call(arguments);
+
+        switch (typeof arg) {
+          case 'object':
+            switch (objCount) {
+              case 0:
+                data = arg;
+                break;
+              case 1:
+                saveOptions = arg;
+                break;
+            }
+            objCount++;
+            break;
+          case 'function':
+            cb = arg;
+            break;
+          default:
+              var err = new Error("Unknown parameter type '" + (typeof arg) + "' in Instance.save()");
+              err.model = Model.table;
+              throw err;
+        }
+      }
+
+      for (var k in data) {
+        if (data.hasOwnProperty(k)) {
+          this[k] = data[k];
+        }
+      }
+
+      saveInstance(saveOptions, function (err) {
+        if (!cb) return;
+        if (err) return cb(err);
+
+        return cb(null, instance);
+      });
+
+      return this;
+    },
+    enumerable: false,
+    writable: true
+  });
+  Object.defineProperty(instance, "saved", {
+    value: function () {
+      return opts.changes.length === 0;
+    },
+    enumerable: false,
+    writable: true
+  });
+  Object.defineProperty(instance, "remove", {
+    value: function (cb) {
+      removeInstance(cb);
+
+      return this;
+    },
+    enumerable: false,
+    writable: true
+  });
+  Object.defineProperty(instance, "set", {
+    value: setPropertyByPath,
+    enumerable: false,
+    writable: true
+  });
+  Object.defineProperty(instance, "markAsDirty", {
+    value: function (propName) {
+      if (propName != undefined) {
+        opts.changes.push(propName);
+      }
+    },
+    enumerable: false,
+    writable: true
+  });
+  Object.defineProperty(instance, "dirtyProperties", {
+    get: function () { return opts.changes; },
+    enumerable: false
+  });
+  Object.defineProperty(instance, "isInstance", {
+    value: true,
+    enumerable: false
+  });
+  Object.defineProperty(instance, "isPersisted", {
+    value: function () {
+      return !opts.is_new;
+    },
+    enumerable: false,
+    writable: true
+  });
+  Object.defineProperty(instance, "isShell", {
+    value: function () {
+      return opts.isShell;
+    },
+    enumerable: false
+  });
+  Object.defineProperty(instance, "validate", {
+    value: function (cb) {
+      handleValidations(function (errors) {
+        cb(null, errors || false);
+      });
+    },
+    enumerable: false,
+    writable: true
+  });
+  Object.defineProperty(instance, "__singleton_uid", {
+    value: function (cb) {
+      return opts.uid;
+    },
+    enumerable: false
+  });
+  Object.defineProperty(instance, "__opts", {
+    value: opts,
+    enumerable: false
+  });
+  Object.defineProperty(instance, "model", {
+    value: function (cb) {
+      return Model;
+    },
+    enumerable: false
+  });
+
+  for (i = 0; i < opts.keyProperties.length; i++) {
+    var prop = opts.keyProperties[i];
+
+    if (!(prop.name in opts.data)) {
+      opts.changes = Object.keys(opts.data);
+      break;
+    }
+  }
+  rememberKeys();
+
+  opts.setupAssociations(instance);
+
+  for (i = 0; i < opts.one_associations.length; i++) {
+    var asc = opts.one_associations[i];
+
+    if (!asc.reversed && !asc.extension) {
+      for (k in asc.field) {
+        if (!opts.data.hasOwnProperty(k)) {
+          addInstanceProperty(k);
+        }
+      }
+    }
+
+    if (asc.name in opts.data) {
+      var d = opts.data[asc.name];
+      var mapper = function (obj) {
+        return obj.isInstance ? obj : new asc.model(obj);
+      };
+
+      if (Array.isArray(d)) {
+        instance[asc.name] = d.map(mapper);
+      } else {
+        instance[asc.name] = mapper(d);
+      }
+      delete opts.data[asc.name];
+    }
+  }
+  for (i = 0; i < opts.many_associations.length; i++) {
+    var aName = opts.many_associations[i].name;
+    opts.associations[aName] = {
+      changed: false, data: opts.many_associations[i]
+    };
+
+    if (Array.isArray(opts.data[aName])) {
+      instance[aName] = opts.data[aName];
+      delete opts.data[aName];
+    }
+  }
+
+  Hook.wait(instance, opts.hooks.afterLoad, function (err) {
+    process.nextTick(function () {
+      emitEvent("ready", err);
+    });
+  });
+
+  return instance;
 }

--- a/lib/LazyLoad.js
+++ b/lib/LazyLoad.js
@@ -1,73 +1,73 @@
 exports.extend = function (Instance, Model, properties) {
-	for (var k in properties) {
-		if (properties[k].lazyload === true) {
-			addLazyLoadProperty(properties[k].lazyname || k, Instance, Model, k);
-		}
-	}
+  for (var k in properties) {
+    if (properties[k].lazyload === true) {
+      addLazyLoadProperty(properties[k].lazyname || k, Instance, Model, k);
+    }
+  }
 };
 
 function addLazyLoadProperty(name, Instance, Model, property) {
-	var method = ucfirst(name);
+  var method = ucfirst(name);
 
-	Object.defineProperty(Instance, "get" + method, {
-		value: function (cb) {
-			var conditions = {};
-			conditions[Model.id] = Instance[Model.id];
+  Object.defineProperty(Instance, "get" + method, {
+    value: function (cb) {
+      var conditions = {};
+      conditions[Model.id] = Instance[Model.id];
 
-			Model.find(conditions, { identityCache: false }).only(Model.id.concat(property)).first(function (err, item) {
-				return cb(err, item ? item[property] : null);
-			});
+      Model.find(conditions, { identityCache: false }).only(Model.id.concat(property)).first(function (err, item) {
+        return cb(err, item ? item[property] : null);
+      });
 
-			return this;
-		},
-		enumerable: false
-	});
-	Object.defineProperty(Instance, "remove" + method, {
-		value: function (cb) {
-			var conditions = {};
-			conditions[Model.id] = Instance[Model.id];
+      return this;
+    },
+    enumerable: false
+  });
+  Object.defineProperty(Instance, "remove" + method, {
+    value: function (cb) {
+      var conditions = {};
+      conditions[Model.id] = Instance[Model.id];
 
-			Model.find(conditions, { identityCache: false }).only(Model.id.concat(property)).first(function (err, item) {
-				if (err) {
-					return cb(err);
-				}
-				if (!item) {
-					return cb(null);
-				}
+      Model.find(conditions, { identityCache: false }).only(Model.id.concat(property)).first(function (err, item) {
+        if (err) {
+          return cb(err);
+        }
+        if (!item) {
+          return cb(null);
+        }
 
-				item[property] = null;
+        item[property] = null;
 
-				return item.save(cb);
-			});
+        return item.save(cb);
+      });
 
-			return this;
-		},
-		enumerable: false
-	});
-	Object.defineProperty(Instance, "set" + method, {
-		value: function (data, cb) {
-			var conditions = {};
-			conditions[Model.id] = Instance[Model.id];
+      return this;
+    },
+    enumerable: false
+  });
+  Object.defineProperty(Instance, "set" + method, {
+    value: function (data, cb) {
+      var conditions = {};
+      conditions[Model.id] = Instance[Model.id];
 
-			Model.find(conditions, { identityCache: false }).first(function (err, item) {
-				if (err) {
-					return cb(err);
-				}
-				if (!item) {
-					return cb(null);
-				}
+      Model.find(conditions, { identityCache: false }).first(function (err, item) {
+        if (err) {
+          return cb(err);
+        }
+        if (!item) {
+          return cb(null);
+        }
 
-				item[property] = data;
+        item[property] = data;
 
-				return item.save(cb);
-			});
+        return item.save(cb);
+      });
 
-			return this;
-		},
-		enumerable: false
-	});
+      return this;
+    },
+    enumerable: false
+  });
 }
 
 function ucfirst(text) {
-	return text[0].toUpperCase() + text.substr(1).toLowerCase();
+  return text[0].toUpperCase() + text.substr(1).toLowerCase();
 }

--- a/lib/Model.js
+++ b/lib/Model.js
@@ -13,726 +13,726 @@ var Validators        = require("./Validators");
 var ORMError          = require("./Error");
 var Hook              = require("./Hook");
 var AvailableHooks    = [
-	"beforeCreate", "afterCreate",
-	"beforeSave", "afterSave",
-	"beforeValidation",
-	"beforeRemove", "afterRemove",
-	"afterLoad",
-	"afterAutoFetch"
+  "beforeCreate", "afterCreate",
+  "beforeSave", "afterSave",
+  "beforeValidation",
+  "beforeRemove", "afterRemove",
+  "afterLoad",
+  "afterAutoFetch"
 ];
 
 exports.Model = Model;
 
 function Model(opts) {
-	opts = _.defaults(opts || {}, {
-		keys: []
-	});
-	opts.keys = Array.isArray(opts.keys) ? opts.keys : [opts.keys];
+  opts = _.defaults(opts || {}, {
+    keys: []
+  });
+  opts.keys = Array.isArray(opts.keys) ? opts.keys : [opts.keys];
 
-	var one_associations       = [];
-	var many_associations      = [];
-	var extend_associations    = [];
-	var association_properties = [];
-	var model_fields           = [];
-	var fieldToPropertyMap     = {};
-	var allProperties          = {};
-	var keyProperties          = [];
+  var one_associations       = [];
+  var many_associations      = [];
+  var extend_associations    = [];
+  var association_properties = [];
+  var model_fields           = [];
+  var fieldToPropertyMap     = {};
+  var allProperties          = {};
+  var keyProperties          = [];
 
-	var createHookHelper = function (hook) {
-		return function (cb) {
-			if (typeof cb !== "function") {
-				delete opts.hooks[hook];
-			} else {
-				opts.hooks[hook] = cb;
-			}
-			return this;
-		};
-	};
-	var createInstance = function (data, inst_opts, cb) {
-		if (!inst_opts) {
-			inst_opts = {};
-		}
+  var createHookHelper = function (hook) {
+    return function (cb) {
+      if (typeof cb !== "function") {
+        delete opts.hooks[hook];
+      } else {
+        opts.hooks[hook] = cb;
+      }
+      return this;
+    };
+  };
+  var createInstance = function (data, inst_opts, cb) {
+    if (!inst_opts) {
+      inst_opts = {};
+    }
 
-		var found_assoc = false, i, k;
+    var found_assoc = false, i, k;
 
-		for (k in data) {
-			if (k === "extra_field") continue;
-			if (opts.properties.hasOwnProperty(k)) continue;
-			if (inst_opts.extra && inst_opts.extra.hasOwnProperty(k)) continue;
-			if (opts.keys.indexOf(k) >= 0) continue;
-			if (association_properties.indexOf(k) >= 0) continue;
+    for (k in data) {
+      if (k === "extra_field") continue;
+      if (opts.properties.hasOwnProperty(k)) continue;
+      if (inst_opts.extra && inst_opts.extra.hasOwnProperty(k)) continue;
+      if (opts.keys.indexOf(k) >= 0) continue;
+      if (association_properties.indexOf(k) >= 0) continue;
 
-			for (i = 0; i < one_associations.length; i++) {
-				if (one_associations[i].name === k) {
-					found_assoc = true;
-					break;
-				}
-			}
-			if (!found_assoc) {
-				for (i = 0; i < many_associations.length; i++) {
-					if (many_associations[i].name === k) {
-						found_assoc = true;
-						break;
-					}
-				}
-			}
-			if (!found_assoc) {
-				delete data[k];
-			}
-		}
+      for (i = 0; i < one_associations.length; i++) {
+        if (one_associations[i].name === k) {
+          found_assoc = true;
+          break;
+        }
+      }
+      if (!found_assoc) {
+        for (i = 0; i < many_associations.length; i++) {
+          if (many_associations[i].name === k) {
+            found_assoc = true;
+            break;
+          }
+        }
+      }
+      if (!found_assoc) {
+        delete data[k];
+      }
+    }
 
-		var assoc_opts = {
-			autoFetch      : inst_opts.autoFetch || false,
-			autoFetchLimit : inst_opts.autoFetchLimit,
-			cascadeRemove  : inst_opts.cascadeRemove
-		};
+    var assoc_opts = {
+      autoFetch      : inst_opts.autoFetch || false,
+      autoFetchLimit : inst_opts.autoFetchLimit,
+      cascadeRemove  : inst_opts.cascadeRemove
+    };
 
-		var setupAssociations = function (instance) {
-			OneAssociation.extend(model, instance, opts.driver, one_associations, assoc_opts);
-			ManyAssociation.extend(model, instance, opts.driver, many_associations, assoc_opts, createInstance);
-			ExtendAssociation.extend(model, instance, opts.driver, extend_associations, assoc_opts);
-		};
+    var setupAssociations = function (instance) {
+      OneAssociation.extend(model, instance, opts.driver, one_associations, assoc_opts);
+      ManyAssociation.extend(model, instance, opts.driver, many_associations, assoc_opts, createInstance);
+      ExtendAssociation.extend(model, instance, opts.driver, extend_associations, assoc_opts);
+    };
 
-		var pending  = 2, create_err = null;
-		var instance = new Instance(model, {
-			uid                    : inst_opts.uid, // singleton unique id
-			keys                   : opts.keys,
-			is_new                 : inst_opts.is_new || false,
-			isShell                : inst_opts.isShell || false,
-			data                   : data,
-			autoSave               : inst_opts.autoSave || false,
-			extra                  : inst_opts.extra,
-			extra_info             : inst_opts.extra_info,
-			driver                 : opts.driver,
-			table                  : opts.table,
-			hooks                  : opts.hooks,
-			methods                : opts.methods,
-			validations            : opts.validations,
-			one_associations       : one_associations,
-			many_associations      : many_associations,
-			extend_associations    : extend_associations,
-			association_properties : association_properties,
-			setupAssociations      : setupAssociations,
-			fieldToPropertyMap     : fieldToPropertyMap,
-			keyProperties          : keyProperties
-		});
-		instance.on("ready", function (err) {
-			if (--pending > 0) {
-				create_err = err;
-				return;
-			}
-			if (typeof cb === "function") {
-				return cb(err || create_err, instance);
-			}
-		});
-		if (model_fields !== null) {
-			LazyLoad.extend(instance, model, opts.properties);
-		}
+    var pending  = 2, create_err = null;
+    var instance = new Instance(model, {
+      uid                    : inst_opts.uid, // singleton unique id
+      keys                   : opts.keys,
+      is_new                 : inst_opts.is_new || false,
+      isShell                : inst_opts.isShell || false,
+      data                   : data,
+      autoSave               : inst_opts.autoSave || false,
+      extra                  : inst_opts.extra,
+      extra_info             : inst_opts.extra_info,
+      driver                 : opts.driver,
+      table                  : opts.table,
+      hooks                  : opts.hooks,
+      methods                : opts.methods,
+      validations            : opts.validations,
+      one_associations       : one_associations,
+      many_associations      : many_associations,
+      extend_associations    : extend_associations,
+      association_properties : association_properties,
+      setupAssociations      : setupAssociations,
+      fieldToPropertyMap     : fieldToPropertyMap,
+      keyProperties          : keyProperties
+    });
+    instance.on("ready", function (err) {
+      if (--pending > 0) {
+        create_err = err;
+        return;
+      }
+      if (typeof cb === "function") {
+        return cb(err || create_err, instance);
+      }
+    });
+    if (model_fields !== null) {
+      LazyLoad.extend(instance, model, opts.properties);
+    }
 
-		OneAssociation.autoFetch(instance, one_associations, assoc_opts, function () {
-			ManyAssociation.autoFetch(instance, many_associations, assoc_opts, function () {
-				ExtendAssociation.autoFetch(instance, extend_associations, assoc_opts, function () {
-					Hook.wait(instance, opts.hooks.afterAutoFetch, function (err) {
-						if (--pending > 0) {
-							create_err = err;
-							return;
-						}
-						if (typeof cb === "function") {
-							return cb(err || create_err, instance);
-						}
-					});
-				});
-			});
-		});
-		return instance;
-	};
+    OneAssociation.autoFetch(instance, one_associations, assoc_opts, function () {
+      ManyAssociation.autoFetch(instance, many_associations, assoc_opts, function () {
+        ExtendAssociation.autoFetch(instance, extend_associations, assoc_opts, function () {
+          Hook.wait(instance, opts.hooks.afterAutoFetch, function (err) {
+            if (--pending > 0) {
+              create_err = err;
+              return;
+            }
+            if (typeof cb === "function") {
+              return cb(err || create_err, instance);
+            }
+          });
+        });
+      });
+    });
+    return instance;
+  };
 
-	var model = function () {
-	    var instance, i;
+  var model = function () {
+      var instance, i;
 
-	    var data = arguments.length > 1 ? arguments : arguments[0];
+      var data = arguments.length > 1 ? arguments : arguments[0];
 
-	    if (Array.isArray(opts.keys) && Array.isArray(data)) {
-	        if (data.length == opts.keys.length) {
-	            var data2 = {};
-	            for (i = 0; i < opts.keys.length; i++) {
-	                data2[opts.keys[i]] = data[i++];
-	            }
+      if (Array.isArray(opts.keys) && Array.isArray(data)) {
+          if (data.length == opts.keys.length) {
+              var data2 = {};
+              for (i = 0; i < opts.keys.length; i++) {
+                  data2[opts.keys[i]] = data[i++];
+              }
 
-	            return createInstance(data2, { isShell: true });
-	        }
-	        else {
-	            var err = new Error('Model requires ' + opts.keys.length + ' keys, only ' + data.length + ' were provided');
-	            err.model = opts.table;
+              return createInstance(data2, { isShell: true });
+          }
+          else {
+              var err = new Error('Model requires ' + opts.keys.length + ' keys, only ' + data.length + ' were provided');
+              err.model = opts.table;
 
-	            throw err;
-	        }
-	    }
-	    else if (typeof data === "number" || typeof data === "string") {
-	        var data2 = {};
-	        data2[opts.keys[0]] = data;
+              throw err;
+          }
+      }
+      else if (typeof data === "number" || typeof data === "string") {
+          var data2 = {};
+          data2[opts.keys[0]] = data;
 
-	        return createInstance(data2, { isShell: true });
-	    } else if (typeof data === "undefined") {
-	        data = {};
-	    }
+          return createInstance(data2, { isShell: true });
+      } else if (typeof data === "undefined") {
+          data = {};
+      }
 
-	    var isNew = false;
+      var isNew = false;
 
-	    for (i = 0; i < opts.keys.length; i++) {
-	        if (!data.hasOwnProperty(opts.keys[i])) {
-	            isNew = true;
-	            break;
-	        }
-	    }
+      for (i = 0; i < opts.keys.length; i++) {
+          if (!data.hasOwnProperty(opts.keys[i])) {
+              isNew = true;
+              break;
+          }
+      }
 
       if (keyProperties.length != 1 || (keyProperties.length == 1 && keyProperties[0].type != 'serial')) {
         isNew = true;
       }
 
-	    return createInstance(data, {
-	        is_new: isNew,
-	        autoSave: opts.autoSave,
-	        cascadeRemove: opts.cascadeRemove
-	    });
-	};
-
-	model.allProperties = allProperties;
-	model.properties    = opts.properties;
-	model.settings      = opts.settings;
-	model.keys          = opts.keys;
-
-	model.drop = function (cb) {
-		if (arguments.length === 0) {
-			cb = function () {};
-		}
-		if (typeof opts.driver.drop === "function") {
-			opts.driver.drop({
-				table             : opts.table,
-				properties        : opts.properties,
-				one_associations  : one_associations,
-				many_associations : many_associations
-			}, cb);
-
-			return this;
-		}
-
-		return cb(new ORMError("Driver does not support Model.drop()", 'NO_SUPPORT', { model: opts.table }));
-	};
-
-	model.sync = function (cb) {
-		if (arguments.length === 0) {
-			cb = function () {};
-		}
-		if (typeof opts.driver.sync === "function") {
-			try {
-				opts.driver.sync({
-					extension           : opts.extension,
-					id                  : opts.keys,
-					table               : opts.table,
-					properties          : opts.properties,
-					allProperties       : allProperties,
-					indexes             : opts.indexes || [],
-					customTypes         : opts.db.customTypes,
-					one_associations    : one_associations,
-					many_associations   : many_associations,
-					extend_associations : extend_associations
-				}, cb);
-			} catch (e) {
-				return cb(e);
-			}
-
-			return this;
-		}
-
-		return cb(new ORMError("Driver does not support Model.sync()", 'NO_SUPPORT', { model: opts.table }));
-	};
-
-	model.get = function () {
-		var conditions = {};
-		var options    = {};
-		var ids        = Array.prototype.slice.apply(arguments);
-		var cb         = ids.pop();
-		var prop;
-
-		if (typeof cb !== "function") {
-		    throw new ORMError("Missing Model.get() callback", 'MISSING_CALLBACK', { model: opts.table });
-		}
-
-		if (typeof ids[ids.length - 1] === "object" && !Array.isArray(ids[ids.length - 1])) {
-			options = ids.pop();
-		}
-
-		if (ids.length === 1 && Array.isArray(ids[0])) {
-			ids = ids[0];
-		}
-
-		if (ids.length !== opts.keys.length) {
-		    throw new ORMError("Model.get() IDs number mismatch (" + opts.keys.length + " needed, " + ids.length + " passed)", 'PARAM_MISMATCH', { model: opts.table });
-		}
-
-		for (var i = 0; i < keyProperties.length; i++) {
-			prop = keyProperties[i];
-			conditions[prop.mapsTo] = ids[i];
-		}
-
-		if (!options.hasOwnProperty("autoFetch")) {
-			options.autoFetch = opts.autoFetch;
-		}
-		if (!options.hasOwnProperty("autoFetchLimit")) {
-			options.autoFetchLimit = opts.autoFetchLimit;
-		}
-		if (!options.hasOwnProperty("cascadeRemove")) {
-			options.cascadeRemove = opts.cascadeRemove;
-		}
-
-		opts.driver.find(model_fields, opts.table, conditions, { limit: 1 }, function (err, data) {
-			if (err) {
-				return cb(new ORMError(err.message, 'QUERY_ERROR', { originalCode: err.code }));
-			}
-			if (data.length === 0) {
-				return cb(new ORMError("Not found", 'NOT_FOUND', { model: opts.table }));
-			}
-
-			Utilities.renameDatastoreFieldsToPropertyNames(data[0], fieldToPropertyMap);
-
-			var uid = opts.driver.uid + "/" + opts.table + "/" + ids.join("/");
-
-			Singleton.get(uid, {
-				identityCache : (options.hasOwnProperty("identityCache") ? options.identityCache : opts.identityCache),
-				saveCheck     : opts.settings.get("instance.identityCacheSaveCheck")
-			}, function (cb) {
-				return createInstance(data[0], {
-					uid            : uid,
-					autoSave       : options.autoSave,
-					autoFetch      : (options.autoFetchLimit === 0 ? false : options.autoFetch),
-					autoFetchLimit : options.autoFetchLimit,
-					cascadeRemove  : options.cascadeRemove
-				}, cb);
-			}, cb);
-		});
-
-		return this;
-	};
-
-	model.find = function () {
-		var options    = {};
-		var conditions = null;
-		var cb         = null;
-		var order      = null;
-		var merge      = null;
-
-		for (var i = 0; i < arguments.length; i++) {
-			switch (typeof arguments[i]) {
-				case "number":
-					options.limit = arguments[i];
-					break;
-				case "object":
-					if (Array.isArray(arguments[i])) {
-						if (arguments[i].length > 0) {
-							order = arguments[i];
-						}
-					} else {
-						if (conditions === null) {
-							conditions = arguments[i];
-						} else {
-							if (options.hasOwnProperty("limit")) {
-								arguments[i].limit = options.limit;
-							}
-							options = arguments[i];
-
-							if (options.hasOwnProperty("__merge")) {
-								merge = options.__merge;
-								merge.select = Object.keys(options.extra);
-								delete options.__merge;
-							}
-							if (options.hasOwnProperty("order")) {
-								order = options.order;
-								delete options.order;
-							}
-						}
-					}
-					break;
-				case "function":
-					cb = arguments[i];
-					break;
-				case "string":
-					if (arguments[i][0] === "-") {
-						order = [ arguments[i].substr(1), "Z" ];
-					} else {
-						order = [ arguments[i] ];
-					}
-					break;
-			}
-		}
-
-		if (!options.hasOwnProperty("identityCache")) {
-			options.identityCache = opts.identityCache;
-		}
-		if (!options.hasOwnProperty("autoFetchLimit")) {
-			options.autoFetchLimit = opts.autoFetchLimit;
-		}
-		if (!options.hasOwnProperty("cascadeRemove")) {
-			options.cascadeRemove = opts.cascadeRemove;
-		}
-
-		if (order) {
-			order = Utilities.standardizeOrder(order);
-		}
-		if (conditions) {
-			conditions = Utilities.checkConditions(conditions, one_associations);
-		}
-
-		var chain = new ChainFind(model, {
-			only         : options.only || model_fields,
-			keys         : opts.keys,
-			table        : opts.table,
-			driver       : opts.driver,
-			conditions   : conditions,
-			associations : many_associations,
-			limit        : options.limit,
-			order        : order,
-			merge        : merge,
-			offset       : options.offset,
-			properties   : allProperties,
-			keyProperties: keyProperties,
-			newInstance  : function (data, cb) {
-				// We need to do the rename before we construct the UID & do the cache lookup
-				// because the cache is loaded using propertyName rather than fieldName
-				Utilities.renameDatastoreFieldsToPropertyNames(data, fieldToPropertyMap);
-
-				// Construct UID
-				var uid = opts.driver.uid + "/" + opts.table + (merge ? "+" + merge.from.table : "");
-				for (var i = 0; i < opts.keys.length; i++) {
-					uid += "/" + data[opts.keys[i]];
-				}
-
-				// Now we can do the cache lookup
-				Singleton.get(uid, {
-					identityCache : options.identityCache,
-					saveCheck     : opts.settings.get("instance.identityCacheSaveCheck")
-				}, function (cb) {
-					return createInstance(data, {
-						uid            : uid,
-						autoSave       : opts.autoSave,
-						autoFetch      : (options.autoFetchLimit === 0 ? false : (options.autoFetch || opts.autoFetch)),
-						autoFetchLimit : options.autoFetchLimit,
-						cascadeRemove  : options.cascadeRemove,
-						extra          : options.extra,
-						extra_info     : options.extra_info
-					}, cb);
-				}, cb);
-			}
-		});
-
-		if (typeof cb !== "function") {
-			return chain;
-		} else {
-			chain.run(cb);
-			return this;
-		}
-	};
-
-	model.where = model.all = model.find;
-
-	model.one = function () {
-		var args = Array.prototype.slice.apply(arguments);
-		var cb   = null;
-
-		// extract callback
-		for (var i = 0; i < args.length; i++) {
-			if (typeof args[i] === "function") {
-				cb = args.splice(i, 1)[0];
-				break;
-			}
-		}
-
-		if (cb === null) {
-		    throw new ORMError("Missing Model.one() callback", 'MISSING_CALLBACK', { model: opts.table });
-		}
-
-		// add limit 1
-		args.push(1);
-		args.push(function (err, results) {
-			if (err) {
-				return cb(err);
-			}
-			return cb(null, results.length ? results[0] : null);
-		});
-
-		return this.find.apply(this, args);
-	};
-
-	model.count = function () {
-		var conditions = null;
-		var cb         = null;
-
-		for (var i = 0; i < arguments.length; i++) {
-			switch (typeof arguments[i]) {
-				case "object":
-					conditions = arguments[i];
-					break;
-				case "function":
-					cb = arguments[i];
-					break;
-			}
-		}
-
-		if (typeof cb !== "function") {
-		    throw new ORMError('MISSING_CALLBACK', "Missing Model.count() callback", { model: opts.table });
-		}
-
-		if (conditions) {
-			conditions = Utilities.checkConditions(conditions, one_associations);
-		}
-
-		opts.driver.count(opts.table, conditions, {}, function (err, data) {
-			if (err || data.length === 0) {
-				return cb(err);
-			}
-			return cb(null, data[0].c);
-		});
-		return this;
-	};
-
-	model.aggregate = function () {
-		var conditions = {};
-		var propertyList = [];
-
-		for (var i = 0; i < arguments.length; i++) {
-			if (typeof arguments[i] === "object") {
-				if (Array.isArray(arguments[i])) {
-					propertyList = arguments[i];
-				} else {
-					conditions = arguments[i];
-				}
-			}
-		}
-
-		if (conditions) {
-			conditions = Utilities.checkConditions(conditions, one_associations);
-		}
-
-		return new require("./AggregateFunctions")({
-			table        : opts.table,
-			driver_name  : opts.driver_name,
-			driver       : opts.driver,
-			conditions   : conditions,
-			propertyList : propertyList,
-			properties   : allProperties
-		});
-	};
-
-	model.exists = function () {
-		var ids = Array.prototype.slice.apply(arguments);
-		var cb  = ids.pop();
-
-		if (typeof cb !== "function") {
-		    throw new ORMError("Missing Model.exists() callback", 'MISSING_CALLBACK', { model: opts.table });
-		}
-
-		var conditions = {}, i;
-
-		if (ids.length === 1 && typeof ids[0] === "object") {
-			if (Array.isArray(ids[0])) {
-				for (i = 0; i < opts.keys.length; i++) {
-					conditions[opts.keys[i]] = ids[0][i];
-				}
-			} else {
-				conditions = ids[0];
-			}
-		} else {
-			for (i = 0; i < opts.keys.length; i++) {
-				conditions[opts.keys[i]] = ids[i];
-			}
-		}
-
-		if (conditions) {
-			conditions = Utilities.checkConditions(conditions, one_associations);
-		}
-
-		opts.driver.count(opts.table, conditions, {}, function (err, data) {
-			if (err || data.length === 0) {
-				return cb(err);
-			}
-			return cb(null, data[0].c > 0);
-		});
-		return this;
-	};
-
-	model.create = function () {
-		var itemsParams = []
-		var items       = [];
-		var options     = {};
-		var done        = null;
-		var single      = false;
-
-		for (var i = 0; i < arguments.length; i++) {
-			switch (typeof arguments[i]) {
-				case "object":
-					if ( !single && Array.isArray(arguments[i]) ) {
-						itemsParams = itemsParams.concat(arguments[i]);
-					} else if (i === 0) {
-						single = true;
-						itemsParams.push(arguments[i]);
-					} else {
-						options = arguments[i];
-					}
-					break;
-				case "function":
-					done = arguments[i];
-					break;
-			}
-		}
-
-		var iterator = function (params, index, cb) {
-			createInstance(params, {
-				is_new    : true,
-				autoSave  : opts.autoSave,
-				autoFetch : false
-			}, function (err, item) {
-				if (err) {
-					err.index    = index;
-					err.instance = item;
-
-					return cb(err);
-				}
-				item.save(function (err) {
-					if (err) {
-						err.index    = index;
-						err.instance = item;
-
-						return cb(err);
-					}
-
-					items[index] = item;
-					cb();
-				});
-			});
-		};
-
-		async.eachOfSeries(itemsParams, iterator, function (err) {
-			if (err) return done(err);
-			done(null, single ? items[0] : items);
-		});
-
-		return this;
-	};
-
-	model.clear = function (cb) {
-		opts.driver.clear(opts.table, function (err) {
-			if (typeof cb === "function") cb(err);
-		});
-
-		return this;
-	};
-
-	model.prependValidation = function (key, validation) {
-		if(opts.validations.hasOwnProperty(key)) {
-			opts.validations[key].splice(0, 0, validation);
-		} else {
-			opts.validations[key] = [validation];
-		}
-	};
-
-	var currFields = {};
-
-	model.addProperty = function (propIn, options) {
-		var cType;
-		var prop = Property.normalize({
-			prop: propIn, name: (options && options.name || propIn.name),
-			customTypes: opts.db.customTypes, settings: opts.settings
-		});
-
-		// Maintains backwards compatibility
-		if (opts.keys.indexOf(k) != -1) {
-			prop.key = true;
-		} else if (prop.key) {
-			opts.keys.push(k);
-		}
-
-		if (options && options.klass) {
-			prop.klass = options.klass;
-		}
-
-		switch (prop.klass) {
-			case 'primary':
-				opts.properties[prop.name]  = prop;
-				break;
-			case 'hasOne':
-				association_properties.push(prop.name)
-				break;
-		}
-
-		allProperties[prop.name]        = prop;
-		fieldToPropertyMap[prop.mapsTo] = prop;
-
-		if (prop.required) {
-			model.prependValidation(prop.name, Validators.required());
-		}
-
-		if (prop.key && prop.klass == 'primary') {
-			keyProperties.push(prop);
-		}
-
-		if (prop.lazyload !== true && !currFields[prop.name]) {
-			currFields[prop.name] = true;
-			if ((cType = opts.db.customTypes[prop.type]) && cType.datastoreGet) {
-				model_fields.push({
-					a: prop.mapsTo, sql: cType.datastoreGet(prop, opts.db.driver.query)
-				});
-			} else {
-				model_fields.push(prop.mapsTo);
-			}
-		}
-
-		return prop;
-	};
-
-	Object.defineProperty(model, "table", {
-		value: opts.table,
-		enumerable: false
-	});
-	Object.defineProperty(model, "id", {
-		value: opts.keys,
-		enumerable: false
-	});
-	Object.defineProperty(model, "uid", {
-	    value: opts.driver.uid + "/" + opts.table + "/" + opts.keys.join("/"),
+      return createInstance(data, {
+          is_new: isNew,
+          autoSave: opts.autoSave,
+          cascadeRemove: opts.cascadeRemove
+      });
+  };
+
+  model.allProperties = allProperties;
+  model.properties    = opts.properties;
+  model.settings      = opts.settings;
+  model.keys          = opts.keys;
+
+  model.drop = function (cb) {
+    if (arguments.length === 0) {
+      cb = function () {};
+    }
+    if (typeof opts.driver.drop === "function") {
+      opts.driver.drop({
+        table             : opts.table,
+        properties        : opts.properties,
+        one_associations  : one_associations,
+        many_associations : many_associations
+      }, cb);
+
+      return this;
+    }
+
+    return cb(new ORMError("Driver does not support Model.drop()", 'NO_SUPPORT', { model: opts.table }));
+  };
+
+  model.sync = function (cb) {
+    if (arguments.length === 0) {
+      cb = function () {};
+    }
+    if (typeof opts.driver.sync === "function") {
+      try {
+        opts.driver.sync({
+          extension           : opts.extension,
+          id                  : opts.keys,
+          table               : opts.table,
+          properties          : opts.properties,
+          allProperties       : allProperties,
+          indexes             : opts.indexes || [],
+          customTypes         : opts.db.customTypes,
+          one_associations    : one_associations,
+          many_associations   : many_associations,
+          extend_associations : extend_associations
+        }, cb);
+      } catch (e) {
+        return cb(e);
+      }
+
+      return this;
+    }
+
+    return cb(new ORMError("Driver does not support Model.sync()", 'NO_SUPPORT', { model: opts.table }));
+  };
+
+  model.get = function () {
+    var conditions = {};
+    var options    = {};
+    var ids        = Array.prototype.slice.apply(arguments);
+    var cb         = ids.pop();
+    var prop;
+
+    if (typeof cb !== "function") {
+        throw new ORMError("Missing Model.get() callback", 'MISSING_CALLBACK', { model: opts.table });
+    }
+
+    if (typeof ids[ids.length - 1] === "object" && !Array.isArray(ids[ids.length - 1])) {
+      options = ids.pop();
+    }
+
+    if (ids.length === 1 && Array.isArray(ids[0])) {
+      ids = ids[0];
+    }
+
+    if (ids.length !== opts.keys.length) {
+        throw new ORMError("Model.get() IDs number mismatch (" + opts.keys.length + " needed, " + ids.length + " passed)", 'PARAM_MISMATCH', { model: opts.table });
+    }
+
+    for (var i = 0; i < keyProperties.length; i++) {
+      prop = keyProperties[i];
+      conditions[prop.mapsTo] = ids[i];
+    }
+
+    if (!options.hasOwnProperty("autoFetch")) {
+      options.autoFetch = opts.autoFetch;
+    }
+    if (!options.hasOwnProperty("autoFetchLimit")) {
+      options.autoFetchLimit = opts.autoFetchLimit;
+    }
+    if (!options.hasOwnProperty("cascadeRemove")) {
+      options.cascadeRemove = opts.cascadeRemove;
+    }
+
+    opts.driver.find(model_fields, opts.table, conditions, { limit: 1 }, function (err, data) {
+      if (err) {
+        return cb(new ORMError(err.message, 'QUERY_ERROR', { originalCode: err.code }));
+      }
+      if (data.length === 0) {
+        return cb(new ORMError("Not found", 'NOT_FOUND', { model: opts.table }));
+      }
+
+      Utilities.renameDatastoreFieldsToPropertyNames(data[0], fieldToPropertyMap);
+
+      var uid = opts.driver.uid + "/" + opts.table + "/" + ids.join("/");
+
+      Singleton.get(uid, {
+        identityCache : (options.hasOwnProperty("identityCache") ? options.identityCache : opts.identityCache),
+        saveCheck     : opts.settings.get("instance.identityCacheSaveCheck")
+      }, function (cb) {
+        return createInstance(data[0], {
+          uid            : uid,
+          autoSave       : options.autoSave,
+          autoFetch      : (options.autoFetchLimit === 0 ? false : options.autoFetch),
+          autoFetchLimit : options.autoFetchLimit,
+          cascadeRemove  : options.cascadeRemove
+        }, cb);
+      }, cb);
+    });
+
+    return this;
+  };
+
+  model.find = function () {
+    var options    = {};
+    var conditions = null;
+    var cb         = null;
+    var order      = null;
+    var merge      = null;
+
+    for (var i = 0; i < arguments.length; i++) {
+      switch (typeof arguments[i]) {
+        case "number":
+          options.limit = arguments[i];
+          break;
+        case "object":
+          if (Array.isArray(arguments[i])) {
+            if (arguments[i].length > 0) {
+              order = arguments[i];
+            }
+          } else {
+            if (conditions === null) {
+              conditions = arguments[i];
+            } else {
+              if (options.hasOwnProperty("limit")) {
+                arguments[i].limit = options.limit;
+              }
+              options = arguments[i];
+
+              if (options.hasOwnProperty("__merge")) {
+                merge = options.__merge;
+                merge.select = Object.keys(options.extra);
+                delete options.__merge;
+              }
+              if (options.hasOwnProperty("order")) {
+                order = options.order;
+                delete options.order;
+              }
+            }
+          }
+          break;
+        case "function":
+          cb = arguments[i];
+          break;
+        case "string":
+          if (arguments[i][0] === "-") {
+            order = [ arguments[i].substr(1), "Z" ];
+          } else {
+            order = [ arguments[i] ];
+          }
+          break;
+      }
+    }
+
+    if (!options.hasOwnProperty("identityCache")) {
+      options.identityCache = opts.identityCache;
+    }
+    if (!options.hasOwnProperty("autoFetchLimit")) {
+      options.autoFetchLimit = opts.autoFetchLimit;
+    }
+    if (!options.hasOwnProperty("cascadeRemove")) {
+      options.cascadeRemove = opts.cascadeRemove;
+    }
+
+    if (order) {
+      order = Utilities.standardizeOrder(order);
+    }
+    if (conditions) {
+      conditions = Utilities.checkConditions(conditions, one_associations);
+    }
+
+    var chain = new ChainFind(model, {
+      only         : options.only || model_fields,
+      keys         : opts.keys,
+      table        : opts.table,
+      driver       : opts.driver,
+      conditions   : conditions,
+      associations : many_associations,
+      limit        : options.limit,
+      order        : order,
+      merge        : merge,
+      offset       : options.offset,
+      properties   : allProperties,
+      keyProperties: keyProperties,
+      newInstance  : function (data, cb) {
+        // We need to do the rename before we construct the UID & do the cache lookup
+        // because the cache is loaded using propertyName rather than fieldName
+        Utilities.renameDatastoreFieldsToPropertyNames(data, fieldToPropertyMap);
+
+        // Construct UID
+        var uid = opts.driver.uid + "/" + opts.table + (merge ? "+" + merge.from.table : "");
+        for (var i = 0; i < opts.keys.length; i++) {
+          uid += "/" + data[opts.keys[i]];
+        }
+
+        // Now we can do the cache lookup
+        Singleton.get(uid, {
+          identityCache : options.identityCache,
+          saveCheck     : opts.settings.get("instance.identityCacheSaveCheck")
+        }, function (cb) {
+          return createInstance(data, {
+            uid            : uid,
+            autoSave       : opts.autoSave,
+            autoFetch      : (options.autoFetchLimit === 0 ? false : (options.autoFetch || opts.autoFetch)),
+            autoFetchLimit : options.autoFetchLimit,
+            cascadeRemove  : options.cascadeRemove,
+            extra          : options.extra,
+            extra_info     : options.extra_info
+          }, cb);
+        }, cb);
+      }
+    });
+
+    if (typeof cb !== "function") {
+      return chain;
+    } else {
+      chain.run(cb);
+      return this;
+    }
+  };
+
+  model.where = model.all = model.find;
+
+  model.one = function () {
+    var args = Array.prototype.slice.apply(arguments);
+    var cb   = null;
+
+    // extract callback
+    for (var i = 0; i < args.length; i++) {
+      if (typeof args[i] === "function") {
+        cb = args.splice(i, 1)[0];
+        break;
+      }
+    }
+
+    if (cb === null) {
+        throw new ORMError("Missing Model.one() callback", 'MISSING_CALLBACK', { model: opts.table });
+    }
+
+    // add limit 1
+    args.push(1);
+    args.push(function (err, results) {
+      if (err) {
+        return cb(err);
+      }
+      return cb(null, results.length ? results[0] : null);
+    });
+
+    return this.find.apply(this, args);
+  };
+
+  model.count = function () {
+    var conditions = null;
+    var cb         = null;
+
+    for (var i = 0; i < arguments.length; i++) {
+      switch (typeof arguments[i]) {
+        case "object":
+          conditions = arguments[i];
+          break;
+        case "function":
+          cb = arguments[i];
+          break;
+      }
+    }
+
+    if (typeof cb !== "function") {
+        throw new ORMError('MISSING_CALLBACK', "Missing Model.count() callback", { model: opts.table });
+    }
+
+    if (conditions) {
+      conditions = Utilities.checkConditions(conditions, one_associations);
+    }
+
+    opts.driver.count(opts.table, conditions, {}, function (err, data) {
+      if (err || data.length === 0) {
+        return cb(err);
+      }
+      return cb(null, data[0].c);
+    });
+    return this;
+  };
+
+  model.aggregate = function () {
+    var conditions = {};
+    var propertyList = [];
+
+    for (var i = 0; i < arguments.length; i++) {
+      if (typeof arguments[i] === "object") {
+        if (Array.isArray(arguments[i])) {
+          propertyList = arguments[i];
+        } else {
+          conditions = arguments[i];
+        }
+      }
+    }
+
+    if (conditions) {
+      conditions = Utilities.checkConditions(conditions, one_associations);
+    }
+
+    return new require("./AggregateFunctions")({
+      table        : opts.table,
+      driver_name  : opts.driver_name,
+      driver       : opts.driver,
+      conditions   : conditions,
+      propertyList : propertyList,
+      properties   : allProperties
+    });
+  };
+
+  model.exists = function () {
+    var ids = Array.prototype.slice.apply(arguments);
+    var cb  = ids.pop();
+
+    if (typeof cb !== "function") {
+        throw new ORMError("Missing Model.exists() callback", 'MISSING_CALLBACK', { model: opts.table });
+    }
+
+    var conditions = {}, i;
+
+    if (ids.length === 1 && typeof ids[0] === "object") {
+      if (Array.isArray(ids[0])) {
+        for (i = 0; i < opts.keys.length; i++) {
+          conditions[opts.keys[i]] = ids[0][i];
+        }
+      } else {
+        conditions = ids[0];
+      }
+    } else {
+      for (i = 0; i < opts.keys.length; i++) {
+        conditions[opts.keys[i]] = ids[i];
+      }
+    }
+
+    if (conditions) {
+      conditions = Utilities.checkConditions(conditions, one_associations);
+    }
+
+    opts.driver.count(opts.table, conditions, {}, function (err, data) {
+      if (err || data.length === 0) {
+        return cb(err);
+      }
+      return cb(null, data[0].c > 0);
+    });
+    return this;
+  };
+
+  model.create = function () {
+    var itemsParams = []
+    var items       = [];
+    var options     = {};
+    var done        = null;
+    var single      = false;
+
+    for (var i = 0; i < arguments.length; i++) {
+      switch (typeof arguments[i]) {
+        case "object":
+          if ( !single && Array.isArray(arguments[i]) ) {
+            itemsParams = itemsParams.concat(arguments[i]);
+          } else if (i === 0) {
+            single = true;
+            itemsParams.push(arguments[i]);
+          } else {
+            options = arguments[i];
+          }
+          break;
+        case "function":
+          done = arguments[i];
+          break;
+      }
+    }
+
+    var iterator = function (params, index, cb) {
+      createInstance(params, {
+        is_new    : true,
+        autoSave  : opts.autoSave,
+        autoFetch : false
+      }, function (err, item) {
+        if (err) {
+          err.index    = index;
+          err.instance = item;
+
+          return cb(err);
+        }
+        item.save(function (err) {
+          if (err) {
+            err.index    = index;
+            err.instance = item;
+
+            return cb(err);
+          }
+
+          items[index] = item;
+          cb();
+        });
+      });
+    };
+
+    async.eachOfSeries(itemsParams, iterator, function (err) {
+      if (err) return done(err);
+      done(null, single ? items[0] : items);
+    });
+
+    return this;
+  };
+
+  model.clear = function (cb) {
+    opts.driver.clear(opts.table, function (err) {
+      if (typeof cb === "function") cb(err);
+    });
+
+    return this;
+  };
+
+  model.prependValidation = function (key, validation) {
+    if(opts.validations.hasOwnProperty(key)) {
+      opts.validations[key].splice(0, 0, validation);
+    } else {
+      opts.validations[key] = [validation];
+    }
+  };
+
+  var currFields = {};
+
+  model.addProperty = function (propIn, options) {
+    var cType;
+    var prop = Property.normalize({
+      prop: propIn, name: (options && options.name || propIn.name),
+      customTypes: opts.db.customTypes, settings: opts.settings
+    });
+
+    // Maintains backwards compatibility
+    if (opts.keys.indexOf(k) != -1) {
+      prop.key = true;
+    } else if (prop.key) {
+      opts.keys.push(k);
+    }
+
+    if (options && options.klass) {
+      prop.klass = options.klass;
+    }
+
+    switch (prop.klass) {
+      case 'primary':
+        opts.properties[prop.name]  = prop;
+        break;
+      case 'hasOne':
+        association_properties.push(prop.name)
+        break;
+    }
+
+    allProperties[prop.name]        = prop;
+    fieldToPropertyMap[prop.mapsTo] = prop;
+
+    if (prop.required) {
+      model.prependValidation(prop.name, Validators.required());
+    }
+
+    if (prop.key && prop.klass == 'primary') {
+      keyProperties.push(prop);
+    }
+
+    if (prop.lazyload !== true && !currFields[prop.name]) {
+      currFields[prop.name] = true;
+      if ((cType = opts.db.customTypes[prop.type]) && cType.datastoreGet) {
+        model_fields.push({
+          a: prop.mapsTo, sql: cType.datastoreGet(prop, opts.db.driver.query)
+        });
+      } else {
+        model_fields.push(prop.mapsTo);
+      }
+    }
+
+    return prop;
+  };
+
+  Object.defineProperty(model, "table", {
+    value: opts.table,
+    enumerable: false
+  });
+  Object.defineProperty(model, "id", {
+    value: opts.keys,
+    enumerable: false
+  });
+  Object.defineProperty(model, "uid", {
+      value: opts.driver.uid + "/" + opts.table + "/" + opts.keys.join("/"),
         enumerable: false
-	});
+  });
 
-	// Standardize validations
-	for (var k in opts.validations) {
-		if (!Array.isArray(opts.validations[k])) {
-			opts.validations[k] = [ opts.validations[k] ];
-		}
-	}
+  // Standardize validations
+  for (var k in opts.validations) {
+    if (!Array.isArray(opts.validations[k])) {
+      opts.validations[k] = [ opts.validations[k] ];
+    }
+  }
 
-	// If no keys are defined add the default one
-	if (opts.keys.length == 0 && !_.some(opts.properties, { key: true })) {
-		opts.properties[opts.settings.get("properties.primary_key")] = {
-			type: 'serial', key: true, required: false, klass: 'primary'
-		};
-	}
+  // If no keys are defined add the default one
+  if (opts.keys.length == 0 && !_.some(opts.properties, { key: true })) {
+    opts.properties[opts.settings.get("properties.primary_key")] = {
+      type: 'serial', key: true, required: false, klass: 'primary'
+    };
+  }
 
-	// standardize properties
-	for (k in opts.properties) {
-		model.addProperty(opts.properties[k], { name: k, klass: 'primary' });
-	}
+  // standardize properties
+  for (k in opts.properties) {
+    model.addProperty(opts.properties[k], { name: k, klass: 'primary' });
+  }
 
-	if (keyProperties.length == 0) {
-		throw new ORMError("Model defined without any keys", 'BAD_MODEL', { model: opts.table });
-	}
+  if (keyProperties.length == 0) {
+    throw new ORMError("Model defined without any keys", 'BAD_MODEL', { model: opts.table });
+  }
 
-	// setup hooks
-	for (k in AvailableHooks) {
-		model[AvailableHooks[k]] = createHookHelper(AvailableHooks[k]);
-	}
+  // setup hooks
+  for (k in AvailableHooks) {
+    model[AvailableHooks[k]] = createHookHelper(AvailableHooks[k]);
+  }
 
-	OneAssociation.prepare(model, one_associations);
-	ManyAssociation.prepare(opts.db, model, many_associations);
-	ExtendAssociation.prepare(opts.db, model, extend_associations);
+  OneAssociation.prepare(model, one_associations);
+  ManyAssociation.prepare(opts.db, model, many_associations);
+  ExtendAssociation.prepare(opts.db, model, extend_associations);
 
-	return model;
+  return model;
 }

--- a/lib/ORM.js
+++ b/lib/ORM.js
@@ -32,379 +32,379 @@ exports.ErrorCodes = ORMError.codes;
 
 exports.Text = Query.Text;
 for (var k in Query.Comparators) {
-	exports[Query.Comparators[k]] = Query[Query.Comparators[k]];
+  exports[Query.Comparators[k]] = Query[Query.Comparators[k]];
 }
 
 exports.express = function () {
-	return require("./Express").apply(this, arguments);
+  return require("./Express").apply(this, arguments);
 };
 
 exports.use = function (connection, proto, opts, cb) {
-	if (DriverAliases[proto]) {
-		proto = DriverAliases[proto];
-	}
-	if (typeof opts === "function") {
-		cb = opts;
-		opts = {};
-	}
+  if (DriverAliases[proto]) {
+    proto = DriverAliases[proto];
+  }
+  if (typeof opts === "function") {
+    cb = opts;
+    opts = {};
+  }
 
-	try {
-		var Driver   = adapters.get(proto);
-		var settings = new Settings.Container(exports.settings.get('*'));
-		var driver   = new Driver(null, connection, {
-			debug    : (opts.query && opts.query.debug === 'true'),
-			settings : settings
-		});
+  try {
+    var Driver   = adapters.get(proto);
+    var settings = new Settings.Container(exports.settings.get('*'));
+    var driver   = new Driver(null, connection, {
+      debug    : (opts.query && opts.query.debug === 'true'),
+      settings : settings
+    });
 
-		return cb(null, new ORM(proto, driver, settings));
-	} catch (ex) {
-		return cb(ex);
-	}
+    return cb(null, new ORM(proto, driver, settings));
+  } catch (ex) {
+    return cb(ex);
+  }
 };
 
 exports.connect = function (opts, cb) {
-	if (arguments.length === 0 || !opts) {
-		return ORM_Error(new ORMError("CONNECTION_URL_EMPTY", 'PARAM_MISMATCH'), cb);
-	}
-	if (typeof opts == 'string') {
-		if (opts.trim().length === 0) {
-			return ORM_Error(new ORMError("CONNECTION_URL_EMPTY", 'PARAM_MISMATCH'), cb);
-		}
-		opts = url.parse(opts, true);
-	} else if (typeof opts == 'object') {
-		opts = _.cloneDeep(opts);
-	}
+  if (arguments.length === 0 || !opts) {
+    return ORM_Error(new ORMError("CONNECTION_URL_EMPTY", 'PARAM_MISMATCH'), cb);
+  }
+  if (typeof opts == 'string') {
+    if (opts.trim().length === 0) {
+      return ORM_Error(new ORMError("CONNECTION_URL_EMPTY", 'PARAM_MISMATCH'), cb);
+    }
+    opts = url.parse(opts, true);
+  } else if (typeof opts == 'object') {
+    opts = _.cloneDeep(opts);
+  }
 
-	opts.query = opts.query || {};
+  opts.query = opts.query || {};
 
-	for(var k in opts.query) {
-		opts.query[k] = queryParamCast(opts.query[k]);
-		opts[k] = opts.query[k];
-	}
+  for(var k in opts.query) {
+    opts.query[k] = queryParamCast(opts.query[k]);
+    opts[k] = opts.query[k];
+  }
 
-	if (!opts.database) {
-		// if (!opts.pathname) {
-		// 	return cb(new Error("CONNECTION_URL_NO_DATABASE"));
-		// }
-		opts.database = (opts.pathname ? opts.pathname.substr(1) : "");
-	}
-	if (!opts.protocol) {
-		return ORM_Error(new ORMError("CONNECTION_URL_NO_PROTOCOL", 'PARAM_MISMATCH'), cb);
-	}
-	// if (!opts.host) {
-	// 	opts.host = opts.hostname = "localhost";
-	// }
-	if (opts.auth) {
-		opts.user = opts.auth.split(":")[0];
-		opts.password = opts.auth.split(":")[1];
-	}
-	if (!opts.hasOwnProperty("user")) {
-		opts.user = "root";
-	}
-	if (!opts.hasOwnProperty("password")) {
-		opts.password = "";
-	}
-	if (opts.hasOwnProperty("hostname")) {
-		opts.host = opts.hostname;
-	}
+  if (!opts.database) {
+    // if (!opts.pathname) {
+    //   return cb(new Error("CONNECTION_URL_NO_DATABASE"));
+    // }
+    opts.database = (opts.pathname ? opts.pathname.substr(1) : "");
+  }
+  if (!opts.protocol) {
+    return ORM_Error(new ORMError("CONNECTION_URL_NO_PROTOCOL", 'PARAM_MISMATCH'), cb);
+  }
+  // if (!opts.host) {
+  //   opts.host = opts.hostname = "localhost";
+  // }
+  if (opts.auth) {
+    opts.user = opts.auth.split(":")[0];
+    opts.password = opts.auth.split(":")[1];
+  }
+  if (!opts.hasOwnProperty("user")) {
+    opts.user = "root";
+  }
+  if (!opts.hasOwnProperty("password")) {
+    opts.password = "";
+  }
+  if (opts.hasOwnProperty("hostname")) {
+    opts.host = opts.hostname;
+  }
 
-	var proto  = opts.protocol.replace(/:$/, '');
-	var db;
-	if (DriverAliases[proto]) {
-		proto = DriverAliases[proto];
-	}
+  var proto  = opts.protocol.replace(/:$/, '');
+  var db;
+  if (DriverAliases[proto]) {
+    proto = DriverAliases[proto];
+  }
 
-	try {
-		var Driver   = adapters.get(proto);
-		var settings = new Settings.Container(exports.settings.get('*'));
-		var driver   = new Driver(opts, null, {
-			debug    : 'debug' in opts.query ? opts.query.debug : settings.get("connection.debug"),
-			pool     : 'pool'  in opts.query ? opts.query.pool  : settings.get("connection.pool"),
-			settings : settings
-		});
+  try {
+    var Driver   = adapters.get(proto);
+    var settings = new Settings.Container(exports.settings.get('*'));
+    var driver   = new Driver(opts, null, {
+      debug    : 'debug' in opts.query ? opts.query.debug : settings.get("connection.debug"),
+      pool     : 'pool'  in opts.query ? opts.query.pool  : settings.get("connection.pool"),
+      settings : settings
+    });
 
-		db = new ORM(proto, driver, settings);
+    db = new ORM(proto, driver, settings);
 
-		driver.connect(function (err) {
-			if (typeof cb === "function") {
-				if (err) {
-					return cb(err);
-				} else {
-					return cb(null, db);
-				}
-			}
+    driver.connect(function (err) {
+      if (typeof cb === "function") {
+        if (err) {
+          return cb(err);
+        } else {
+          return cb(null, db);
+        }
+      }
 
-			db.emit("connect", err, !err ? db : null);
-		});
-	} catch (ex) {
-		if (ex.code === "MODULE_NOT_FOUND" || ex.message.indexOf('find module') > -1) {
-			return ORM_Error(new ORMError("Connection protocol not supported - have you installed the database driver for " + proto + "?", 'NO_SUPPORT'), cb);
-		}
-		return ORM_Error(ex, cb);
-	}
+      db.emit("connect", err, !err ? db : null);
+    });
+  } catch (ex) {
+    if (ex.code === "MODULE_NOT_FOUND" || ex.message.indexOf('find module') > -1) {
+      return ORM_Error(new ORMError("Connection protocol not supported - have you installed the database driver for " + proto + "?", 'NO_SUPPORT'), cb);
+    }
+    return ORM_Error(ex, cb);
+  }
 
-	return db;
+  return db;
 };
 
 exports.addAdapter = adapters.add;
 
 function ORM(driver_name, driver, settings) {
-	this.validators  = exports.validators;
-	this.enforce     = exports.enforce;
-	this.settings    = settings;
-	this.driver_name = driver_name;
-	this.driver      = driver;
-	this.driver.uid  = hat();
-	this.tools       = {};
-	this.models      = {};
-	this.plugins     = [];
-	this.customTypes = {};
+  this.validators  = exports.validators;
+  this.enforce     = exports.enforce;
+  this.settings    = settings;
+  this.driver_name = driver_name;
+  this.driver      = driver;
+  this.driver.uid  = hat();
+  this.tools       = {};
+  this.models      = {};
+  this.plugins     = [];
+  this.customTypes = {};
 
-	for (var k in Query.Comparators) {
-		this.tools[Query.Comparators[k]] = Query[Query.Comparators[k]];
-	}
+  for (var k in Query.Comparators) {
+    this.tools[Query.Comparators[k]] = Query[Query.Comparators[k]];
+  }
 
-	events.EventEmitter.call(this);
+  events.EventEmitter.call(this);
 
-	var onError = function (err) {
-		if (this.settings.get("connection.reconnect")) {
-			if (typeof this.driver.reconnect === "undefined") {
-				return this.emit("error", new ORMError("Connection lost - driver does not support reconnection", 'CONNECTION_LOST'));
-			}
-			this.driver.reconnect(function () {
-				this.driver.on("error", onError);
-			}.bind(this));
+  var onError = function (err) {
+    if (this.settings.get("connection.reconnect")) {
+      if (typeof this.driver.reconnect === "undefined") {
+        return this.emit("error", new ORMError("Connection lost - driver does not support reconnection", 'CONNECTION_LOST'));
+      }
+      this.driver.reconnect(function () {
+        this.driver.on("error", onError);
+      }.bind(this));
 
-			if (this.listeners("error").length === 0) {
-				// since user want auto reconnect,
-				// don't emit without listeners or it will throw
-				return;
-			}
-		}
-		this.emit("error", err);
-	}.bind(this);
+      if (this.listeners("error").length === 0) {
+        // since user want auto reconnect,
+        // don't emit without listeners or it will throw
+        return;
+      }
+    }
+    this.emit("error", err);
+  }.bind(this);
 
-	driver.on("error", onError);
+  driver.on("error", onError);
 }
 
 util.inherits(ORM, events.EventEmitter);
 
 ORM.prototype.use = function (plugin_const, opts) {
-	if (typeof plugin_const === "string") {
-		try {
-			plugin_const = require(Utilities.getRealPath(plugin_const));
-		} catch (e) {
-			throw e;
-		}
-	}
+  if (typeof plugin_const === "string") {
+    try {
+      plugin_const = require(Utilities.getRealPath(plugin_const));
+    } catch (e) {
+      throw e;
+    }
+  }
 
-	var plugin = new plugin_const(this, opts || {});
+  var plugin = new plugin_const(this, opts || {});
 
-	if (typeof plugin.define === "function") {
-		for (var k in this.models) {
-			plugin.define(this.models[k]);
-		}
-	}
+  if (typeof plugin.define === "function") {
+    for (var k in this.models) {
+      plugin.define(this.models[k]);
+    }
+  }
 
-	this.plugins.push(plugin);
+  this.plugins.push(plugin);
 
-	return this;
+  return this;
 };
 ORM.prototype.define = function (name, properties, opts) {
     var i;
 
-	properties = properties || {};
-	opts       = opts || {};
+  properties = properties || {};
+  opts       = opts || {};
 
-	for (i = 0; i < this.plugins.length; i++) {
-		if (typeof this.plugins[i].beforeDefine === "function") {
-			this.plugins[i].beforeDefine(name, properties, opts);
-		}
-	}
+  for (i = 0; i < this.plugins.length; i++) {
+    if (typeof this.plugins[i].beforeDefine === "function") {
+      this.plugins[i].beforeDefine(name, properties, opts);
+    }
+  }
 
-	this.models[name] = new Model({
-		db             : this,
-		settings       : this.settings,
-		driver_name    : this.driver_name,
-		driver         : this.driver,
-		table          : opts.table || opts.collection || ((this.settings.get("model.namePrefix") || "") + name),
-		properties     : properties,
-		extension      : opts.extension || false,
-		indexes        : opts.indexes || [],
-		identityCache       : opts.hasOwnProperty("identityCache") ? opts.identityCache : this.settings.get("instance.identityCache"),
-		keys           : opts.id,
-		autoSave       : opts.hasOwnProperty("autoSave") ? opts.autoSave : this.settings.get("instance.autoSave"),
-		autoFetch      : opts.hasOwnProperty("autoFetch") ? opts.autoFetch : this.settings.get("instance.autoFetch"),
-		autoFetchLimit : opts.autoFetchLimit || this.settings.get("instance.autoFetchLimit"),
-		cascadeRemove  : opts.hasOwnProperty("cascadeRemove") ? opts.cascadeRemove : this.settings.get("instance.cascadeRemove"),
-		hooks          : opts.hooks || {},
-		methods        : opts.methods || {},
-		validations    : opts.validations || {}
-	});
+  this.models[name] = new Model({
+    db             : this,
+    settings       : this.settings,
+    driver_name    : this.driver_name,
+    driver         : this.driver,
+    table          : opts.table || opts.collection || ((this.settings.get("model.namePrefix") || "") + name),
+    properties     : properties,
+    extension      : opts.extension || false,
+    indexes        : opts.indexes || [],
+    identityCache       : opts.hasOwnProperty("identityCache") ? opts.identityCache : this.settings.get("instance.identityCache"),
+    keys           : opts.id,
+    autoSave       : opts.hasOwnProperty("autoSave") ? opts.autoSave : this.settings.get("instance.autoSave"),
+    autoFetch      : opts.hasOwnProperty("autoFetch") ? opts.autoFetch : this.settings.get("instance.autoFetch"),
+    autoFetchLimit : opts.autoFetchLimit || this.settings.get("instance.autoFetchLimit"),
+    cascadeRemove  : opts.hasOwnProperty("cascadeRemove") ? opts.cascadeRemove : this.settings.get("instance.cascadeRemove"),
+    hooks          : opts.hooks || {},
+    methods        : opts.methods || {},
+    validations    : opts.validations || {}
+  });
 
-	for (i = 0; i < this.plugins.length; i++) {
-		if (typeof this.plugins[i].define === "function") {
-			this.plugins[i].define(this.models[name], this);
-		}
-	}
+  for (i = 0; i < this.plugins.length; i++) {
+    if (typeof this.plugins[i].define === "function") {
+      this.plugins[i].define(this.models[name], this);
+    }
+  }
 
-	return this.models[name];
+  return this.models[name];
 };
 ORM.prototype.defineType = function (name, opts) {
-	this.customTypes[name] = opts;
-	this.driver.customTypes[name] = opts;
-	return this;
+  this.customTypes[name] = opts;
+  this.driver.customTypes[name] = opts;
+  return this;
 };
 ORM.prototype.ping = function (cb) {
-	this.driver.ping(cb);
+  this.driver.ping(cb);
 
-	return this;
+  return this;
 };
 ORM.prototype.close = function (cb) {
-	this.driver.close(cb);
+  this.driver.close(cb);
 
-	return this;
+  return this;
 };
 ORM.prototype.load = function () {
-	var files = _.flatten(Array.prototype.slice.apply(arguments));
-	var cb    = function () {};
+  var files = _.flatten(Array.prototype.slice.apply(arguments));
+  var cb    = function () {};
 
-	if (typeof files[files.length - 1] == "function") {
-		cb = files.pop();
-	}
+  if (typeof files[files.length - 1] == "function") {
+    cb = files.pop();
+  }
 
-	var loadNext = function () {
-		if (files.length === 0) {
-			return cb();
-		}
+  var loadNext = function () {
+    if (files.length === 0) {
+      return cb();
+    }
 
-		var file = files.shift();
+    var file = files.shift();
 
-		try {
-			return require(Utilities.getRealPath(file, 4))(this, function (err) {
-				if (err) return cb(err);
+    try {
+      return require(Utilities.getRealPath(file, 4))(this, function (err) {
+        if (err) return cb(err);
 
-				return loadNext();
-			});
-		} catch (ex) {
-			return cb(ex);
-		}
-	}.bind(this);
+        return loadNext();
+      });
+    } catch (ex) {
+      return cb(ex);
+    }
+  }.bind(this);
 
-	return loadNext();
+  return loadNext();
 };
 ORM.prototype.sync = function (cb) {
-	var modelIds = Object.keys(this.models);
-	var syncNext = function () {
-		if (modelIds.length === 0) {
-			return cb();
-		}
+  var modelIds = Object.keys(this.models);
+  var syncNext = function () {
+    if (modelIds.length === 0) {
+      return cb();
+    }
 
-		var modelId = modelIds.shift();
+    var modelId = modelIds.shift();
 
-		this.models[modelId].sync(function (err) {
-			if (err) {
-				err.model = modelId;
+    this.models[modelId].sync(function (err) {
+      if (err) {
+        err.model = modelId;
 
-				return cb(err);
-			}
+        return cb(err);
+      }
 
-			return syncNext();
-		});
-	}.bind(this);
+      return syncNext();
+    });
+  }.bind(this);
 
-	if (arguments.length === 0) {
-		cb = function () {};
-	}
+  if (arguments.length === 0) {
+    cb = function () {};
+  }
 
-	syncNext();
+  syncNext();
 
-	return this;
+  return this;
 };
 ORM.prototype.drop = function (cb) {
-	var modelIds = Object.keys(this.models);
-	var dropNext = function () {
-		if (modelIds.length === 0) {
-			return cb();
-		}
+  var modelIds = Object.keys(this.models);
+  var dropNext = function () {
+    if (modelIds.length === 0) {
+      return cb();
+    }
 
-		var modelId = modelIds.shift();
+    var modelId = modelIds.shift();
 
-		this.models[modelId].drop(function (err) {
-			if (err) {
-				err.model = modelId;
+    this.models[modelId].drop(function (err) {
+      if (err) {
+        err.model = modelId;
 
-				return cb(err);
-			}
+        return cb(err);
+      }
 
-			return dropNext();
-		});
-	}.bind(this);
+      return dropNext();
+    });
+  }.bind(this);
 
-	if (arguments.length === 0) {
-		cb = function () {};
-	}
+  if (arguments.length === 0) {
+    cb = function () {};
+  }
 
-	dropNext();
+  dropNext();
 
-	return this;
+  return this;
 };
 ORM.prototype.serial = function () {
-	var chains = Array.prototype.slice.apply(arguments);
+  var chains = Array.prototype.slice.apply(arguments);
 
-	return {
-		get: function (cb) {
-			var params = [];
-			var getNext = function () {
-				if (params.length === chains.length) {
-					params.unshift(null);
-					return cb.apply(null, params);
-				}
+  return {
+    get: function (cb) {
+      var params = [];
+      var getNext = function () {
+        if (params.length === chains.length) {
+          params.unshift(null);
+          return cb.apply(null, params);
+        }
 
-				chains[params.length].run(function (err, instances) {
-					if (err) {
-						params.unshift(err);
-						return cb.apply(null, params);
-					}
+        chains[params.length].run(function (err, instances) {
+          if (err) {
+            params.unshift(err);
+            return cb.apply(null, params);
+          }
 
-					params.push(instances);
-					return getNext();
-				});
-			};
+          params.push(instances);
+          return getNext();
+        });
+      };
 
-			getNext();
+      getNext();
 
-			return this;
-		}
-	};
+      return this;
+    }
+  };
 };
 
 function ORM_Error(err, cb) {
-	var Emitter = new events.EventEmitter();
+  var Emitter = new events.EventEmitter();
 
-	Emitter.use = Emitter.define = Emitter.sync = Emitter.load = function () {};
+  Emitter.use = Emitter.define = Emitter.sync = Emitter.load = function () {};
 
-	if (typeof cb === "function") {
-		cb(err);
-	}
+  if (typeof cb === "function") {
+    cb(err);
+  }
 
-	process.nextTick(function () {
-		Emitter.emit("connect", err);
-	});
+  process.nextTick(function () {
+    Emitter.emit("connect", err);
+  });
 
-	return Emitter;
+  return Emitter;
 }
 
 function queryParamCast (val) {
-	if (typeof val == 'string')	{
-		switch (val) {
-			case '1':
-			case 'true':
-				return true;
-			case '0':
-			case 'false':
-				return false;
-		}
-	}
-	return val;
+  if (typeof val == 'string')  {
+    switch (val) {
+      case '1':
+      case 'true':
+        return true;
+      case '0':
+      case 'false':
+        return false;
+    }
+  }
+  return val;
 }

--- a/lib/Promise.js
+++ b/lib/Promise.js
@@ -1,30 +1,30 @@
 exports.Promise = Promise;
 
 function Promise(opts) {
-	opts = opts || {};
+  opts = opts || {};
 
-	var success_cb = opts.success || null;
-	var fail_cb    = opts.fail    || null;
+  var success_cb = opts.success || null;
+  var fail_cb    = opts.fail    || null;
 
-	return {
-		handle: function (promise) {
-			promise(function (err) {
-				if (err) {
-					if (fail_cb) fail_cb(err);
-				} else {
-					var args = Array.prototype.slice.call(arguments, 1);
+  return {
+    handle: function (promise) {
+      promise(function (err) {
+        if (err) {
+          if (fail_cb) fail_cb(err);
+        } else {
+          var args = Array.prototype.slice.call(arguments, 1);
 
-					if (success_cb) success_cb.apply(null, args);
-				}
-			});
-		},
-		success: function (cb) {
-			success_cb = cb;
-			return this;
-		},
-		fail: function (cb) {
-			fail_cb = cb;
-			return this;
-		}
-	};
+          if (success_cb) success_cb.apply(null, args);
+        }
+      });
+    },
+    success: function (cb) {
+      success_cb = cb;
+      return this;
+    },
+    fail: function (cb) {
+      fail_cb = cb;
+      return this;
+    }
+  };
 }

--- a/lib/Property.js
+++ b/lib/Property.js
@@ -2,70 +2,70 @@ var _        = require('lodash');
 var ORMError = require("./Error");
 
 var KNOWN_TYPES = [
-	"text",   "number", "integer", "boolean", "date", "enum", "object",
-	"binary", "point",  "serial"
+  "text",   "number", "integer", "boolean", "date", "enum", "object",
+  "binary", "point",  "serial"
 ];
 
 exports.normalize = function (opts) {
-	if (typeof opts.prop === "function") {
-		switch (opts.prop.name) {
-			case "String":
-				opts.prop = { type: "text" };
-				break;
-			case "Number":
-				opts.prop = { type: "number" };
-				break;
-			case "Boolean":
-				opts.prop = { type: "boolean" };
-				break;
-			case "Date":
-				opts.prop = { type: "date" };
-				break;
-			case "Object":
-				opts.prop = { type: "object" };
-				break;
-			case "Buffer":
-				opts.prop = { type: "binary" };
-				break;
-		}
-	} else if (typeof opts.prop === "string") {
-		var tmp = opts.prop;
-		opts.prop = {};
-		opts.prop.type = tmp;
-	} else if (Array.isArray(opts.prop)) {
-		opts.prop = { type: "enum", values: opts.prop };
-	} else {
-		opts.prop = _.cloneDeep(opts.prop);
-	}
+  if (typeof opts.prop === "function") {
+    switch (opts.prop.name) {
+      case "String":
+        opts.prop = { type: "text" };
+        break;
+      case "Number":
+        opts.prop = { type: "number" };
+        break;
+      case "Boolean":
+        opts.prop = { type: "boolean" };
+        break;
+      case "Date":
+        opts.prop = { type: "date" };
+        break;
+      case "Object":
+        opts.prop = { type: "object" };
+        break;
+      case "Buffer":
+        opts.prop = { type: "binary" };
+        break;
+    }
+  } else if (typeof opts.prop === "string") {
+    var tmp = opts.prop;
+    opts.prop = {};
+    opts.prop.type = tmp;
+  } else if (Array.isArray(opts.prop)) {
+    opts.prop = { type: "enum", values: opts.prop };
+  } else {
+    opts.prop = _.cloneDeep(opts.prop);
+  }
 
-	if (KNOWN_TYPES.indexOf(opts.prop.type) === -1 && !(opts.prop.type in opts.customTypes)) {
-		throw new ORMError("Unknown property type: " + opts.prop.type, 'NO_SUPPORT');
-	}
+  if (KNOWN_TYPES.indexOf(opts.prop.type) === -1 && !(opts.prop.type in opts.customTypes)) {
+    throw new ORMError("Unknown property type: " + opts.prop.type, 'NO_SUPPORT');
+  }
 
-	if (!opts.prop.hasOwnProperty("required") && opts.settings.get("properties.required")) {
-		opts.prop.required = true;
-	}
+  if (!opts.prop.hasOwnProperty("required") && opts.settings.get("properties.required")) {
+    opts.prop.required = true;
+  }
 
-	// Defaults to true. Setting to false hides properties from JSON.stringify(modelInstance).
-	if (!opts.prop.hasOwnProperty("enumerable") || opts.prop.enumerable === true) {
-		opts.prop.enumerable = true;
-	}
+  // Defaults to true. Setting to false hides properties from JSON.stringify(modelInstance).
+  if (!opts.prop.hasOwnProperty("enumerable") || opts.prop.enumerable === true) {
+    opts.prop.enumerable = true;
+  }
 
-	// Defaults to true. Rational means floating point here.
-	if (opts.prop.type == "number" && opts.prop.rational === undefined) {
-		opts.prop.rational = true;
-	}
+  // Defaults to true. Rational means floating point here.
+  if (opts.prop.type == "number" && opts.prop.rational === undefined) {
+    opts.prop.rational = true;
+  }
 
-	if (!('mapsTo' in opts.prop)) {
-		opts.prop.mapsTo = opts.name
-	}
+  if (!('mapsTo' in opts.prop)) {
+    opts.prop.mapsTo = opts.name
+  }
 
-	if (opts.prop.type == "number" && opts.prop.rational === false) {
-		opts.prop.type = "integer";
-		delete opts.prop.rational;
-	}
+  if (opts.prop.type == "number" && opts.prop.rational === false) {
+    opts.prop.type = "integer";
+    delete opts.prop.rational;
+  }
 
-	opts.prop.name = opts.name;
+  opts.prop.name = opts.name;
 
-	return opts.prop;
+  return opts.prop;
 };

--- a/lib/Settings.js
+++ b/lib/Settings.js
@@ -1,114 +1,114 @@
 var _ = require('lodash');
 var default_settings = {
-	properties : {
-		primary_key               : "id",
-		association_key           : "{name}_{field}",
-		required                  : false
-	},
-	instance   : {
-		identityCache             : false,
-		identityCacheSaveCheck    : true,
-		autoSave                  : false,
-		autoFetch                 : false,
-		autoFetchLimit            : 1,
-		cascadeRemove             : true,
-		returnAllErrors           : false,
-		saveAssociationsByDefault : true
-	},
-	hasMany    : {
-		// Makes the foreign key fields a composite key
-		key                       : false
-	},
-	connection : {
-		reconnect                 : true,
-		pool                      : false,
-		debug                     : false
-	}
+  properties : {
+    primary_key               : "id",
+    association_key           : "{name}_{field}",
+    required                  : false
+  },
+  instance   : {
+    identityCache             : false,
+    identityCacheSaveCheck    : true,
+    autoSave                  : false,
+    autoFetch                 : false,
+    autoFetchLimit            : 1,
+    cascadeRemove             : true,
+    returnAllErrors           : false,
+    saveAssociationsByDefault : true
+  },
+  hasMany    : {
+    // Makes the foreign key fields a composite key
+    key                       : false
+  },
+  connection : {
+    reconnect                 : true,
+    pool                      : false,
+    debug                     : false
+  }
 };
 
 exports.Container = Settings;
 exports.defaults = function () {
-	return default_settings;
+  return default_settings;
 };
 
 function Settings(settings) {
-	this.settings = settings;
+  this.settings = settings;
 
-	return {
-		set: function (key, value) {
-			set(key, value, settings);
+  return {
+    set: function (key, value) {
+      set(key, value, settings);
 
-			return this;
-		},
-		get: function (key, def) {
-			var v = get(key, def, settings)
+      return this;
+    },
+    get: function (key, def) {
+      var v = get(key, def, settings)
 
-			if (v instanceof Function) {
-				return v;
-			} else {
-				return _.cloneDeep(v);
-			}
-		},
-		unset: function () {
-			for (var i = 0; i < arguments.length; i++) {
-				if (typeof arguments[i] === "string") {
-					unset(arguments[i], settings);
-				}
-			}
+      if (v instanceof Function) {
+        return v;
+      } else {
+        return _.cloneDeep(v);
+      }
+    },
+    unset: function () {
+      for (var i = 0; i < arguments.length; i++) {
+        if (typeof arguments[i] === "string") {
+          unset(arguments[i], settings);
+        }
+      }
 
-			return this;
-		}
-	};
+      return this;
+    }
+  };
 }
 
 function set(key, value, obj) {
-	var p = key.indexOf(".");
+  var p = key.indexOf(".");
 
-	if (p === -1) {
-		return obj[key] = value;
-	}
+  if (p === -1) {
+    return obj[key] = value;
+  }
 
-	if (!obj.hasOwnProperty(key.substr(0, p))) {
-		obj[key.substr(0, p)] = {};
-	}
+  if (!obj.hasOwnProperty(key.substr(0, p))) {
+    obj[key.substr(0, p)] = {};
+  }
 
-	return set(key.substr(p + 1), value, obj[key.substr(0, p)]);
+  return set(key.substr(p + 1), value, obj[key.substr(0, p)]);
 }
 
 function get(key, def, obj) {
-	var p = key.indexOf(".");
+  var p = key.indexOf(".");
 
-	if (p === -1) {
-		if (key === '*') {
-			return obj;
-		}
-		return obj.hasOwnProperty(key) ? obj[key] : def;
-	}
+  if (p === -1) {
+    if (key === '*') {
+      return obj;
+    }
+    return obj.hasOwnProperty(key) ? obj[key] : def;
+  }
 
-	if (!obj.hasOwnProperty(key.substr(0, p))) {
-		return def;
-	}
+  if (!obj.hasOwnProperty(key.substr(0, p))) {
+    return def;
+  }
 
-	return get(key.substr(p + 1), def, obj[key.substr(0, p)]);
+  return get(key.substr(p + 1), def, obj[key.substr(0, p)]);
 }
 
 function unset(key, obj) {
-	var p = key.indexOf(".");
+  var p = key.indexOf(".");
 
-	if (p === -1) {
-		if (key === '*') {
-			return 'reset';
-		} else {
-			delete obj[key];
-		}
-		return;
-	}
+  if (p === -1) {
+    if (key === '*') {
+      return 'reset';
+    } else {
+      delete obj[key];
+    }
+    return;
+  }
 
-	if (!obj.hasOwnProperty(key.substr(0, p))) {
-		return;
-	}
+  if (!obj.hasOwnProperty(key.substr(0, p))) {
+    return;
+  }
 
-	if (unset(key.substr(p + 1), obj[key.substr(0, p)]) === 'reset') {
-		obj[key.substr(0, p)] = {};
-	}
+  if (unset(key.substr(p + 1), obj[key.substr(0, p)]) === 'reset') {
+    obj[key.substr(0, p)] = {};
+  }
 }

--- a/lib/Singleton.js
+++ b/lib/Singleton.js
@@ -1,36 +1,36 @@
 var map = {};
 
 exports.clear = function (key) {
-	if (typeof key === "string") {
-		delete map[key];
-	} else {
-		map = {};
-	}
-	return this;
+  if (typeof key === "string") {
+    delete map[key];
+  } else {
+    map = {};
+  }
+  return this;
 };
 
 exports.get = function (key, opts, createCb, returnCb) {
-	if (opts && opts.identityCache === false) {
-		return createCb(returnCb);
-	}
-	if (map.hasOwnProperty(key)) {
-		if (opts && opts.saveCheck && typeof map[key].o.saved === "function" && !map[key].o.saved()) {
-			// if not saved, don't return it, fetch original from db
-			return createCb(returnCb);
-		} else if (map[key].t !== null && map[key].t <= Date.now()) {
-			delete map[key];
-		} else  {
-			return returnCb(null, map[key].o);
-		}
-	}
+  if (opts && opts.identityCache === false) {
+    return createCb(returnCb);
+  }
+  if (map.hasOwnProperty(key)) {
+    if (opts && opts.saveCheck && typeof map[key].o.saved === "function" && !map[key].o.saved()) {
+      // if not saved, don't return it, fetch original from db
+      return createCb(returnCb);
+    } else if (map[key].t !== null && map[key].t <= Date.now()) {
+      delete map[key];
+    } else  {
+      return returnCb(null, map[key].o);
+    }
+  }
 
-	createCb(function (err, value) {
-		if (err) return returnCb(err);
+  createCb(function (err, value) {
+    if (err) return returnCb(err);
 
-		map[key] = { // object , timeout
-			o : value,
-			t : (opts && typeof opts.identityCache === "number" ? Date.now() + (opts.identityCache * 1000) : null)
-		};
-		return returnCb(null, map[key].o);
-	});
+    map[key] = { // object , timeout
+      o : value,
+      t : (opts && typeof opts.identityCache === "number" ? Date.now() + (opts.identityCache * 1000) : null)
+    };
+    return returnCb(null, map[key].o);
+  });
 };

--- a/lib/Utilities.js
+++ b/lib/Utilities.js
@@ -18,32 +18,32 @@ var _ = require('lodash')
  * ...
  */
 exports.standardizeOrder = function (order) {
-	if (typeof order === "string") {
-		if (order[0] === "-") {
-			return [ [ order.substr(1), "Z" ] ];
-		}
-		return [ [ order, "A" ] ];
-	}
+  if (typeof order === "string") {
+    if (order[0] === "-") {
+      return [ [ order.substr(1), "Z" ] ];
+    }
+    return [ [ order, "A" ] ];
+  }
 
-	var new_order = [], minus;
+  var new_order = [], minus;
 
-	for (var i = 0; i < order.length; i++) {
-		minus = (order[i][0] === "-");
+  for (var i = 0; i < order.length; i++) {
+    minus = (order[i][0] === "-");
 
-		if (i < order.length - 1 && [ "A", "Z" ].indexOf(order[i + 1].toUpperCase()) >= 0) {
-			new_order.push([
-				(minus ? order[i].substr(1) : order[i]),
-				order[i + 1]
-			]);
-			i += 1;
-		} else if (minus) {
-			new_order.push([ order[i].substr(1), "Z" ]);
-		} else {
-			new_order.push([ order[i], "A" ]);
-		}
-	}
+    if (i < order.length - 1 && [ "A", "Z" ].indexOf(order[i + 1].toUpperCase()) >= 0) {
+      new_order.push([
+        (minus ? order[i].substr(1) : order[i]),
+        order[i + 1]
+      ]);
+      i += 1;
+    } else if (minus) {
+      new_order.push([ order[i].substr(1), "Z" ]);
+    } else {
+      new_order.push([ order[i], "A" ]);
+    }
+  }
 
-	return new_order;
+  return new_order;
 };
 
 /**
@@ -56,54 +56,54 @@ exports.standardizeOrder = function (order) {
  * F) Itterate through values for the condition, only accept instances of the same type as the association
  */
 exports.checkConditions = function (conditions, one_associations) {
-	var k, i, j;
+  var k, i, j;
 
-	// A)
-	var associations = {};
-	for (i = 0; i < one_associations.length; i++) {
-		associations[one_associations[i].name] = one_associations[i];
-	}
+  // A)
+  var associations = {};
+  for (i = 0; i < one_associations.length; i++) {
+    associations[one_associations[i].name] = one_associations[i];
+  }
 
-	for (k in conditions) {
-		// B)
-		if (!associations.hasOwnProperty(k)) continue;
+  for (k in conditions) {
+    // B)
+    if (!associations.hasOwnProperty(k)) continue;
 
-		// C)
-		var values = conditions[k];
-		if (!Array.isArray(values)) values = [values];
+    // C)
+    var values = conditions[k];
+    if (!Array.isArray(values)) values = [values];
 
-		// D)
-		delete conditions[k];
+    // D)
+    delete conditions[k];
 
-		// E)
-		var association_fields = Object.keys(associations[k].field);
-		var model = associations[k].model;
+    // E)
+    var association_fields = Object.keys(associations[k].field);
+    var model = associations[k].model;
 
-		// F)
-		for (i = 0; i < values.length; i++) {
-			if (values[i].isInstance && values[i].model().uid === model.uid) {
-				if (association_fields.length === 1) {
-					if (typeof conditions[association_fields[0]] === 'undefined') {
-						conditions[association_fields[0]] = values[i][model.id[0]];
-					} else if(Array.isArray(conditions[association_fields[0]])) {
-						conditions[association_fields[0]].push(values[i][model.id[0]]);
-					} else {
-						conditions[association_fields[0]] = [conditions[association_fields[0]], values[i][model.id[0]]];
-					}
-				} else {
-					var _conds = {};
-					for (j = 0; j < association_fields.length; i++) {
-						_conds[association_fields[j]] = values[i][model.id[j]];
-					}
+    // F)
+    for (i = 0; i < values.length; i++) {
+      if (values[i].isInstance && values[i].model().uid === model.uid) {
+        if (association_fields.length === 1) {
+          if (typeof conditions[association_fields[0]] === 'undefined') {
+            conditions[association_fields[0]] = values[i][model.id[0]];
+          } else if(Array.isArray(conditions[association_fields[0]])) {
+            conditions[association_fields[0]].push(values[i][model.id[0]]);
+          } else {
+            conditions[association_fields[0]] = [conditions[association_fields[0]], values[i][model.id[0]]];
+          }
+        } else {
+          var _conds = {};
+          for (j = 0; j < association_fields.length; i++) {
+            _conds[association_fields[j]] = values[i][model.id[j]];
+          }
 
-					conditions.or = conditions.or || [];
-					conditions.or.push(_conds);
-				}
-			}
-		}
-	}
+          conditions.or = conditions.or || [];
+          conditions.or.push(_conds);
+        }
+      }
+    }
+  }
 
-	return conditions;
+  return conditions;
 };
 
 /**
@@ -111,237 +111,237 @@ exports.checkConditions = function (conditions, one_associations) {
  * using a keys array to get only specific values
  */
 exports.values = function (obj, keys) {
-	var i, k, vals = [];
+  var i, k, vals = [];
 
-	if (keys) {
-		for (i = 0; i < keys.length; i++) {
-			vals.push(obj[keys[i]]);
-		}
-	} else if (Array.isArray(obj)) {
-		for (i = 0; i < obj.length; i++) {
-			vals.push(obj[i]);
-		}
-	} else {
-		for (k in obj) {
-			if (!/[0-9]+/.test(k)) {
-				vals.push(obj[k]);
-			}
-		}
-	}
-	return vals;
+  if (keys) {
+    for (i = 0; i < keys.length; i++) {
+      vals.push(obj[keys[i]]);
+    }
+  } else if (Array.isArray(obj)) {
+    for (i = 0; i < obj.length; i++) {
+      vals.push(obj[i]);
+    }
+  } else {
+    for (k in obj) {
+      if (!/[0-9]+/.test(k)) {
+        vals.push(obj[k]);
+      }
+    }
+  }
+  return vals;
 };
 
 // Qn:       is Zero a valid value for a FK column?
 // Why?      Well I've got a pre-existing database that started all its 'serial' IDs at zero...
 // Answer:   hasValues() is only used in hasOne association, so it's probably ok...
 exports.hasValues = function (obj, keys) {
-	for (var i = 0; i < keys.length; i++) {
-		if (!obj[keys[i]] && obj[keys[i]] !== 0) return false;  // 0 is also a good value...
-	}
-	return true;
+  for (var i = 0; i < keys.length; i++) {
+    if (!obj[keys[i]] && obj[keys[i]] !== 0) return false;  // 0 is also a good value...
+  }
+  return true;
 };
 
 exports.populateConditions = function (model, fields, source, target, overwrite) {
-	for (var i = 0; i < model.id.length; i++) {
-		if (typeof target[fields[i]] === 'undefined' || overwrite !== false) {
-			target[fields[i]] = source[model.id[i]];
-		} else if (Array.isArray(target[fields[i]])) {
-			target[fields[i]].push(source[model.id[i]]);
-		} else {
-			target[fields[i]] = [target[fields[i]], source[model.id[i]]];
-		}
-	}
+  for (var i = 0; i < model.id.length; i++) {
+    if (typeof target[fields[i]] === 'undefined' || overwrite !== false) {
+      target[fields[i]] = source[model.id[i]];
+    } else if (Array.isArray(target[fields[i]])) {
+      target[fields[i]].push(source[model.id[i]]);
+    } else {
+      target[fields[i]] = [target[fields[i]], source[model.id[i]]];
+    }
+  }
 };
 
 exports.getConditions = function (model, fields, from) {
-	var conditions = {};
+  var conditions = {};
 
-	exports.populateConditions(model, fields, from, conditions);
+  exports.populateConditions(model, fields, from, conditions);
 
-	return conditions;
+  return conditions;
 };
 
 exports.wrapFieldObject = function (params) {
-	if (!params.field) {
-		var assoc_key = params.model.settings.get("properties.association_key");
+  if (!params.field) {
+    var assoc_key = params.model.settings.get("properties.association_key");
 
-		if (typeof assoc_key === "function") {
-		    params.field = assoc_key(params.altName.toLowerCase(), params.model.id[0]);
-		} else {
-			params.field = assoc_key.replace("{name}", params.altName.toLowerCase())
-			               .replace("{field}", params.model.id[0]);
-		}
-	}
+    if (typeof assoc_key === "function") {
+        params.field = assoc_key(params.altName.toLowerCase(), params.model.id[0]);
+    } else {
+      params.field = assoc_key.replace("{name}", params.altName.toLowerCase())
+                     .replace("{field}", params.model.id[0]);
+    }
+  }
 
-	if (typeof params.field == 'object') {
-		for (var k in params.field) {
-			if (!/[0-9]+/.test(k) && params.field.hasOwnProperty(k)) {
-				return params.field;
-			}
-		}
-	}
+  if (typeof params.field == 'object') {
+    for (var k in params.field) {
+      if (!/[0-9]+/.test(k) && params.field.hasOwnProperty(k)) {
+        return params.field;
+      }
+    }
+  }
 
-	var newObj = {}, newProp, propPreDefined, propFromKey;
+  var newObj = {}, newProp, propPreDefined, propFromKey;
 
-	propPreDefined = params.model.properties[params.field];
-	propFromKey    = params.model.properties[params.model.id[0]];
-	newProp        = { type: 'integer' };
+  propPreDefined = params.model.properties[params.field];
+  propFromKey    = params.model.properties[params.model.id[0]];
+  newProp        = { type: 'integer' };
 
-	var prop = _.cloneDeep(propPreDefined || propFromKey || newProp);
+  var prop = _.cloneDeep(propPreDefined || propFromKey || newProp);
 
-	if (!propPreDefined) {
-		_.extend(prop, {
-			name: params.field, mapsTo: params.mapsTo || params.field
-		});
-	}
+  if (!propPreDefined) {
+    _.extend(prop, {
+      name: params.field, mapsTo: params.mapsTo || params.field
+    });
+  }
 
-	newObj[params.field] = prop;
+  newObj[params.field] = prop;
 
-	return newObj;
+  return newObj;
 };
 
 exports.formatField = function (model, name, required, reversed) {
-	var fields = {}, field_opts, field_name;
-	var keys = model.id;
-	var assoc_key = model.settings.get("properties.association_key");
+  var fields = {}, field_opts, field_name;
+  var keys = model.id;
+  var assoc_key = model.settings.get("properties.association_key");
 
-	for (var i = 0; i < keys.length; i++) {
-		if (reversed) {
-			field_name = keys[i];
-		} else if (typeof assoc_key === "function") {
-			field_name = assoc_key(name.toLowerCase(), keys[i]);
-		} else {
-			field_name = assoc_key.replace("{name}", name.toLowerCase())
-			                      .replace("{field}", keys[i]);
-		}
+  for (var i = 0; i < keys.length; i++) {
+    if (reversed) {
+      field_name = keys[i];
+    } else if (typeof assoc_key === "function") {
+      field_name = assoc_key(name.toLowerCase(), keys[i]);
+    } else {
+      field_name = assoc_key.replace("{name}", name.toLowerCase())
+                            .replace("{field}", keys[i]);
+    }
 
-		if (model.properties.hasOwnProperty(keys[i])) {
-			var p = model.properties[keys[i]];
+    if (model.properties.hasOwnProperty(keys[i])) {
+      var p = model.properties[keys[i]];
 
-			field_opts = {
-				type     : p.type || "integer",
-				size     : p.size || 4,
-				unsigned : p.unsigned || true,
-				time     : p.time || false,
-				big      : p.big || false,
-				values   : p.values || null,
-				required : required,
-				name     : field_name,
-				mapsTo   : field_name
-			};
-		} else {
-			field_opts = {
-				type     : "integer",
-				unsigned : true,
-				size     : 4,
-				required : required,
-				name     : field_name,
-				mapsTo   : field_name
-			};
-		}
+      field_opts = {
+        type     : p.type || "integer",
+        size     : p.size || 4,
+        unsigned : p.unsigned || true,
+        time     : p.time || false,
+        big      : p.big || false,
+        values   : p.values || null,
+        required : required,
+        name     : field_name,
+        mapsTo   : field_name
+      };
+    } else {
+      field_opts = {
+        type     : "integer",
+        unsigned : true,
+        size     : 4,
+        required : required,
+        name     : field_name,
+        mapsTo   : field_name
+      };
+    }
 
-		fields[field_name] = field_opts;
-	}
+    fields[field_name] = field_opts;
+  }
 
-	return fields;
+  return fields;
 };
 
 // If the parent associations key is `serial`, the join tables
 // key should be changed to `integer`.
 exports.convertPropToJoinKeyProp = function (props, opts) {
-	var prop;
+  var prop;
 
-	for (var k in props) {
-		prop = props[k];
+  for (var k in props) {
+    prop = props[k];
 
-		prop.required = opts.required;
+    prop.required = opts.required;
 
-		if (prop.type == 'serial') {
-			prop.type = 'integer';
-		}
-		if (opts.makeKey) {
-			prop.key = true;
-		} else {
-			delete prop.key;
-		}
-	}
+    if (prop.type == 'serial') {
+      prop.type = 'integer';
+    }
+    if (opts.makeKey) {
+      prop.key = true;
+    } else {
+      delete prop.key;
+    }
+  }
 
-	return props;
+  return props;
 }
 
 exports.getRealPath = function (path_str, stack_index) {
-	var path = require("path"); // for now, load here (only when needed)
-	var cwd = process.cwd();
-	var err = new Error();
-	var tmp = err.stack.split(/\r?\n/)[typeof stack_index !== "undefined" ? stack_index : 3], m;
+  var path = require("path"); // for now, load here (only when needed)
+  var cwd = process.cwd();
+  var err = new Error();
+  var tmp = err.stack.split(/\r?\n/)[typeof stack_index !== "undefined" ? stack_index : 3], m;
 
-	if ((m = tmp.match(/^\s*at\s+(.+):\d+:\d+$/)) !== null) {
-		cwd = path.dirname(m[1]);
-	} else if ((m = tmp.match(/^\s*at\s+module\.exports\s+\((.+?)\)/)) !== null) {
-		cwd = path.dirname(m[1]);
-	} else if ((m = tmp.match(/^\s*at\s+.+\s+\((.+):\d+:\d+\)$/)) !== null) {
-		cwd = path.dirname(m[1]);
-	}
-	var pathIsAbsolute = path.isAbsolute || require('path-is-absolute');
-	if (!pathIsAbsolute(path_str)) {
-		path_str = path.join(cwd, path_str);
-	}
-	if (path_str.substr(-1) === path.sep) {
-		path_str += "index";
-	}
+  if ((m = tmp.match(/^\s*at\s+(.+):\d+:\d+$/)) !== null) {
+    cwd = path.dirname(m[1]);
+  } else if ((m = tmp.match(/^\s*at\s+module\.exports\s+\((.+?)\)/)) !== null) {
+    cwd = path.dirname(m[1]);
+  } else if ((m = tmp.match(/^\s*at\s+.+\s+\((.+):\d+:\d+\)$/)) !== null) {
+    cwd = path.dirname(m[1]);
+  }
+  var pathIsAbsolute = path.isAbsolute || require('path-is-absolute');
+  if (!pathIsAbsolute(path_str)) {
+    path_str = path.join(cwd, path_str);
+  }
+  if (path_str.substr(-1) === path.sep) {
+    path_str += "index";
+  }
 
-	return path_str;
+  return path_str;
 };
 
 exports.transformPropertyNames = function (dataIn, properties) {
-	var k, prop;
-	var dataOut = {};
+  var k, prop;
+  var dataOut = {};
 
-	for (k in dataIn) {
-		prop = properties[k];
-		if (prop) {
-			dataOut[prop.mapsTo] = dataIn[k];
-		} else {
-			dataOut[k] = dataIn[k];
-		}
-	}
-	return dataOut;
+  for (k in dataIn) {
+    prop = properties[k];
+    if (prop) {
+      dataOut[prop.mapsTo] = dataIn[k];
+    } else {
+      dataOut[k] = dataIn[k];
+    }
+  }
+  return dataOut;
 };
 
 exports.transformOrderPropertyNames = function (order, properties) {
-	if (!order) return order;
+  if (!order) return order;
 
-	var i, item;
-	var newOrder = JSON.parse(JSON.stringify(order));
+  var i, item;
+  var newOrder = JSON.parse(JSON.stringify(order));
 
-	// Rename order properties according to mapsTo
-	for (var i = 0; i < newOrder.length; i++) {
-		item = newOrder[i];
+  // Rename order properties according to mapsTo
+  for (var i = 0; i < newOrder.length; i++) {
+    item = newOrder[i];
 
-		// orderRaw
-		if (Array.isArray(item[1])) continue;
+    // orderRaw
+    if (Array.isArray(item[1])) continue;
 
-		if (Array.isArray(item[0])) {
-			// order on a hasMany
-			// [ ['modelName', 'propName'], 'Z']
-			item[0][1] = properties[item[0][1]].mapsTo;
-		} else {
-			// normal order
-			item[0] = properties[item[0]].mapsTo;
-		}
-	}
-	return newOrder;
+    if (Array.isArray(item[0])) {
+      // order on a hasMany
+      // [ ['modelName', 'propName'], 'Z']
+      item[0][1] = properties[item[0][1]].mapsTo;
+    } else {
+      // normal order
+      item[0] = properties[item[0]].mapsTo;
+    }
+  }
+  return newOrder;
 }
 
 exports.renameDatastoreFieldsToPropertyNames = function (data, fieldToPropertyMap) {
-	var k, prop;
+  var k, prop;
 
-	for (k in data) {
-		prop = fieldToPropertyMap[k];
-		if (prop && prop.name != k) {
-			data[prop.name] = data[k];
-			delete data[k];
-		}
-	}
-	return data;
+  for (k in data) {
+    prop = fieldToPropertyMap[k];
+    if (prop && prop.name != k) {
+      data[prop.name] = data[k];
+      delete data[k];
+    }
+  }
+  return data;
 }

--- a/lib/Validators.js
+++ b/lib/Validators.js
@@ -2,18 +2,18 @@ var enforce = require("enforce");
 var util    = require("util");
 
 var validators = {
-	required       : enforce.required,
-	notEmptyString : enforce.notEmptyString,
+  required       : enforce.required,
+  notEmptyString : enforce.notEmptyString,
 
-	rangeNumber    : enforce.ranges.number,
-	rangeLength    : enforce.ranges.length,
+  rangeNumber    : enforce.ranges.number,
+  rangeLength    : enforce.ranges.length,
 
-	insideList     : enforce.lists.inside,
-	outsideList    : enforce.lists.outside,
+  insideList     : enforce.lists.inside,
+  outsideList    : enforce.lists.outside,
 
-	password       : enforce.security.password,
+  password       : enforce.security.password,
 
-	patterns       : enforce.patterns
+  patterns       : enforce.patterns
 };
 
 
@@ -23,12 +23,12 @@ var validators = {
  * checking).
  **/
 validators.equalToProperty = function (name, msg) {
-	return function (v, next) {
-		if (v === this[name]) {
-			return next();
-		}
-		return next(msg || 'not-equal-to-property');
-	};
+  return function (v, next) {
+    if (v === this[name]) {
+      return next();
+    }
+    return next(msg || 'not-equal-to-property');
+  };
 };
 
 /**
@@ -46,77 +46,77 @@ validators.equalToProperty = function (name, msg) {
  *   scope: (Array) scope uniqueness to listed properties
  **/
 validators.unique = function () {
-	var arg, k;
-	var msg = null, opts = {};
+  var arg, k;
+  var msg = null, opts = {};
 
-	for (k in arguments) {
-		arg = arguments[k];
-		if (typeof arg === "string") {
-			msg = arg;
-		} else if (typeof arg === "object") {
-			opts = arg;
-		}
-	}
+  for (k in arguments) {
+    arg = arguments[k];
+    if (typeof arg === "string") {
+      msg = arg;
+    } else if (typeof arg === "object") {
+      opts = arg;
+    }
+  }
 
-	return function (v, next, ctx) {
-		var s, scopeProp;
+  return function (v, next, ctx) {
+    var s, scopeProp;
 
-		if (typeof v === "undefined" || v === null) {
-			return next();
-		}
+    if (typeof v === "undefined" || v === null) {
+      return next();
+    }
 
-		//Cannot process on database engines which don't support SQL syntax
-		if (!ctx.driver.isSql) {
-			return next('not-supported');
-		}
+    //Cannot process on database engines which don't support SQL syntax
+    if (!ctx.driver.isSql) {
+      return next('not-supported');
+    }
 
-		var chain = ctx.model.find();
+    var chain = ctx.model.find();
 
-		var chainQuery = function (prop, value) {
-			var query = null;
+    var chainQuery = function (prop, value) {
+      var query = null;
 
-			if (opts.ignoreCase === true && ctx.model.properties[prop] && ctx.model.properties[prop].type === 'text') {
-				query = util.format('LOWER(%s.%s) LIKE LOWER(?)',
-					ctx.driver.query.escapeId(ctx.model.table), ctx.driver.query.escapeId(prop)
-				);
-				chain.where(query, [value]);
-			} else {
-				query = {};
-				query[prop] = value;
-				chain.where(query);
-			}
-		};
+      if (opts.ignoreCase === true && ctx.model.properties[prop] && ctx.model.properties[prop].type === 'text') {
+        query = util.format('LOWER(%s.%s) LIKE LOWER(?)',
+          ctx.driver.query.escapeId(ctx.model.table), ctx.driver.query.escapeId(prop)
+        );
+        chain.where(query, [value]);
+      } else {
+        query = {};
+        query[prop] = value;
+        chain.where(query);
+      }
+    };
 
-		var handler = function (err, records) {
-			if (err) {
-				return next();
-			}
-			if (!records || records.length === 0) {
-				return next();
-			}
-			if (records.length === 1 && records[0][ctx.model.id] === this[ctx.model.id]) {
-				return next();
-			}
-			return next(msg || 'not-unique');
-		}.bind(this);
+    var handler = function (err, records) {
+      if (err) {
+        return next();
+      }
+      if (!records || records.length === 0) {
+        return next();
+      }
+      if (records.length === 1 && records[0][ctx.model.id] === this[ctx.model.id]) {
+        return next();
+      }
+      return next(msg || 'not-unique');
+    }.bind(this);
 
-		chainQuery(ctx.property, v);
+    chainQuery(ctx.property, v);
 
-		if (opts.scope) {
-			for (s in opts.scope) {
-				scopeProp = opts.scope[s];
+    if (opts.scope) {
+      for (s in opts.scope) {
+        scopeProp = opts.scope[s];
 
-				// In SQL unique index land, NULL values are not considered equal.
-				if (typeof ctx.instance[scopeProp] == 'undefined' || ctx.instance[scopeProp] === null) {
-					return next();
-				}
+        // In SQL unique index land, NULL values are not considered equal.
+        if (typeof ctx.instance[scopeProp] == 'undefined' || ctx.instance[scopeProp] === null) {
+          return next();
+        }
 
-				chainQuery(scopeProp, ctx.instance[scopeProp]);
-			}
-		}
+        chainQuery(scopeProp, ctx.instance[scopeProp]);
+      }
+    }
 
-		chain.all(handler);
-	};
+    chain.all(handler);
+  };
 };
 
 module.exports = validators;

--- a/package.json
+++ b/package.json
@@ -1,84 +1,84 @@
 {
-	"author": "Diogo Resende <dresende@thinkdigital.pt>",
-	"name": "orm",
-	"description": "NodeJS Object-relational mapping",
-	"keywords": [
-		"orm",
-		"odm",
-		"database",
-		"mysql",
-		"postgres",
-		"redshift",
-		"sqlite",
-		"mongodb"
-	],
-	"version": "3.2.4",
-	"license": "MIT",
-	"homepage": "http://dresende.github.io/node-orm2",
-	"repository": "http://github.com/dresende/node-orm2.git",
-	"contributors": [
-		{
-			"name": "Bramus Van Damme",
-			"email": "bramus@bram.us"
-		},
-		{
-			"name": "Lorien Gamaroff",
-			"email": "lorien@gamaroff.org"
-		},
-		{
-			"name": "preslavrachev"
-		},
-		{
-			"name": "Chris Cowan",
-			"email": "me@chriscowan.us"
-		},
-		{
-			"name": "Paul Dixon",
-			"email": "paul.dixon@mintbridge.co.uk"
-		},
-		{
-			"name": "David Kosub"
-		},
-		{
-			"name": "Arek W",
-			"email": "arek01@gmail.com"
-		},
-		{
-			"name": "Joseph Gilley",
-			"email": "joe.gilley@gmail.com"
-		},
-		{
-			"name": "Benjamin Pannell",
-			"email": "admin@sierrasoftworks.com"
-		}
-	],
-	"main": "./lib/ORM",
-	"scripts": {
-		"test": "make test"
-	},
-	"engines": {
-		"node": "*"
-	},
-	"analyse": false,
-	"dependencies": {
-		"async": "2.5.0",
-		"enforce": "0.1.7",
-		"hat": "0.0.3",
-		"lodash": "4.17.4",
-		"path-is-absolute": "1.0.1",
-		"sql-query": "0.1.26",
-		"sql-ddl-sync": "0.3.13"
-	},
-	"devDependencies": {
-		"chalk": "2.0.1",
-		"glob": "7.1.2",
-		"mocha": "3.4.2",
-		"mongodb": "1.4.10",
-		"mysql": "2.13.0",
-		"pg": "6.4.1",
-		"semver": "5.3.0",
-		"should": "11.2.1",
-		"sqlite3": "3.1.8"
-	},
-	"optionalDependencies": {}
+  "author": "Diogo Resende <dresende@thinkdigital.pt>",
+  "name": "orm",
+  "description": "NodeJS Object-relational mapping",
+  "keywords": [
+    "orm",
+    "odm",
+    "database",
+    "mysql",
+    "postgres",
+    "redshift",
+    "sqlite",
+    "mongodb"
+  ],
+  "version": "3.2.4",
+  "license": "MIT",
+  "homepage": "http://dresende.github.io/node-orm2",
+  "repository": "http://github.com/dresende/node-orm2.git",
+  "contributors": [
+    {
+      "name": "Bramus Van Damme",
+      "email": "bramus@bram.us"
+    },
+    {
+      "name": "Lorien Gamaroff",
+      "email": "lorien@gamaroff.org"
+    },
+    {
+      "name": "preslavrachev"
+    },
+    {
+      "name": "Chris Cowan",
+      "email": "me@chriscowan.us"
+    },
+    {
+      "name": "Paul Dixon",
+      "email": "paul.dixon@mintbridge.co.uk"
+    },
+    {
+      "name": "David Kosub"
+    },
+    {
+      "name": "Arek W",
+      "email": "arek01@gmail.com"
+    },
+    {
+      "name": "Joseph Gilley",
+      "email": "joe.gilley@gmail.com"
+    },
+    {
+      "name": "Benjamin Pannell",
+      "email": "admin@sierrasoftworks.com"
+    }
+  ],
+  "main": "./lib/ORM",
+  "scripts": {
+    "test": "make test"
+  },
+  "engines": {
+    "node": "*"
+  },
+  "analyse": false,
+  "dependencies": {
+    "async": "2.5.0",
+    "enforce": "0.1.7",
+    "hat": "0.0.3",
+    "lodash": "4.17.4",
+    "path-is-absolute": "1.0.1",
+    "sql-query": "0.1.26",
+    "sql-ddl-sync": "0.3.13"
+  },
+  "devDependencies": {
+    "chalk": "2.0.1",
+    "glob": "7.1.2",
+    "mocha": "3.4.2",
+    "mongodb": "1.4.10",
+    "mysql": "2.13.0",
+    "pg": "6.4.1",
+    "semver": "5.3.0",
+    "should": "11.2.1",
+    "sqlite3": "3.1.8"
+  },
+  "optionalDependencies": {}
 }

--- a/test/common.js
+++ b/test/common.js
@@ -10,163 +10,163 @@ var ORM         = require('../');
 common.ORM = ORM;
 
 common.protocol = function () {
-	return process.env.ORM_PROTOCOL;
+  return process.env.ORM_PROTOCOL;
 };
 
 common.isTravis = function() {
-	return Boolean(process.env.CI);
+  return Boolean(process.env.CI);
 };
 
 common.createConnection = function(opts, cb) {
-	ORM.connect(this.getConnectionString(opts), cb);
+  ORM.connect(this.getConnectionString(opts), cb);
 };
 
 common.hasConfig = function (proto) {
-	var config;
+  var config;
 
-	if (common.isTravis()) return 'found';
+  if (common.isTravis()) return 'found';
 
-	try {
-		config = require("./config");
-	} catch (ex) {
-		return 'not-found';
-	}
+  try {
+    config = require("./config");
+  } catch (ex) {
+    return 'not-found';
+  }
 
-	return (config.hasOwnProperty(proto) ? 'found' : 'not-defined');
+  return (config.hasOwnProperty(proto) ? 'found' : 'not-defined');
 };
 
 common.getConfig = function () {
-	if (common.isTravis()) {
-		switch (this.protocol()) {
-			case 'mysql':
-				return { user: "root", host: "localhost", database: "orm_test" };
-			case 'postgres':
-			case 'redshift':
-				return { user: "postgres", host: "localhost", database: "orm_test" };
-			case 'sqlite':
-				return {};
-			case 'mongodb':
-				return { host: "localhost", database: "test" };
-			default:
-				throw new Error("Unknown protocol");
-		}
-	} else {
-		var config = require("./config")[this.protocol()];
-		if (typeof config == "string") {
-			config = require("url").parse(config);
-		}
-		if (config.hasOwnProperty("auth")) {
-			if (config.auth.indexOf(":") >= 0) {
-				config.user = config.auth.substr(0, config.auth.indexOf(":"));
-				config.password = config.auth.substr(config.auth.indexOf(":") + 1);
-			} else {
-				config.user = config.auth;
-				config.password = "";
-			}
-		}
-		if (config.hostname) {
-			config.host = config.hostname;
-		}
+  if (common.isTravis()) {
+    switch (this.protocol()) {
+      case 'mysql':
+        return { user: "root", host: "localhost", database: "orm_test" };
+      case 'postgres':
+      case 'redshift':
+        return { user: "postgres", host: "localhost", database: "orm_test" };
+      case 'sqlite':
+        return {};
+      case 'mongodb':
+        return { host: "localhost", database: "test" };
+      default:
+        throw new Error("Unknown protocol");
+    }
+  } else {
+    var config = require("./config")[this.protocol()];
+    if (typeof config == "string") {
+      config = require("url").parse(config);
+    }
+    if (config.hasOwnProperty("auth")) {
+      if (config.auth.indexOf(":") >= 0) {
+        config.user = config.auth.substr(0, config.auth.indexOf(":"));
+        config.password = config.auth.substr(config.auth.indexOf(":") + 1);
+      } else {
+        config.user = config.auth;
+        config.password = "";
+      }
+    }
+    if (config.hostname) {
+      config.host = config.hostname;
+    }
 
-		return config;
-	}
+    return config;
+  }
 };
 
 common.getConnectionString = function (opts) {
-	var config   = this.getConfig();
-	var protocol = this.protocol();
-	var query;
+  var config   = this.getConfig();
+  var protocol = this.protocol();
+  var query;
 
-	_.defaults(config, {
-		user     : { postgres: 'postgres', redshift: 'postgres', mongodb: '' }[protocol] || 'root',
-		database : { mongodb:  'test'     }[protocol] || 'orm_test',
-		password : '',
-		host     : 'localhost',
-		pathname : '',
-		query    : {}
-	});
-	_.merge(config, opts || {});
+  _.defaults(config, {
+    user     : { postgres: 'postgres', redshift: 'postgres', mongodb: '' }[protocol] || 'root',
+    database : { mongodb:  'test'     }[protocol] || 'orm_test',
+    password : '',
+    host     : 'localhost',
+    pathname : '',
+    query    : {}
+  });
+  _.merge(config, opts || {});
 
-	query = querystring.stringify(config.query);
+  query = querystring.stringify(config.query);
 
-	switch (protocol) {
-		case 'mysql':
-		case 'postgres':
-		case 'redshift':
-		case 'mongodb':
-			if (common.isTravis()) {
-				if (protocol == 'redshift') protocol = 'postgres';
-				return util.format("%s://%s@%s/%s?%s",
-					protocol, config.user, config.host, config.database, query
-				);
-			} else {
-				return util.format("%s://%s:%s@%s/%s?%s",
-					protocol, config.user, config.password,
-					config.host, config.database, query
-				).replace(':@','@');
-			}
-		case 'sqlite':
-			return util.format("%s://%s?%s", protocol, config.pathname, query);
-		default:
-			throw new Error("Unknown protocol " + protocol);
-	}
+  switch (protocol) {
+    case 'mysql':
+    case 'postgres':
+    case 'redshift':
+    case 'mongodb':
+      if (common.isTravis()) {
+        if (protocol == 'redshift') protocol = 'postgres';
+        return util.format("%s://%s@%s/%s?%s",
+          protocol, config.user, config.host, config.database, query
+        );
+      } else {
+        return util.format("%s://%s:%s@%s/%s?%s",
+          protocol, config.user, config.password,
+          config.host, config.database, query
+        ).replace(':@','@');
+      }
+    case 'sqlite':
+      return util.format("%s://%s?%s", protocol, config.pathname, query);
+    default:
+      throw new Error("Unknown protocol " + protocol);
+  }
 };
 
 common.retry = function (before, run, until, done, args) {
-	if (typeof until === "number") {
-		var countDown = until;
-		until = function (err) {
-			if (err && --countDown > 0) return false;
-			return true;
-		};
-	}
+  if (typeof until === "number") {
+    var countDown = until;
+    until = function (err) {
+      if (err && --countDown > 0) return false;
+      return true;
+    };
+  }
 
-	if (typeof args === "undefined") args = [];
+  if (typeof args === "undefined") args = [];
 
-	var handler = function (err) {
-		if (until(err)) return done.apply(this, arguments);
-		return runNext();
-	};
+  var handler = function (err) {
+    if (until(err)) return done.apply(this, arguments);
+    return runNext();
+  };
 
-	args.push(handler);
+  args.push(handler);
 
-	var runCurrent = function () {
-		if (run.length == args.length) {
-			return run.apply(this, args);
-		} else {
-			run.apply(this, args);
-			handler();
-		}
-	};
+  var runCurrent = function () {
+    if (run.length == args.length) {
+      return run.apply(this, args);
+    } else {
+      run.apply(this, args);
+      handler();
+    }
+  };
 
-	var runNext = function () {
-		try {
-			if (before.length > 0) {
-				before(function (err) {
-					if (until(err)) return done(err);
-					return runCurrent();
-				});
-			} else {
-				before();
-				runCurrent();
-			}
-		}
-		catch (e) {
-			handler(e);
-		}
-	};
+  var runNext = function () {
+    try {
+      if (before.length > 0) {
+        before(function (err) {
+          if (until(err)) return done(err);
+          return runCurrent();
+        });
+      } else {
+        before();
+        runCurrent();
+      }
+    }
+    catch (e) {
+      handler(e);
+    }
+  };
 
-	if (before.length > 0) {
-		before(function (err) {
-			if (err) return done(err);
-			runNext();
-		});
-	} else {
-		before();
-		runNext();
-	}
+  if (before.length > 0) {
+    before(function (err) {
+      if (err) return done(err);
+      runNext();
+    });
+  } else {
+    before();
+    runNext();
+  }
 };
 
 common.nodeVersion = function () {
-	return new Semver(process.versions.node);
+  return new Semver(process.versions.node);
 }

--- a/test/config.example.js
+++ b/test/config.example.js
@@ -8,19 +8,19 @@
 // make test
 
 exports.mysql = {
-	user     : "root",
-	password : "",
-	database : "test"
+  user     : "root",
+  password : "",
+  database : "test"
 };
 exports.postgres = {
-	user     : "root",
-	password : "",
-	database : "test"
+  user     : "root",
+  password : "",
+  database : "test"
 };
 exports.redshift = {
-	user      : "root",
-	password  : "",
-	database  : "test"
+  user      : "root",
+  password  : "",
+  database  : "test"
 };
 exports.mongodb = {
     host: "localhost",

--- a/test/integration/association-extend.js
+++ b/test/integration/association-extend.js
@@ -3,248 +3,248 @@ var helper   = require('../support/spec_helper');
 var ORM      = require('../../');
 
 describe("Model.extendsTo()", function() {
-	var db = null;
-	var Person = null;
-	var PersonAddress = null;
+  var db = null;
+  var Person = null;
+  var PersonAddress = null;
 
-	var setup = function () {
-		return function (done) {
-			Person = db.define("person", {
-				name   : String
-			});
-			PersonAddress = Person.extendsTo("address", {
-				street : String,
-				number : Number
-			});
+  var setup = function () {
+    return function (done) {
+      Person = db.define("person", {
+        name   : String
+      });
+      PersonAddress = Person.extendsTo("address", {
+        street : String,
+        number : Number
+      });
 
-			ORM.singleton.clear();
+      ORM.singleton.clear();
 
-			return helper.dropSync([ Person, PersonAddress ], function () {
-				Person.create({
-					name: "John Doe"
-				}, function (err, person) {
-					should.not.exist(err);
+      return helper.dropSync([ Person, PersonAddress ], function () {
+        Person.create({
+          name: "John Doe"
+        }, function (err, person) {
+          should.not.exist(err);
 
-					return person.setAddress(new PersonAddress({
-						street : "Liberty",
-						number : 123
-					}), done);
-				});
-			});
-		};
-	};
+          return person.setAddress(new PersonAddress({
+            street : "Liberty",
+            number : 123
+          }), done);
+        });
+      });
+    };
+  };
 
-	before(function (done) {
-		helper.connect(function (connection) {
-			db = connection;
+  before(function (done) {
+    helper.connect(function (connection) {
+      db = connection;
 
-			return done();
-		});
-	});
+      return done();
+    });
+  });
 
-	after(function () {
-		return db.close();
-	});
+  after(function () {
+    return db.close();
+  });
 
-	describe("when calling hasAccessor", function () {
-		before(setup());
+  describe("when calling hasAccessor", function () {
+    before(setup());
 
-		it("should return true if found", function (done) {
-			Person.find().first(function (err, John) {
-				should.equal(err, null);
+    it("should return true if found", function (done) {
+      Person.find().first(function (err, John) {
+        should.equal(err, null);
 
-				John.hasAddress(function (err, hasAddress) {
-					should.equal(err, null);
-					hasAddress.should.equal(true);
+        John.hasAddress(function (err, hasAddress) {
+          should.equal(err, null);
+          hasAddress.should.equal(true);
 
-					return done();
-				});
-			});
-		});
+          return done();
+        });
+      });
+    });
 
-		it("should return false if not found", function (done) {
-			Person.find().first(function (err, John) {
-				should.equal(err, null);
+    it("should return false if not found", function (done) {
+      Person.find().first(function (err, John) {
+        should.equal(err, null);
 
-				John.removeAddress(function () {
-					John.hasAddress(function (err, hasAddress) {
-						err.should.be.a.Object();
-						hasAddress.should.equal(false);
+        John.removeAddress(function () {
+          John.hasAddress(function (err, hasAddress) {
+            err.should.be.a.Object();
+            hasAddress.should.equal(false);
 
-						return done();
-					});
-				});
-			});
-		});
+            return done();
+          });
+        });
+      });
+    });
 
-		it("should return error if instance not with an ID", function (done) {
-			var Jane = new Person({
-				name: "Jane"
-			});
-			Jane.hasAddress(function (err, hasAddress) {
-				err.should.be.a.Object();
-				err.should.have.property("code", ORM.ErrorCodes.NOT_DEFINED);
+    it("should return error if instance not with an ID", function (done) {
+      var Jane = new Person({
+        name: "Jane"
+      });
+      Jane.hasAddress(function (err, hasAddress) {
+        err.should.be.a.Object();
+        err.should.have.property("code", ORM.ErrorCodes.NOT_DEFINED);
 
-				return done();
-			});
-		});
-	});
+        return done();
+      });
+    });
+  });
 
-	describe("when calling getAccessor", function () {
-		before(setup());
+  describe("when calling getAccessor", function () {
+    before(setup());
 
-		it("should return extension if found", function (done) {
-			Person.find().first(function (err, John) {
-				should.equal(err, null);
+    it("should return extension if found", function (done) {
+      Person.find().first(function (err, John) {
+        should.equal(err, null);
 
-				John.getAddress(function (err, Address) {
-					should.equal(err, null);
-					Address.should.be.a.Object();
-					Address.should.have.property("street", "Liberty");
+        John.getAddress(function (err, Address) {
+          should.equal(err, null);
+          Address.should.be.a.Object();
+          Address.should.have.property("street", "Liberty");
 
-					return done();
-				});
-			});
-		});
+          return done();
+        });
+      });
+    });
 
-		it("should return error if not found", function (done) {
-			Person.find().first(function (err, John) {
-				should.equal(err, null);
+    it("should return error if not found", function (done) {
+      Person.find().first(function (err, John) {
+        should.equal(err, null);
 
-				John.removeAddress(function () {
-					John.getAddress(function (err, Address) {
-						err.should.be.a.Object();
-						err.should.have.property("code", ORM.ErrorCodes.NOT_FOUND);
+        John.removeAddress(function () {
+          John.getAddress(function (err, Address) {
+            err.should.be.a.Object();
+            err.should.have.property("code", ORM.ErrorCodes.NOT_FOUND);
 
-						return done();
-					});
-				});
-			});
-		});
+            return done();
+          });
+        });
+      });
+    });
 
-		it("should return error if instance not with an ID", function (done) {
-			var Jane = new Person({
-				name: "Jane"
-			});
-			Jane.getAddress(function (err, Address) {
-				err.should.be.a.Object();
-				err.should.have.property("code", ORM.ErrorCodes.NOT_DEFINED);
+    it("should return error if instance not with an ID", function (done) {
+      var Jane = new Person({
+        name: "Jane"
+      });
+      Jane.getAddress(function (err, Address) {
+        err.should.be.a.Object();
+        err.should.have.property("code", ORM.ErrorCodes.NOT_DEFINED);
 
-				return done();
-			});
-		});
-	});
+        return done();
+      });
+    });
+  });
 
-	describe("when calling setAccessor", function () {
-		before(setup());
+  describe("when calling setAccessor", function () {
+    before(setup());
 
-		it("should remove any previous extension", function (done) {
-			Person.find().first(function (err, John) {
-				should.equal(err, null);
+    it("should remove any previous extension", function (done) {
+      Person.find().first(function (err, John) {
+        should.equal(err, null);
 
-				PersonAddress.find({ number: 123 }).count(function (err, c) {
-					should.equal(err, null);
-					c.should.equal(1);
+        PersonAddress.find({ number: 123 }).count(function (err, c) {
+          should.equal(err, null);
+          c.should.equal(1);
 
-					var addr = new PersonAddress({
-						street : "4th Ave",
-						number : 4
-					});
+          var addr = new PersonAddress({
+            street : "4th Ave",
+            number : 4
+          });
 
-					John.setAddress(addr, function (err) {
-						should.equal(err, null);
+          John.setAddress(addr, function (err) {
+            should.equal(err, null);
 
-						John.getAddress(function (err, Address) {
-							should.equal(err, null);
-							Address.should.be.a.Object();
-							Address.should.have.property("street", addr.street);
+            John.getAddress(function (err, Address) {
+              should.equal(err, null);
+              Address.should.be.a.Object();
+              Address.should.have.property("street", addr.street);
 
-							PersonAddress.find({ number: 123 }).count(function (err, c) {
-								should.equal(err, null);
-								c.should.equal(0);
+              PersonAddress.find({ number: 123 }).count(function (err, c) {
+                should.equal(err, null);
+                c.should.equal(0);
 
-								return done();
-							});
-						});
-					});
-				});
-			});
-		});
-	});
+                return done();
+              });
+            });
+          });
+        });
+      });
+    });
+  });
 
-	describe("when calling delAccessor", function () {
-		before(setup());
+  describe("when calling delAccessor", function () {
+    before(setup());
 
-		it("should remove any extension", function (done) {
-			Person.find().first(function (err, John) {
-				should.equal(err, null);
+    it("should remove any extension", function (done) {
+      Person.find().first(function (err, John) {
+        should.equal(err, null);
 
-				PersonAddress.find({ number: 123 }).count(function (err, c) {
-					should.equal(err, null);
-					c.should.equal(1);
+        PersonAddress.find({ number: 123 }).count(function (err, c) {
+          should.equal(err, null);
+          c.should.equal(1);
 
-					var addr = new PersonAddress({
-						street : "4th Ave",
-						number : 4
-					});
+          var addr = new PersonAddress({
+            street : "4th Ave",
+            number : 4
+          });
 
-					John.removeAddress(function (err) {
-						should.equal(err, null);
+          John.removeAddress(function (err) {
+            should.equal(err, null);
 
-						PersonAddress.find({ number: 123 }).count(function (err, c) {
-							should.equal(err, null);
-							c.should.equal(0);
+            PersonAddress.find({ number: 123 }).count(function (err, c) {
+              should.equal(err, null);
+              c.should.equal(0);
 
-							return done();
-						});
-					});
-				});
-			});
-		});
+              return done();
+            });
+          });
+        });
+      });
+    });
 
-		it("should return error if instance not with an ID", function (done) {
-			var Jane = new Person({
-				name: "Jane"
-			});
-			Jane.removeAddress(function (err) {
-				err.should.be.a.Object();
-				err.should.have.property("code", ORM.ErrorCodes.NOT_DEFINED);
+    it("should return error if instance not with an ID", function (done) {
+      var Jane = new Person({
+        name: "Jane"
+      });
+      Jane.removeAddress(function (err) {
+        err.should.be.a.Object();
+        err.should.have.property("code", ORM.ErrorCodes.NOT_DEFINED);
 
-				return done();
-			});
-		});
-	});
+        return done();
+      });
+    });
+  });
 
-	describe("findBy()", function () {
-		before(setup());
+  describe("findBy()", function () {
+    before(setup());
 
-		it("should throw if no conditions passed", function (done) {
-			(function () {
-				Person.findByAddress(function () {});
-			}).should.throw();
+    it("should throw if no conditions passed", function (done) {
+      (function () {
+        Person.findByAddress(function () {});
+      }).should.throw();
 
-			return done();
-		});
+      return done();
+    });
 
-		it("should lookup in Model based on associated model properties", function (done) {
-			Person.findByAddress({
-				number: 123
-			}, function (err, people) {
-				should.equal(err, null);
-				should(Array.isArray(people));
-				should(people.length == 1);
+    it("should lookup in Model based on associated model properties", function (done) {
+      Person.findByAddress({
+        number: 123
+      }, function (err, people) {
+        should.equal(err, null);
+        should(Array.isArray(people));
+        should(people.length == 1);
 
-				return done();
-			});
-		});
+        return done();
+      });
+    });
 
-		it("should return a ChainFind if no callback passed", function (done) {
-			var ChainFind = Person.findByAddress({
-				number: 123
-			});
-			ChainFind.run.should.be.a.Function();
+    it("should return a ChainFind if no callback passed", function (done) {
+      var ChainFind = Person.findByAddress({
+        number: 123
+      });
+      ChainFind.run.should.be.a.Function();
 
-			return done();
-		});
-	});
+      return done();
+    });
+  });
 });

--- a/test/integration/association-hasmany-extra.js
+++ b/test/integration/association-hasmany-extra.js
@@ -3,78 +3,78 @@ var helper = require('../support/spec_helper');
 var ORM    = require('../../');
 
 describe("hasMany extra properties", function() {
-	var db     = null;
-	var Person = null;
-	var Pet    = null;
+  var db     = null;
+  var Person = null;
+  var Pet    = null;
 
-	var setup = function (opts) {
-		opts = opts || {};
-		return function (done) {
-			db.settings.set('instance.identityCache', false);
+  var setup = function (opts) {
+    opts = opts || {};
+    return function (done) {
+      db.settings.set('instance.identityCache', false);
 
-			Person = db.define('person', {
-				name    : String,
-			}, opts);
-			Pet = db.define('pet', {
-				name    : String
-			});
-			Person.hasMany('pets', Pet, {
-				since   : Date,
-				data    : Object
-			});
+      Person = db.define('person', {
+        name    : String,
+      }, opts);
+      Pet = db.define('pet', {
+        name    : String
+      });
+      Person.hasMany('pets', Pet, {
+        since   : Date,
+        data    : Object
+      });
 
-			return helper.dropSync([ Person, Pet ], done);
-		};
-	};
+      return helper.dropSync([ Person, Pet ], done);
+    };
+  };
 
-	before(function(done) {
-		this.timeout(4000);
+  before(function(done) {
+    this.timeout(4000);
 
-		helper.connect(function (connection) {
-			db = connection;
-			done();
-		});
-	});
+    helper.connect(function (connection) {
+      db = connection;
+      done();
+    });
+  });
 
-	describe("if passed to addAccessor", function () {
-		before(setup());
+  describe("if passed to addAccessor", function () {
+    before(setup());
 
-		it("should be added to association", function (done) {
-			Person.create([{
-				name    : "John"
-			}], function (err, people) {
-				Pet.create([{
-					name : "Deco"
-				}, {
-					name : "Mutt"
-				}], function (err, pets) {
-					var data = { adopted: true };
+    it("should be added to association", function (done) {
+      Person.create([{
+        name    : "John"
+      }], function (err, people) {
+        Pet.create([{
+          name : "Deco"
+        }, {
+          name : "Mutt"
+        }], function (err, pets) {
+          var data = { adopted: true };
 
-					people[0].addPets(pets, { since : new Date(), data: data }, function (err) {
-						should.equal(err, null);
+          people[0].addPets(pets, { since : new Date(), data: data }, function (err) {
+            should.equal(err, null);
 
-						Person.find({ name: "John" }, { autoFetch : true }).first(function (err, John) {
-							should.equal(err, null);
+            Person.find({ name: "John" }, { autoFetch : true }).first(function (err, John) {
+              should.equal(err, null);
 
-							John.should.have.property("pets");
-							should(Array.isArray(pets));
+              John.should.have.property("pets");
+              should(Array.isArray(pets));
 
-							John.pets.length.should.equal(2);
+              John.pets.length.should.equal(2);
 
-							John.pets[0].should.have.property("name");
-							John.pets[0].should.have.property("extra");
-							John.pets[0].extra.should.be.a.Object();
-							John.pets[0].extra.should.have.property("since");
-							should(John.pets[0].extra.since instanceof Date);
+              John.pets[0].should.have.property("name");
+              John.pets[0].should.have.property("extra");
+              John.pets[0].extra.should.be.a.Object();
+              John.pets[0].extra.should.have.property("since");
+              should(John.pets[0].extra.since instanceof Date);
 
-							should.equal(typeof John.pets[0].extra.data, 'object');
-							should.equal(JSON.stringify(data), JSON.stringify(John.pets[0].extra.data));
+              should.equal(typeof John.pets[0].extra.data, 'object');
+              should.equal(JSON.stringify(data), JSON.stringify(John.pets[0].extra.data));
 
-							return done();
-						});
-					});
-				});
-			});
-		});
-	});
+              return done();
+            });
+          });
+        });
+      });
+    });
+  });
 });

--- a/test/integration/association-hasmany-extra.js
+++ b/test/integration/association-hasmany-extra.js
@@ -28,8 +28,6 @@ describe("hasMany extra properties", function() {
   };
 
   before(function(done) {
-    this.timeout(4000);
-
     helper.connect(function (connection) {
       db = connection;
       done();

--- a/test/integration/association-hasmany-hooks.js
+++ b/test/integration/association-hasmany-hooks.js
@@ -3,123 +3,123 @@ var helper = require('../support/spec_helper');
 var ORM    = require('../../');
 
 describe("hasMany hooks", function() {
-	var db     = null;
-	var Person = null;
-	var Pet    = null;
+  var db     = null;
+  var Person = null;
+  var Pet    = null;
 
-	var setup = function (props, opts) {
-		return function (done) {
-			db.settings.set('instance.identityCache', false);
+  var setup = function (props, opts) {
+    return function (done) {
+      db.settings.set('instance.identityCache', false);
 
-			Person = db.define('person', {
-				name    : String,
-			});
-			Pet = db.define('pet', {
-				name    : String
-			});
-			Person.hasMany('pets', Pet, props || {}, opts || {});
+      Person = db.define('person', {
+        name    : String,
+      });
+      Pet = db.define('pet', {
+        name    : String
+      });
+      Person.hasMany('pets', Pet, props || {}, opts || {});
 
-			return helper.dropSync([ Person, Pet ], done);
-		};
-	};
+      return helper.dropSync([ Person, Pet ], done);
+    };
+  };
 
-	before(function(done) {
-		helper.connect(function (connection) {
-			db = connection;
-			done();
-		});
-	});
+  before(function(done) {
+    helper.connect(function (connection) {
+      db = connection;
+      done();
+    });
+  });
 
-	describe("beforeSave", function () {
-		var had_extra = false;
+  describe("beforeSave", function () {
+    var had_extra = false;
 
-		before(setup({
-			born : Date
-		}, {
-			hooks : {
-				beforeSave: function (extra, next) {
-					had_extra = (typeof extra == "object");
-					return next();
-				}
-			}
-		}));
+    before(setup({
+      born : Date
+    }, {
+      hooks : {
+        beforeSave: function (extra, next) {
+          had_extra = (typeof extra == "object");
+          return next();
+        }
+      }
+    }));
 
-		it("should pass extra data to hook if extra defined", function (done) {
-			Person.create({
-				name    : "John"
-			}, function (err, John) {
-				Pet.create({
-					name : "Deco"
-				}, function (err, Deco) {
-					John.addPets(Deco, function (err) {
-						should.not.exist(err);
+    it("should pass extra data to hook if extra defined", function (done) {
+      Person.create({
+        name    : "John"
+      }, function (err, John) {
+        Pet.create({
+          name : "Deco"
+        }, function (err, Deco) {
+          John.addPets(Deco, function (err) {
+            should.not.exist(err);
 
-						had_extra.should.be.true;
+            had_extra.should.be.true;
 
-						return done();
-					});
-				});
-			});
-		});
-	});
+            return done();
+          });
+        });
+      });
+    });
+  });
 
-	describe("beforeSave", function () {
-		var had_extra = false;
+  describe("beforeSave", function () {
+    var had_extra = false;
 
-		before(setup({}, {
-			hooks : {
-				beforeSave: function (next) {
-					next.should.be.a.Function();
-					return next();
-				}
-			}
-		}));
+    before(setup({}, {
+      hooks : {
+        beforeSave: function (next) {
+          next.should.be.a.Function();
+          return next();
+        }
+      }
+    }));
 
-		it("should not pass extra data to hook if extra defined", function (done) {
-			Person.create({
-				name    : "John"
-			}, function (err, John) {
-				Pet.create({
-					name : "Deco"
-				}, function (err, Deco) {
-					John.addPets(Deco, function (err) {
-						should.not.exist(err);
+    it("should not pass extra data to hook if extra defined", function (done) {
+      Person.create({
+        name    : "John"
+      }, function (err, John) {
+        Pet.create({
+          name : "Deco"
+        }, function (err, Deco) {
+          John.addPets(Deco, function (err) {
+            should.not.exist(err);
 
-						return done();
-					});
-				});
-			});
-		});
-	});
+            return done();
+          });
+        });
+      });
+    });
+  });
 
-	describe("beforeSave", function () {
-		var had_extra = false;
+  describe("beforeSave", function () {
+    var had_extra = false;
 
-		before(setup({}, {
-			hooks : {
-				beforeSave: function (next) {
-					setTimeout(function () {
-						return next(new Error('blocked'));
-					}, 100);
-				}
-			}
-		}));
+    before(setup({}, {
+      hooks : {
+        beforeSave: function (next) {
+          setTimeout(function () {
+            return next(new Error('blocked'));
+          }, 100);
+        }
+      }
+    }));
 
-		it("should block if error returned", function (done) {
-			Person.create({
-				name    : "John"
-			}, function (err, John) {
-				Pet.create({
-					name : "Deco"
-				}, function (err, Deco) {
-					John.addPets(Deco, function (err) {
-						should.exist(err);
-						err.message.should.equal('blocked');
+    it("should block if error returned", function (done) {
+      Person.create({
+        name    : "John"
+      }, function (err, John) {
+        Pet.create({
+          name : "Deco"
+        }, function (err, Deco) {
+          John.addPets(Deco, function (err) {
+            should.exist(err);
+            err.message.should.equal('blocked');
 
-						return done();
-					});
-				});
-			});
-		});
-	});
+            return done();
+          });
+        });
+      });
+    });
+  });
 });

--- a/test/integration/association-hasmany-mapsto.js
+++ b/test/integration/association-hasmany-mapsto.js
@@ -8,661 +8,661 @@ var protocol = common.protocol();
 if (common.protocol() == "mongodb") return;   // Can't do mapsTo testing on mongoDB ()
 
 describe("hasMany with mapsTo", function () {
-	this.timeout(4000);
-	var db     = null;
-	var Person = null;
-	var Pet    = null;
+  this.timeout(4000);
+  var db     = null;
+  var Person = null;
+  var Pet    = null;
 
-	before(function(done) {
-		helper.connect(function (connection) {
-			db = connection;
-			done();
-		});
-	});
+  before(function(done) {
+    helper.connect(function (connection) {
+      db = connection;
+      done();
+    });
+  });
 
-	describe("normal", function () {
+  describe("normal", function () {
 
-		var setup = function (opts) {
-			opts = opts || {};
+    var setup = function (opts) {
+      opts = opts || {};
 
-			return function (done) {
-				db.settings.set('instance.identityCache', false);
+      return function (done) {
+        db.settings.set('instance.identityCache', false);
 
-				Person = db.define('person', {
+        Person = db.define('person', {
                                         id        : {type : "serial",  size:"8",    mapsTo: "personID", key:true},
-					firstName : {type : "text",    size:"255",  mapsTo: "name"},
-					lastName  : {type : "text",    size:"255",  mapsTo: "surname"},
-					ageYears  : {type : "number",  size:"8",    mapsTo: "age"}
-				});
+          firstName : {type : "text",    size:"255",  mapsTo: "name"},
+          lastName  : {type : "text",    size:"255",  mapsTo: "surname"},
+          ageYears  : {type : "number",  size:"8",    mapsTo: "age"}
+        });
 
-				Pet = db.define('pet', {
+        Pet = db.define('pet', {
                                         id      :  {type : "serial",   size:"8",    mapsTo:"petID", key:true},
-					petName :  {type : "text",     size:"255",  mapsTo: "name"}
-				});
+          petName :  {type : "text",     size:"255",  mapsTo: "name"}
+        });
 
-				Person.hasMany('pets', Pet, {},
+        Person.hasMany('pets', Pet, {},
                                                { autoFetch:  opts.autoFetchPets,
                                                  mergeTable: 'person_pet',
                                                  mergeId: 'person_id',
                                                  mergeAssocId: 'pet_id'});
 
-				helper.dropSync([ Person, Pet ], function (err) {
-					if (err) return done(err);
-					//
-					// John --+---> Deco
-					//        '---> Mutt <----- Jane
-					//
-					// Justin
-					//
-					Person.create([{
-						firstName    : "John",
-						lastName     : "Doe",
-						ageYears     : 20,
-						pets    : [{
-							petName    : "Deco"
-						}, {
-							petName    : "Mutt"
-						}]
-					}, {
-						firstName  : "Jane",
-						lastName   : "Doe",
-						ageYears   : 16
-					}, {
-						firstName : "Justin",
-						lastName  : "Dean",
-						ageYears  : 18
-					}], function (err) {
-						Person.find({ firstName: "Jane" }, function (err, people) {
-							Pet.find({ petName: "Mutt" }, function (err, pets) {
-								people[0].addPets(pets, done);
-							});
-						});
-					});
-				});
-			};
-		};
-
-		describe("getAccessor", function () {
-			before(setup());
-
-			it("should not auto-fetch associations", function (done) {
-				Person.find({ firstName: "John" }).first(function (err, John) {
-					should.equal(err, null);
-
-					should.equal(John.pets, null);
-					return done();
-				});
-			});
-
-			it("should allow to specify order as string", function (done) {
-				Person.find({ firstName: "John" }, function (err, people) {
-					should.equal(err, null);
-
-					people[0].getPets("-petName", function (err, pets) {
-						should.equal(err, null);
-
-						should(Array.isArray(pets));
-						pets.length.should.equal(2);
-						pets[0].model().should.equal(Pet);
-						pets[0].petName.should.equal("Mutt");
-						pets[1].petName.should.equal("Deco");
-
-						return done();
-					});
-				});
-			});
-
- 			it ("should return proper instance model", function(done){
- 				Person.find({ firstName: "John" }, function (err, people) {
-					people[0].getPets("-petName", function (err, pets) {
-						pets[0].model().should.equal(Pet);
-						return done();
-					});
-				});
- 			});
-
-			it("should allow to specify order as Array", function (done) {
-				Person.find({ firstName: "John" }, function (err, people) {
-					should.equal(err, null);
-
-					people[0].getPets([ "petName", "Z" ], function (err, pets) {
-						should.equal(err, null);
-
-						should(Array.isArray(pets));
-						pets.length.should.equal(2);
-						pets[0].petName.should.equal("Mutt");
-						pets[1].petName.should.equal("Deco");
-
-						return done();
-					});
-				});
-			});
-
-			it("should allow to specify a limit", function (done) {
-				Person.find({ firstName: "John" }).first(function (err, John) {
-					should.equal(err, null);
-
-					John.getPets(1, function (err, pets) {
-						should.equal(err, null);
-
-						should(Array.isArray(pets));
-						pets.length.should.equal(1);
+        helper.dropSync([ Person, Pet ], function (err) {
+          if (err) return done(err);
+          //
+          // John --+---> Deco
+          //        '---> Mutt <----- Jane
+          //
+          // Justin
+          //
+          Person.create([{
+            firstName    : "John",
+            lastName     : "Doe",
+            ageYears     : 20,
+            pets    : [{
+              petName    : "Deco"
+            }, {
+              petName    : "Mutt"
+            }]
+          }, {
+            firstName  : "Jane",
+            lastName   : "Doe",
+            ageYears   : 16
+          }, {
+            firstName : "Justin",
+            lastName  : "Dean",
+            ageYears  : 18
+          }], function (err) {
+            Person.find({ firstName: "Jane" }, function (err, people) {
+              Pet.find({ petName: "Mutt" }, function (err, pets) {
+                people[0].addPets(pets, done);
+              });
+            });
+          });
+        });
+      };
+    };
+
+    describe("getAccessor", function () {
+      before(setup());
+
+      it("should not auto-fetch associations", function (done) {
+        Person.find({ firstName: "John" }).first(function (err, John) {
+          should.equal(err, null);
+
+          should.equal(John.pets, null);
+          return done();
+        });
+      });
+
+      it("should allow to specify order as string", function (done) {
+        Person.find({ firstName: "John" }, function (err, people) {
+          should.equal(err, null);
+
+          people[0].getPets("-petName", function (err, pets) {
+            should.equal(err, null);
+
+            should(Array.isArray(pets));
+            pets.length.should.equal(2);
+            pets[0].model().should.equal(Pet);
+            pets[0].petName.should.equal("Mutt");
+            pets[1].petName.should.equal("Deco");
+
+            return done();
+          });
+        });
+      });
+
+       it ("should return proper instance model", function(done){
+         Person.find({ firstName: "John" }, function (err, people) {
+          people[0].getPets("-petName", function (err, pets) {
+            pets[0].model().should.equal(Pet);
+            return done();
+          });
+        });
+       });
+
+      it("should allow to specify order as Array", function (done) {
+        Person.find({ firstName: "John" }, function (err, people) {
+          should.equal(err, null);
+
+          people[0].getPets([ "petName", "Z" ], function (err, pets) {
+            should.equal(err, null);
+
+            should(Array.isArray(pets));
+            pets.length.should.equal(2);
+            pets[0].petName.should.equal("Mutt");
+            pets[1].petName.should.equal("Deco");
+
+            return done();
+          });
+        });
+      });
+
+      it("should allow to specify a limit", function (done) {
+        Person.find({ firstName: "John" }).first(function (err, John) {
+          should.equal(err, null);
+
+          John.getPets(1, function (err, pets) {
+            should.equal(err, null);
+
+            should(Array.isArray(pets));
+            pets.length.should.equal(1);
 
-						return done();
-					});
-				});
-			});
+            return done();
+          });
+        });
+      });
 
-			it("should allow to specify conditions", function (done) {
-				Person.find({ firstName: "John" }).first(function (err, John) {
-					should.equal(err, null);
+      it("should allow to specify conditions", function (done) {
+        Person.find({ firstName: "John" }).first(function (err, John) {
+          should.equal(err, null);
 
-					John.getPets({ petName: "Mutt" }, function (err, pets) {
-						should.equal(err, null);
+          John.getPets({ petName: "Mutt" }, function (err, pets) {
+            should.equal(err, null);
 
-						should(Array.isArray(pets));
-						pets.length.should.equal(1);
-						pets[0].petName.should.equal("Mutt");
+            should(Array.isArray(pets));
+            pets.length.should.equal(1);
+            pets[0].petName.should.equal("Mutt");
 
-						return done();
-					});
-				});
-			});
+            return done();
+          });
+        });
+      });
 
-			if (common.protocol() == "mongodb") return;
+      if (common.protocol() == "mongodb") return;
 
-			it("should return a chain if no callback defined", function (done) {
-				Person.find({ firstName: "John" }, function (err, people) {
-					should.equal(err, null);
+      it("should return a chain if no callback defined", function (done) {
+        Person.find({ firstName: "John" }, function (err, people) {
+          should.equal(err, null);
 
-					var chain = people[0].getPets({ firstName: "Mutt" });
-
-					chain.should.be.a.Object();
-					chain.find.should.be.a.Function();
-					chain.only.should.be.a.Function();
-					chain.limit.should.be.a.Function();
-					chain.order.should.be.a.Function();
+          var chain = people[0].getPets({ firstName: "Mutt" });
+
+          chain.should.be.a.Object();
+          chain.find.should.be.a.Function();
+          chain.only.should.be.a.Function();
+          chain.limit.should.be.a.Function();
+          chain.order.should.be.a.Function();
 
-					return done();
-				});
-			});
+          return done();
+        });
+      });
 
-			it("should allow chaining count()", function (done) {
-				Person.find({}, function (err, people) {
-					should.equal(err, null);
+      it("should allow chaining count()", function (done) {
+        Person.find({}, function (err, people) {
+          should.equal(err, null);
 
-					people[0].getPets().count(function (err, count) {
-						should.not.exist(err);
+          people[0].getPets().count(function (err, count) {
+            should.not.exist(err);
 
-						should.strictEqual(count, 2);
-
-						people[1].getPets().count(function (err, count) {
-							should.not.exist(err);
+            should.strictEqual(count, 2);
+
+            people[1].getPets().count(function (err, count) {
+              should.not.exist(err);
 
-							should.strictEqual(count, 1);
-
-							people[2].getPets().count(function (err, count) {
-								should.not.exist(err);
-
-								should.strictEqual(count, 0);
-
-								return done();
-							});
-						});
-					});
-				});
-			});
-		});
-
-		describe("hasAccessor", function () {
-			before(setup());
-
-			it("should return true if instance has associated item", function (done) {
-				Pet.find({ petName: "Mutt" }, function (err, pets) {
-					should.equal(err, null);
-
-					Person.find({ firstName: "Jane" }).first(function (err, Jane) {
-						should.equal(err, null);
-
-						Jane.hasPets(pets[0], function (err, has_pets) {
-							should.equal(err, null);
-							has_pets.should.be.true;
-
-							return done();
-						});
-					});
-				});
-			});
-
-			it("should return true if not passing any instance and has associated items", function (done) {
-				Person.find({ firstName: "Jane" }).first(function (err, Jane) {
-					should.equal(err, null);
-
-					Jane.hasPets(function (err, has_pets) {
-						should.equal(err, null);
-						has_pets.should.be.true;
-
-						return done();
-					});
-				});
-			});
-
-			it("should return true if all passed instances are associated", function (done) {
-				Pet.find(function (err, pets) {
-					Person.find({ firstName: "John" }).first(function (err, John) {
-						should.equal(err, null);
-
-						John.hasPets(pets, function (err, has_pets) {
-							should.equal(err, null);
-							has_pets.should.be.true;
-
-							return done();
-						});
-					});
-				});
-			});
-
-			it("should return false if any passed instances are not associated", function (done) {
-				Pet.find(function (err, pets) {
-					Person.find({ firstName: "Jane" }).first(function (err, Jane) {
-						should.equal(err, null);
-
-						Jane.hasPets(pets, function (err, has_pets) {
-							should.equal(err, null);
-							has_pets.should.be.false;
-
-							return done();
-						});
-					});
-				});
-			});
-		});
-
-		describe("delAccessor", function () {
-			before(setup());
-
-			it("should accept arguments in different orders", function (done) {
-				Pet.find({ petName: "Mutt" }, function (err, pets) {
-					Person.find({ firstName: "John" }, function (err, people) {
-						should.equal(err, null);
-
-						people[0].removePets(function (err) {
-							should.equal(err, null);
-
-							people[0].getPets(function (err, pets) {
-								should.equal(err, null);
-
-								should(Array.isArray(pets));
-								pets.length.should.equal(1);
-								pets[0].petName.should.equal("Deco");
-
-								return done();
-							});
-						}, pets[0]);
-					});
-				});
-			});
-		});
-
-		describe("delAccessor", function () {
-			before(setup());
-
-			it("should remove specific associations if passed", function (done) {
-				Pet.find({ petName: "Mutt" }, function (err, pets) {
-					Person.find({ firstName: "John" }, function (err, people) {
-						should.equal(err, null);
-
-						people[0].removePets(pets[0], function (err) {
-							should.equal(err, null);
-
-							people[0].getPets(function (err, pets) {
-								should.equal(err, null);
-
-								should(Array.isArray(pets));
-								pets.length.should.equal(1);
-								pets[0].petName.should.equal("Deco");
-
-								return done();
-							});
-						});
-					});
-				});
-			});
-
-			it("should remove all associations if none passed", function (done) {
-				Person.find({ firstName: "John" }).first(function (err, John) {
-					should.equal(err, null);
-
-					John.removePets(function (err) {
-						should.equal(err, null);
-
-						John.getPets(function (err, pets) {
-							should.equal(err, null);
-
-							should(Array.isArray(pets));
-							pets.length.should.equal(0);
-
-							return done();
-						});
-					});
-				});
-			});
-		});
-
-		describe("addAccessor", function () {
-			before(setup());
-
-			if (common.protocol() != "mongodb") {
-				it("might add duplicates", function (done) {
-					Pet.find({ petName: "Mutt" }, function (err, pets) {
-						Person.find({ firstName: "Jane" }, function (err, people) {
-							should.equal(err, null);
-
-							people[0].addPets(pets[0], function (err) {
-								should.equal(err, null);
-
-								people[0].getPets("petName", function (err, pets) {
-									should.equal(err, null);
-
-									should(Array.isArray(pets));
-									pets.length.should.equal(2);
-									pets[0].petName.should.equal("Mutt");
-									pets[1].petName.should.equal("Mutt");
-
-									return done();
-								});
-							});
-						});
-					});
-				});
-			}
-
-			it("should keep associations and add new ones", function (done) {
-				Pet.find({ petName: "Deco" }).first(function (err, Deco) {
-					Person.find({ firstName: "Jane" }).first(function (err, Jane) {
-						should.equal(err, null);
-
-						Jane.getPets(function (err, janesPets) {
-							should.not.exist(err);
-
-							var petsAtStart = janesPets.length;
-
-							Jane.addPets(Deco, function (err) {
-								should.equal(err, null);
-
-								Jane.getPets("petName", function (err, pets) {
-									should.equal(err, null);
-
-									should(Array.isArray(pets));
-									pets.length.should.equal(petsAtStart + 1);
-									pets[0].petName.should.equal("Deco");
-									pets[1].petName.should.equal("Mutt");
-
-									return done();
-								});
-							});
-						});
-					});
-				});
-			});
-
-			it("should accept several arguments as associations", function (done) {
-				Pet.find(function (err, pets) {
-					Person.find({ firstName: "Justin" }).first(function (err, Justin) {
-						should.equal(err, null);
-
-						Justin.addPets(pets[0], pets[1], function (err) {
-							should.equal(err, null);
-
-							Justin.getPets(function (err, pets) {
-								should.equal(err, null);
-
-								should(Array.isArray(pets));
-								pets.length.should.equal(2);
-
-								return done();
-							});
-						});
-					});
-				});
-			});
-
-			it("should accept array as list of associations", function (done) {
-				Pet.create([{ petName: 'Ruff' }, { petName: 'Spotty' }],function (err, pets) {
-					Person.find({ firstName: "Justin" }).first(function (err, Justin) {
-						should.equal(err, null);
-
-						Justin.getPets(function (err, justinsPets) {
-							should.equal(err, null);
-
-							var petCount = justinsPets.length;
-
-							Justin.addPets(pets, function (err) {
-								should.equal(err, null);
-
-								Justin.getPets(function (err, justinsPets) {
-									should.equal(err, null);
-
-									should(Array.isArray(justinsPets));
-									// Mongo doesn't like adding duplicates here, so we add new ones.
-									should.equal(justinsPets.length, petCount + 2);
-
-									return done();
-								});
-							});
-						});
-					});
-				});
-			});
-
-			it("should throw if no items passed", function (done) {
-				Person.one(function (err, person) {
-					should.equal(err, null);
-
-					(function () {
-						person.addPets(function () {});
-					}).should.throw();
-
-					return done();
-				});
-			});
-		});
-
-		describe("setAccessor", function () {
-			before(setup());
-
-			it("should accept several arguments as associations", function (done) {
-				Pet.find(function (err, pets) {
-					Person.find({ firstName: "Justin" }).first(function (err, Justin) {
-						should.equal(err, null);
-
-						Justin.setPets(pets[0], pets[1], function (err) {
-							should.equal(err, null);
-
-							Justin.getPets(function (err, pets) {
-								should.equal(err, null);
-
-								should(Array.isArray(pets));
-								pets.length.should.equal(2);
-
-								return done();
-							});
-						});
-					});
-				});
-			});
-
-			it("should accept an array of associations", function (done) {
-				Pet.find(function (err, pets) {
-					Person.find({ firstName: "Justin" }).first(function (err, Justin) {
-						should.equal(err, null);
-
-						Justin.setPets(pets, function (err) {
-							should.equal(err, null);
-
-							Justin.getPets(function (err, all_pets) {
-								should.equal(err, null);
-
-								should(Array.isArray(all_pets));
-								all_pets.length.should.equal(pets.length);
-
-								return done();
-							});
-						});
-					});
-				});
-			});
-
-			it("should remove all associations if an empty array is passed", function (done) {
-				Person.find({ firstName: "Justin" }).first(function (err, Justin) {
-					should.equal(err, null);
-					Justin.getPets(function (err, pets) {
-						should.equal(err, null);
-						should.equal(pets.length, 2);
-
-						Justin.setPets([], function (err) {
-							should.equal(err, null);
-
-							Justin.getPets(function (err, pets) {
-								should.equal(err, null);
-								should.equal(pets.length, 0);
-
-								return done();
-							});
-						});
-					});
-				});
-			});
-
-			it("clears current associations", function (done) {
-				Pet.find({ petName: "Deco" }, function (err, pets) {
-					var Deco = pets[0];
-
-					Person.find({ firstName: "Jane" }).first(function (err, Jane) {
-						should.equal(err, null);
-
-						Jane.getPets(function (err, pets) {
-							should.equal(err, null);
-
-							should(Array.isArray(pets));
-							pets.length.should.equal(1);
-							pets[0].petName.should.equal("Mutt");
-
-							Jane.setPets(Deco, function (err) {
-								should.equal(err, null);
-
-								Jane.getPets(function (err, pets) {
-									should.equal(err, null);
-
-									should(Array.isArray(pets));
-									pets.length.should.equal(1);
-									pets[0].petName.should.equal(Deco.petName);
-
-									return done();
-								});
-							});
-						});
-					});
-				});
-			});
-		});
-
-		describe("with autoFetch turned on", function () {
-			before(setup({
-				autoFetchPets : true
-			}));
-
-			it("should fetch associations", function (done) {
-				Person.find({ firstName: "John" }).first(function (err, John) {
-					should.equal(err, null);
-
-					John.should.have.property("pets");
-					should(Array.isArray(John.pets));
-					John.pets.length.should.equal(2);
-
-					return done();
-				});
-			});
-
-			it("should save existing", function (done) {
-				Person.create({ firstName: 'Bishan' }, function (err) {
-					should.not.exist(err);
-
-					Person.one({ firstName: 'Bishan' }, function (err, person) {
-						should.not.exist(err);
-
-						person.lastName = 'Dominar';
-
-						person.save(function (err) {
-							should.not.exist(err);
-
-							done();
-						});
-					});
-				});
-			});
-
-			it("should not auto save associations which were autofetched", function (done) {
-				Pet.all(function (err, pets) {
-					should.not.exist(err);
-					should.equal(pets.length, 2);
-
-					Person.create({ firstName: 'Paul' }, function (err, paul) {
-						should.not.exist(err);
-
-						Person.one({ firstName: 'Paul' }, function (err, paul2) {
-							should.not.exist(err);
-							should.equal(paul2.pets.length, 0);
-
-							paul.setPets(pets, function (err) {
-								should.not.exist(err);
-
-								// reload paul to make sure we have 2 pets
-								Person.one({ firstName: 'Paul' }, function (err, paul) {
-									should.not.exist(err);
-									should.equal(paul.pets.length, 2);
-
-									// Saving paul2 should NOT auto save associations and hence delete
-									// the associations we just created.
-									paul2.save(function (err) {
-										should.not.exist(err);
-
-										// let's check paul - pets should still be associated
-										Person.one({ firstName: 'Paul' }, function (err, paul) {
-											should.not.exist(err);
-											should.equal(paul.pets.length, 2);
-
-											done();
-										});
-									});
-								});
-							});
-						});
-					});
-				});
-			});
-
-			it("should save associations set by the user", function (done) {
-				Person.one({ firstName: 'John' }, function (err, john) {
-					should.not.exist(err);
-					should.equal(john.pets.length, 2);
-
-					john.pets = [];
-
-					john.save(function (err) {
-						should.not.exist(err);
-
-						// reload john to make sure pets were deleted
-						Person.one({ firstName: 'John' }, function (err, john) {
-							should.not.exist(err);
-							should.equal(john.pets.length, 0);
-
-							done();
-						});
-					});
-				});
-			});
-
-		});
-	});
+              should.strictEqual(count, 1);
+
+              people[2].getPets().count(function (err, count) {
+                should.not.exist(err);
+
+                should.strictEqual(count, 0);
+
+                return done();
+              });
+            });
+          });
+        });
+      });
+    });
+
+    describe("hasAccessor", function () {
+      before(setup());
+
+      it("should return true if instance has associated item", function (done) {
+        Pet.find({ petName: "Mutt" }, function (err, pets) {
+          should.equal(err, null);
+
+          Person.find({ firstName: "Jane" }).first(function (err, Jane) {
+            should.equal(err, null);
+
+            Jane.hasPets(pets[0], function (err, has_pets) {
+              should.equal(err, null);
+              has_pets.should.be.true;
+
+              return done();
+            });
+          });
+        });
+      });
+
+      it("should return true if not passing any instance and has associated items", function (done) {
+        Person.find({ firstName: "Jane" }).first(function (err, Jane) {
+          should.equal(err, null);
+
+          Jane.hasPets(function (err, has_pets) {
+            should.equal(err, null);
+            has_pets.should.be.true;
+
+            return done();
+          });
+        });
+      });
+
+      it("should return true if all passed instances are associated", function (done) {
+        Pet.find(function (err, pets) {
+          Person.find({ firstName: "John" }).first(function (err, John) {
+            should.equal(err, null);
+
+            John.hasPets(pets, function (err, has_pets) {
+              should.equal(err, null);
+              has_pets.should.be.true;
+
+              return done();
+            });
+          });
+        });
+      });
+
+      it("should return false if any passed instances are not associated", function (done) {
+        Pet.find(function (err, pets) {
+          Person.find({ firstName: "Jane" }).first(function (err, Jane) {
+            should.equal(err, null);
+
+            Jane.hasPets(pets, function (err, has_pets) {
+              should.equal(err, null);
+              has_pets.should.be.false;
+
+              return done();
+            });
+          });
+        });
+      });
+    });
+
+    describe("delAccessor", function () {
+      before(setup());
+
+      it("should accept arguments in different orders", function (done) {
+        Pet.find({ petName: "Mutt" }, function (err, pets) {
+          Person.find({ firstName: "John" }, function (err, people) {
+            should.equal(err, null);
+
+            people[0].removePets(function (err) {
+              should.equal(err, null);
+
+              people[0].getPets(function (err, pets) {
+                should.equal(err, null);
+
+                should(Array.isArray(pets));
+                pets.length.should.equal(1);
+                pets[0].petName.should.equal("Deco");
+
+                return done();
+              });
+            }, pets[0]);
+          });
+        });
+      });
+    });
+
+    describe("delAccessor", function () {
+      before(setup());
+
+      it("should remove specific associations if passed", function (done) {
+        Pet.find({ petName: "Mutt" }, function (err, pets) {
+          Person.find({ firstName: "John" }, function (err, people) {
+            should.equal(err, null);
+
+            people[0].removePets(pets[0], function (err) {
+              should.equal(err, null);
+
+              people[0].getPets(function (err, pets) {
+                should.equal(err, null);
+
+                should(Array.isArray(pets));
+                pets.length.should.equal(1);
+                pets[0].petName.should.equal("Deco");
+
+                return done();
+              });
+            });
+          });
+        });
+      });
+
+      it("should remove all associations if none passed", function (done) {
+        Person.find({ firstName: "John" }).first(function (err, John) {
+          should.equal(err, null);
+
+          John.removePets(function (err) {
+            should.equal(err, null);
+
+            John.getPets(function (err, pets) {
+              should.equal(err, null);
+
+              should(Array.isArray(pets));
+              pets.length.should.equal(0);
+
+              return done();
+            });
+          });
+        });
+      });
+    });
+
+    describe("addAccessor", function () {
+      before(setup());
+
+      if (common.protocol() != "mongodb") {
+        it("might add duplicates", function (done) {
+          Pet.find({ petName: "Mutt" }, function (err, pets) {
+            Person.find({ firstName: "Jane" }, function (err, people) {
+              should.equal(err, null);
+
+              people[0].addPets(pets[0], function (err) {
+                should.equal(err, null);
+
+                people[0].getPets("petName", function (err, pets) {
+                  should.equal(err, null);
+
+                  should(Array.isArray(pets));
+                  pets.length.should.equal(2);
+                  pets[0].petName.should.equal("Mutt");
+                  pets[1].petName.should.equal("Mutt");
+
+                  return done();
+                });
+              });
+            });
+          });
+        });
+      }
+
+      it("should keep associations and add new ones", function (done) {
+        Pet.find({ petName: "Deco" }).first(function (err, Deco) {
+          Person.find({ firstName: "Jane" }).first(function (err, Jane) {
+            should.equal(err, null);
+
+            Jane.getPets(function (err, janesPets) {
+              should.not.exist(err);
+
+              var petsAtStart = janesPets.length;
+
+              Jane.addPets(Deco, function (err) {
+                should.equal(err, null);
+
+                Jane.getPets("petName", function (err, pets) {
+                  should.equal(err, null);
+
+                  should(Array.isArray(pets));
+                  pets.length.should.equal(petsAtStart + 1);
+                  pets[0].petName.should.equal("Deco");
+                  pets[1].petName.should.equal("Mutt");
+
+                  return done();
+                });
+              });
+            });
+          });
+        });
+      });
+
+      it("should accept several arguments as associations", function (done) {
+        Pet.find(function (err, pets) {
+          Person.find({ firstName: "Justin" }).first(function (err, Justin) {
+            should.equal(err, null);
+
+            Justin.addPets(pets[0], pets[1], function (err) {
+              should.equal(err, null);
+
+              Justin.getPets(function (err, pets) {
+                should.equal(err, null);
+
+                should(Array.isArray(pets));
+                pets.length.should.equal(2);
+
+                return done();
+              });
+            });
+          });
+        });
+      });
+
+      it("should accept array as list of associations", function (done) {
+        Pet.create([{ petName: 'Ruff' }, { petName: 'Spotty' }],function (err, pets) {
+          Person.find({ firstName: "Justin" }).first(function (err, Justin) {
+            should.equal(err, null);
+
+            Justin.getPets(function (err, justinsPets) {
+              should.equal(err, null);
+
+              var petCount = justinsPets.length;
+
+              Justin.addPets(pets, function (err) {
+                should.equal(err, null);
+
+                Justin.getPets(function (err, justinsPets) {
+                  should.equal(err, null);
+
+                  should(Array.isArray(justinsPets));
+                  // Mongo doesn't like adding duplicates here, so we add new ones.
+                  should.equal(justinsPets.length, petCount + 2);
+
+                  return done();
+                });
+              });
+            });
+          });
+        });
+      });
+
+      it("should throw if no items passed", function (done) {
+        Person.one(function (err, person) {
+          should.equal(err, null);
+
+          (function () {
+            person.addPets(function () {});
+          }).should.throw();
+
+          return done();
+        });
+      });
+    });
+
+    describe("setAccessor", function () {
+      before(setup());
+
+      it("should accept several arguments as associations", function (done) {
+        Pet.find(function (err, pets) {
+          Person.find({ firstName: "Justin" }).first(function (err, Justin) {
+            should.equal(err, null);
+
+            Justin.setPets(pets[0], pets[1], function (err) {
+              should.equal(err, null);
+
+              Justin.getPets(function (err, pets) {
+                should.equal(err, null);
+
+                should(Array.isArray(pets));
+                pets.length.should.equal(2);
+
+                return done();
+              });
+            });
+          });
+        });
+      });
+
+      it("should accept an array of associations", function (done) {
+        Pet.find(function (err, pets) {
+          Person.find({ firstName: "Justin" }).first(function (err, Justin) {
+            should.equal(err, null);
+
+            Justin.setPets(pets, function (err) {
+              should.equal(err, null);
+
+              Justin.getPets(function (err, all_pets) {
+                should.equal(err, null);
+
+                should(Array.isArray(all_pets));
+                all_pets.length.should.equal(pets.length);
+
+                return done();
+              });
+            });
+          });
+        });
+      });
+
+      it("should remove all associations if an empty array is passed", function (done) {
+        Person.find({ firstName: "Justin" }).first(function (err, Justin) {
+          should.equal(err, null);
+          Justin.getPets(function (err, pets) {
+            should.equal(err, null);
+            should.equal(pets.length, 2);
+
+            Justin.setPets([], function (err) {
+              should.equal(err, null);
+
+              Justin.getPets(function (err, pets) {
+                should.equal(err, null);
+                should.equal(pets.length, 0);
+
+                return done();
+              });
+            });
+          });
+        });
+      });
+
+      it("clears current associations", function (done) {
+        Pet.find({ petName: "Deco" }, function (err, pets) {
+          var Deco = pets[0];
+
+          Person.find({ firstName: "Jane" }).first(function (err, Jane) {
+            should.equal(err, null);
+
+            Jane.getPets(function (err, pets) {
+              should.equal(err, null);
+
+              should(Array.isArray(pets));
+              pets.length.should.equal(1);
+              pets[0].petName.should.equal("Mutt");
+
+              Jane.setPets(Deco, function (err) {
+                should.equal(err, null);
+
+                Jane.getPets(function (err, pets) {
+                  should.equal(err, null);
+
+                  should(Array.isArray(pets));
+                  pets.length.should.equal(1);
+                  pets[0].petName.should.equal(Deco.petName);
+
+                  return done();
+                });
+              });
+            });
+          });
+        });
+      });
+    });
+
+    describe("with autoFetch turned on", function () {
+      before(setup({
+        autoFetchPets : true
+      }));
+
+      it("should fetch associations", function (done) {
+        Person.find({ firstName: "John" }).first(function (err, John) {
+          should.equal(err, null);
+
+          John.should.have.property("pets");
+          should(Array.isArray(John.pets));
+          John.pets.length.should.equal(2);
+
+          return done();
+        });
+      });
+
+      it("should save existing", function (done) {
+        Person.create({ firstName: 'Bishan' }, function (err) {
+          should.not.exist(err);
+
+          Person.one({ firstName: 'Bishan' }, function (err, person) {
+            should.not.exist(err);
+
+            person.lastName = 'Dominar';
+
+            person.save(function (err) {
+              should.not.exist(err);
+
+              done();
+            });
+          });
+        });
+      });
+
+      it("should not auto save associations which were autofetched", function (done) {
+        Pet.all(function (err, pets) {
+          should.not.exist(err);
+          should.equal(pets.length, 2);
+
+          Person.create({ firstName: 'Paul' }, function (err, paul) {
+            should.not.exist(err);
+
+            Person.one({ firstName: 'Paul' }, function (err, paul2) {
+              should.not.exist(err);
+              should.equal(paul2.pets.length, 0);
+
+              paul.setPets(pets, function (err) {
+                should.not.exist(err);
+
+                // reload paul to make sure we have 2 pets
+                Person.one({ firstName: 'Paul' }, function (err, paul) {
+                  should.not.exist(err);
+                  should.equal(paul.pets.length, 2);
+
+                  // Saving paul2 should NOT auto save associations and hence delete
+                  // the associations we just created.
+                  paul2.save(function (err) {
+                    should.not.exist(err);
+
+                    // let's check paul - pets should still be associated
+                    Person.one({ firstName: 'Paul' }, function (err, paul) {
+                      should.not.exist(err);
+                      should.equal(paul.pets.length, 2);
+
+                      done();
+                    });
+                  });
+                });
+              });
+            });
+          });
+        });
+      });
+
+      it("should save associations set by the user", function (done) {
+        Person.one({ firstName: 'John' }, function (err, john) {
+          should.not.exist(err);
+          should.equal(john.pets.length, 2);
+
+          john.pets = [];
+
+          john.save(function (err) {
+            should.not.exist(err);
+
+            // reload john to make sure pets were deleted
+            Person.one({ firstName: 'John' }, function (err, john) {
+              should.not.exist(err);
+              should.equal(john.pets.length, 0);
+
+              done();
+            });
+          });
+        });
+      });
+
+    });
+  });
 });

--- a/test/integration/association-hasmany-mapsto.js
+++ b/test/integration/association-hasmany-mapsto.js
@@ -8,7 +8,6 @@ var protocol = common.protocol();
 if (common.protocol() == "mongodb") return;   // Can't do mapsTo testing on mongoDB ()
 
 describe("hasMany with mapsTo", function () {
-  this.timeout(4000);
   var db     = null;
   var Person = null;
   var Pet    = null;

--- a/test/integration/association-hasmany.js
+++ b/test/integration/association-hasmany.js
@@ -6,7 +6,6 @@ var common   = require('../common');
 var protocol = common.protocol();
 
 describe("hasMany", function () {
-  this.timeout(4000);
   var db     = null;
   var Person = null;
   var Pet    = null;

--- a/test/integration/association-hasmany.js
+++ b/test/integration/association-hasmany.js
@@ -6,835 +6,835 @@ var common   = require('../common');
 var protocol = common.protocol();
 
 describe("hasMany", function () {
-	this.timeout(4000);
-	var db     = null;
-	var Person = null;
-	var Pet    = null;
-
-	before(function(done) {
-		helper.connect(function (connection) {
-			db = connection;
-			done();
-		});
-	});
-
-	describe("normal", function () {
-
-		var setup = function (opts) {
-			opts = opts || {};
-
-			return function (done) {
-				db.settings.set('instance.identityCache', false);
-
-				Person = db.define('person', {
-					name    : String,
-					surname : String,
-					age     : Number
-				});
-				Pet = db.define('pet', {
-					name    : String
-				});
-				Person.hasMany('pets', Pet, {}, { autoFetch: opts.autoFetchPets });
-
-				helper.dropSync([ Person, Pet], function (err) {
-					should.not.exist(err);
-
-					Pet.create([{ name: "Cat" }, { name: "Dog" }], function (err) {
-						should.not.exist(err);
-
-						/**
-						 * John --+---> Deco
-						 *        '---> Mutt <----- Jane
-						 *
-						 * Justin
-						 */
-						Person.create([
-							{
-								name    : "Bob",
-								surname : "Smith",
-								age     : 30
-							},
-							{
-								name    : "John",
-								surname : "Doe",
-								age     : 20,
-								pets    : [{
-									name    : "Deco"
-								}, {
-									name    : "Mutt"
-								}]
-							}, {
-								name    : "Jane",
-								surname : "Doe",
-								age     : 16
-							}, {
-								name    : "Justin",
-								surname : "Dean",
-								age     : 18
-							}
-						], function (err) {
-							should.not.exist(err);
-
-							Person.find({ name: "Jane" }, function (err, people) {
-								should.not.exist(err);
-
-								Pet.find({ name: "Mutt" }, function (err, pets) {
-									should.not.exist(err);
-
-									people[0].addPets(pets, done);
-								});
-							});
-						});
-					});
-				});
-			};
-		};
-
-		describe("getAccessor", function () {
-			before(setup());
-
-			it("should allow to specify order as string", function (done) {
-				Person.find({ name: "John" }, function (err, people) {
-					should.equal(err, null);
-
-					people[0].getPets("-name", function (err, pets) {
-						should.equal(err, null);
-
-						should(Array.isArray(pets));
-						pets.length.should.equal(2);
-						pets[0].model().should.equal(Pet);
-						pets[0].name.should.equal("Mutt");
-						pets[1].name.should.equal("Deco");
-
-						return done();
-					});
-				});
-			});
+  this.timeout(4000);
+  var db     = null;
+  var Person = null;
+  var Pet    = null;
+
+  before(function(done) {
+    helper.connect(function (connection) {
+      db = connection;
+      done();
+    });
+  });
+
+  describe("normal", function () {
+
+    var setup = function (opts) {
+      opts = opts || {};
+
+      return function (done) {
+        db.settings.set('instance.identityCache', false);
+
+        Person = db.define('person', {
+          name    : String,
+          surname : String,
+          age     : Number
+        });
+        Pet = db.define('pet', {
+          name    : String
+        });
+        Person.hasMany('pets', Pet, {}, { autoFetch: opts.autoFetchPets });
+
+        helper.dropSync([ Person, Pet], function (err) {
+          should.not.exist(err);
+
+          Pet.create([{ name: "Cat" }, { name: "Dog" }], function (err) {
+            should.not.exist(err);
+
+            /**
+             * John --+---> Deco
+             *        '---> Mutt <----- Jane
+             *
+             * Justin
+             */
+            Person.create([
+              {
+                name    : "Bob",
+                surname : "Smith",
+                age     : 30
+              },
+              {
+                name    : "John",
+                surname : "Doe",
+                age     : 20,
+                pets    : [{
+                  name    : "Deco"
+                }, {
+                  name    : "Mutt"
+                }]
+              }, {
+                name    : "Jane",
+                surname : "Doe",
+                age     : 16
+              }, {
+                name    : "Justin",
+                surname : "Dean",
+                age     : 18
+              }
+            ], function (err) {
+              should.not.exist(err);
+
+              Person.find({ name: "Jane" }, function (err, people) {
+                should.not.exist(err);
+
+                Pet.find({ name: "Mutt" }, function (err, pets) {
+                  should.not.exist(err);
+
+                  people[0].addPets(pets, done);
+                });
+              });
+            });
+          });
+        });
+      };
+    };
+
+    describe("getAccessor", function () {
+      before(setup());
+
+      it("should allow to specify order as string", function (done) {
+        Person.find({ name: "John" }, function (err, people) {
+          should.equal(err, null);
+
+          people[0].getPets("-name", function (err, pets) {
+            should.equal(err, null);
+
+            should(Array.isArray(pets));
+            pets.length.should.equal(2);
+            pets[0].model().should.equal(Pet);
+            pets[0].name.should.equal("Mutt");
+            pets[1].name.should.equal("Deco");
+
+            return done();
+          });
+        });
+      });
 
- 			it ("should return proper instance model", function(done){
- 				Person.find({ name: "John" }, function (err, people) {
-					people[0].getPets("-name", function (err, pets) {
-						pets[0].model().should.equal(Pet);
-						return done();
-					});
-				});
- 			});
-
-			it("should allow to specify order as Array", function (done) {
-				Person.find({ name: "John" }, function (err, people) {
-					should.equal(err, null);
+       it ("should return proper instance model", function(done){
+         Person.find({ name: "John" }, function (err, people) {
+          people[0].getPets("-name", function (err, pets) {
+            pets[0].model().should.equal(Pet);
+            return done();
+          });
+        });
+       });
+
+      it("should allow to specify order as Array", function (done) {
+        Person.find({ name: "John" }, function (err, people) {
+          should.equal(err, null);
 
-					people[0].getPets([ "name", "Z" ], function (err, pets) {
-						should.equal(err, null);
+          people[0].getPets([ "name", "Z" ], function (err, pets) {
+            should.equal(err, null);
 
-						should(Array.isArray(pets));
-						pets.length.should.equal(2);
-						pets[0].name.should.equal("Mutt");
-						pets[1].name.should.equal("Deco");
-
-						return done();
-					});
-				});
-			});
-
-			it("should allow to specify a limit", function (done) {
-				Person.find({ name: "John" }).first(function (err, John) {
-					should.equal(err, null);
-
-					John.getPets(1, function (err, pets) {
-						should.equal(err, null);
-
-						should(Array.isArray(pets));
-						pets.length.should.equal(1);
+            should(Array.isArray(pets));
+            pets.length.should.equal(2);
+            pets[0].name.should.equal("Mutt");
+            pets[1].name.should.equal("Deco");
+
+            return done();
+          });
+        });
+      });
+
+      it("should allow to specify a limit", function (done) {
+        Person.find({ name: "John" }).first(function (err, John) {
+          should.equal(err, null);
+
+          John.getPets(1, function (err, pets) {
+            should.equal(err, null);
+
+            should(Array.isArray(pets));
+            pets.length.should.equal(1);
 
-						return done();
-					});
-				});
-			});
-
-			it("should allow to specify conditions", function (done) {
-				Person.find({ name: "John" }).first(function (err, John) {
-					should.equal(err, null);
-
-					John.getPets({ name: "Mutt" }, function (err, pets) {
-						should.equal(err, null);
-
-						should(Array.isArray(pets));
-						pets.length.should.equal(1);
-						pets[0].name.should.equal("Mutt");
-
-						return done();
-					});
-				});
-			});
-
-			if (common.protocol() == "mongodb") return;
-
-			it("should return a chain if no callback defined", function (done) {
-				Person.find({ name: "John" }, function (err, people) {
-					should.equal(err, null);
-
-					var chain = people[0].getPets({ name: "Mutt" });
-
-					chain.should.be.a.Object();
-					chain.find.should.be.a.Function();
-					chain.only.should.be.a.Function();
-					chain.limit.should.be.a.Function();
-					chain.order.should.be.a.Function();
-
-					return done();
-				});
-			});
-
-			it("should allow chaining count()", function (done) {
-				Person.find({}, function (err, people) {
-					should.equal(err, null);
-
-					people[1].getPets().count(function (err, count) {
-						should.not.exist(err);
-
-						should.strictEqual(count, 2);
-
-						people[2].getPets().count(function (err, count) {
-							should.not.exist(err);
-
-							should.strictEqual(count, 1);
-
-							people[3].getPets().count(function (err, count) {
-								should.not.exist(err);
-
-								should.strictEqual(count, 0);
-
-								return done();
-							});
-						});
-					});
-				});
-			});
-		});
-
-		describe("hasAccessor", function () {
-			before(setup());
-
-			it("should return true if instance has associated item", function (done) {
-				Pet.find({ name: "Mutt" }, function (err, pets) {
-					should.equal(err, null);
-
-					Person.find({ name: "Jane" }).first(function (err, Jane) {
-						should.equal(err, null);
-
-						Jane.hasPets(pets[0], function (err, has_pets) {
-							should.equal(err, null);
-							has_pets.should.be.true;
-
-							return done();
-						});
-					});
-				});
-			});
-
-			it("should return true if not passing any instance and has associated items", function (done) {
-				Person.find({ name: "Jane" }).first(function (err, Jane) {
-					should.equal(err, null);
-
-					Jane.hasPets(function (err, has_pets) {
-						should.equal(err, null);
-						has_pets.should.be.true;
-
-						return done();
-					});
-				});
-			});
-
-			it("should return true if all passed instances are associated", function (done) {
-				Pet.find(function (err, pets) {
-					Person.find({ name: "John" }).first(function (err, John) {
-						should.equal(err, null);
-
-						John.hasPets(pets, function (err, has_pets) {
-							should.equal(err, null);
-							has_pets.should.be.true;
-
-							return done();
-						});
-					});
-				});
-			});
-
-			it("should return false if any passed instances are not associated", function (done) {
-				Pet.find(function (err, pets) {
-					Person.find({ name: "Jane" }).first(function (err, Jane) {
-						should.equal(err, null);
-
-						Jane.hasPets(pets, function (err, has_pets) {
-							should.equal(err, null);
-							has_pets.should.be.false;
-
-							return done();
-						});
-					});
-				});
-			});
-
-			if (common.protocol() != "mongodb") {
-				it("should return true if join table has duplicate entries", function (done) {
-					Pet.find({ name: ["Mutt", "Deco"] }, function (err, pets) {
-						should.not.exist(err);
-						should.equal(pets.length, 2);
-
-						Person.find({ name: "John" }).first(function (err, John) {
-							should.not.exist(err);
-
-							John.hasPets(pets, function (err, hasPets) {
-								should.equal(err, null);
-								should.equal(hasPets, true);
-
-								db.driver.execQuery(
-									"INSERT INTO person_pets (person_id, pets_id) VALUES (?,?), (?,?)",
-									[John.id, pets[0].id, John.id, pets[1].id],
-									function (err) {
-										should.not.exist(err);
-
-										John.hasPets(pets, function (err, hasPets) {
-											should.equal(err, null);
-											should.equal(hasPets, true);
-
-											done()
-										});
-									}
-								);
-							});
-						});
-					});
-				});
-			}
-		});
-
-		describe("delAccessor", function () {
-			before(setup());
-
-			it("should accept arguments in different orders", function (done) {
-				Pet.find({ name: "Mutt" }, function (err, pets) {
-					Person.find({ name: "John" }, function (err, people) {
-						should.equal(err, null);
-
-						people[0].removePets(function (err) {
-							should.equal(err, null);
-
-							people[0].getPets(function (err, pets) {
-								should.equal(err, null);
-
-								should(Array.isArray(pets));
-								pets.length.should.equal(1);
-								pets[0].name.should.equal("Deco");
-
-								return done();
-							});
-						}, pets[0]);
-					});
-				});
-			});
-		});
-
-		describe("delAccessor", function () {
-			before(setup());
-
-			it("should remove specific associations if passed", function (done) {
-				Pet.find({ name: "Mutt" }, function (err, pets) {
-					Person.find({ name: "John" }, function (err, people) {
-						should.equal(err, null);
-
-						people[0].removePets(pets[0], function (err) {
-							should.equal(err, null);
-
-							people[0].getPets(function (err, pets) {
-								should.equal(err, null);
-
-								should(Array.isArray(pets));
-								pets.length.should.equal(1);
-								pets[0].name.should.equal("Deco");
-
-								return done();
-							});
-						});
-					});
-				});
-			});
-
-			it("should remove all associations if none passed", function (done) {
-				Person.find({ name: "John" }).first(function (err, John) {
-					should.equal(err, null);
-
-					John.removePets(function (err) {
-						should.equal(err, null);
-
-						John.getPets(function (err, pets) {
-							should.equal(err, null);
-
-							should(Array.isArray(pets));
-							pets.length.should.equal(0);
-
-							return done();
-						});
-					});
-				});
-			});
-		});
-
-		describe("addAccessor", function () {
-			before(setup());
-
-			if (common.protocol() != "mongodb") {
-				it("might add duplicates", function (done) {
-					Pet.find({ name: "Mutt" }, function (err, pets) {
-						Person.find({ name: "Jane" }, function (err, people) {
-							should.equal(err, null);
-
-							people[0].addPets(pets[0], function (err) {
-								should.equal(err, null);
-
-								people[0].getPets("name", function (err, pets) {
-									should.equal(err, null);
-
-									should(Array.isArray(pets));
-									pets.length.should.equal(2);
-									pets[0].name.should.equal("Mutt");
-									pets[1].name.should.equal("Mutt");
-
-									return done();
-								});
-							});
-						});
-					});
-				});
-			}
-
-			it("should keep associations and add new ones", function (done) {
-				Pet.find({ name: "Deco" }).first(function (err, Deco) {
-					Person.find({ name: "Jane" }).first(function (err, Jane) {
-						should.equal(err, null);
-
-						Jane.getPets(function (err, janesPets) {
-							should.not.exist(err);
-
-							var petsAtStart = janesPets.length;
-
-							Jane.addPets(Deco, function (err) {
-								should.equal(err, null);
-
-								Jane.getPets("name", function (err, pets) {
-									should.equal(err, null);
-
-									should(Array.isArray(pets));
-									pets.length.should.equal(petsAtStart + 1);
-									pets[0].name.should.equal("Deco");
-									pets[1].name.should.equal("Mutt");
-
-									return done();
-								});
-							});
-						});
-					});
-				});
-			});
-
-			it("should accept several arguments as associations", function (done) {
-				Pet.find(function (err, pets) {
-					Person.find({ name: "Justin" }).first(function (err, Justin) {
-						should.equal(err, null);
-
-						Justin.addPets(pets[0], pets[1], function (err) {
-							should.equal(err, null);
-
-							Justin.getPets(function (err, pets) {
-								should.equal(err, null);
-
-								should(Array.isArray(pets));
-								pets.length.should.equal(2);
-
-								return done();
-							});
-						});
-					});
-				});
-			});
-
-			it("should accept array as list of associations", function (done) {
-				Pet.create([{ name: 'Ruff' }, { name: 'Spotty' }],function (err, pets) {
-					Person.find({ name: "Justin" }).first(function (err, Justin) {
-						should.equal(err, null);
-
-						Justin.getPets(function (err, justinsPets) {
-							should.equal(err, null);
-
-							var petCount = justinsPets.length;
-
-							Justin.addPets(pets, function (err) {
-								should.equal(err, null);
-
-								Justin.getPets(function (err, justinsPets) {
-									should.equal(err, null);
-
-									should(Array.isArray(justinsPets));
-									// Mongo doesn't like adding duplicates here, so we add new ones.
-									should.equal(justinsPets.length, petCount + 2);
-
-									return done();
-								});
-							});
-						});
-					});
-				});
-			});
-
-			it("should throw if no items passed", function (done) {
-				Person.one(function (err, person) {
-					should.equal(err, null);
-
-					(function () {
-						person.addPets(function () {});
-					}).should.throw();
-
-					return done();
-				});
-			});
-		});
-
-		describe("setAccessor", function () {
-			before(setup());
-
-			it("should accept several arguments as associations", function (done) {
-				Pet.find(function (err, pets) {
-					Person.find({ name: "Justin" }).first(function (err, Justin) {
-						should.equal(err, null);
-
-						Justin.setPets(pets[0], pets[1], function (err) {
-							should.equal(err, null);
-
-							Justin.getPets(function (err, pets) {
-								should.equal(err, null);
-
-								should(Array.isArray(pets));
-								pets.length.should.equal(2);
-
-								return done();
-							});
-						});
-					});
-				});
-			});
-
-			it("should accept an array of associations", function (done) {
-				Pet.find(function (err, pets) {
-					Person.find({ name: "Justin" }).first(function (err, Justin) {
-						should.equal(err, null);
-
-						Justin.setPets(pets, function (err) {
-							should.equal(err, null);
-
-							Justin.getPets(function (err, all_pets) {
-								should.equal(err, null);
-
-								should(Array.isArray(all_pets));
-								all_pets.length.should.equal(pets.length);
-
-								return done();
-							});
-						});
-					});
-				});
-			});
-
-			it("should remove all associations if an empty array is passed", function (done) {
-				Person.find({ name: "Justin" }).first(function (err, Justin) {
-					should.equal(err, null);
-					Justin.getPets(function (err, pets) {
-						should.equal(err, null);
-						should.equal(pets.length, 4);
-
-						Justin.setPets([], function (err) {
-							should.equal(err, null);
-
-							Justin.getPets(function (err, pets) {
-								should.equal(err, null);
-								should.equal(pets.length, 0);
-
-								return done();
-							});
-						});
-					});
-				});
-			});
-
-			it("clears current associations", function (done) {
-				Pet.find({ name: "Deco" }, function (err, pets) {
-					var Deco = pets[0];
-
-					Person.find({ name: "Jane" }).first(function (err, Jane) {
-						should.equal(err, null);
-
-						Jane.getPets(function (err, pets) {
-							should.equal(err, null);
-
-							should(Array.isArray(pets));
-							pets.length.should.equal(1);
-							pets[0].name.should.equal("Mutt");
-
-							Jane.setPets(Deco, function (err) {
-								should.equal(err, null);
-
-								Jane.getPets(function (err, pets) {
-									should.equal(err, null);
-
-									should(Array.isArray(pets));
-									pets.length.should.equal(1);
-									pets[0].name.should.equal(Deco.name);
-
-									return done();
-								});
-							});
-						});
-					});
-				});
-			});
-		});
-
-		describe("with autoFetch turned on", function () {
-			before(setup({
-				autoFetchPets : true
-			}));
-
-			it("should fetch associations", function (done) {
-				Person.find({ name: "John" }).first(function (err, John) {
-					should.equal(err, null);
-
-					John.should.have.property("pets");
-					should(Array.isArray(John.pets));
-					John.pets.length.should.equal(2);
-
-					return done();
-				});
-			});
-
-			it("should save existing", function (done) {
-				Person.create({ name: 'Bishan' }, function (err) {
-					should.not.exist(err);
-
-					Person.one({ name: 'Bishan' }, function (err, person) {
-						should.not.exist(err);
-
-						person.surname = 'Dominar';
-
-						person.save(function (err) {
-							should.not.exist(err);
-
-							done();
-						});
-					});
-				});
-			});
-
-			it("should not auto save associations which were autofetched", function (done) {
-				Pet.all(function (err, pets) {
-					should.not.exist(err);
-					should.equal(pets.length, 4);
-
-					Person.create({ name: 'Paul' }, function (err, paul) {
-						should.not.exist(err);
-
-						Person.one({ name: 'Paul' }, function (err, paul2) {
-							should.not.exist(err);
-							should.equal(paul2.pets.length, 0);
-
-							paul.setPets(pets, function (err) {
-								should.not.exist(err);
-
-								// reload paul to make sure we have 2 pets
-								Person.one({ name: 'Paul' }, function (err, paul) {
-									should.not.exist(err);
-									should.equal(paul.pets.length, 4);
-
-									// Saving paul2 should NOT auto save associations and hence delete
-									// the associations we just created.
-									paul2.save(function (err) {
-										should.not.exist(err);
-
-										// let's check paul - pets should still be associated
-										Person.one({ name: 'Paul' }, function (err, paul) {
-											should.not.exist(err);
-											should.equal(paul.pets.length, 4);
-
-											done();
-										});
-									});
-								});
-							});
-						});
-					});
-				});
-			});
-
-			it("should save associations set by the user", function (done) {
-				Person.one({ name: 'John' }, function (err, john) {
-					should.not.exist(err);
-					should.equal(john.pets.length, 2);
-
-					john.pets = [];
-
-					john.save(function (err) {
-						should.not.exist(err);
-
-						// reload john to make sure pets were deleted
-						Person.one({ name: 'John' }, function (err, john) {
-							should.not.exist(err);
-							should.equal(john.pets.length, 0);
-
-							done();
-						});
-					});
-				});
-			});
-
-		});
-	});
-
-	if (protocol == "mongodb") return;
-
-	describe("with non-standard keys", function () {
-		var Email;
-		var Account;
-
-		setup = function (opts, done) {
-			Email = db.define('email', {
-			  text         : { type: 'text', key: true, required: true },
-			  bounced      : Boolean
-			});
-
-			Account = db.define('account', {
-			  name: String
-			});
-
-			Account.hasMany('emails', Email, {}, { key: opts.key });
-
-			helper.dropSync([ Email, Account ], function (err) {
-				should.not.exist(err);
-				done()
-			});
-		};
-
-		it("should place ids in the right place", function (done) {
-			setup({}, function (err) {
-				should.not.exist(err);
-
-				Email.create([{bounced: true, text: 'a@test.com'}, {bounced: false, text: 'z@test.com'}], function (err, emails) {
-					should.not.exist(err);
-
-					Account.create({ name: "Stuff" }, function (err, account) {
-						should.not.exist(err);
-
-						account.addEmails(emails[1], function (err) {
-							should.not.exist(err);
-
-							db.driver.execQuery("SELECT * FROM account_emails", function (err, data) {
-								should.not.exist(err);
-
-								should.equal(data[0].account_id, 1);
-								should.equal(data[0].emails_text, 'z@test.com');
-
-								done();
-							});
-						});
-					});
-				});
-			});
-		});
-
-		it("should generate correct tables", function (done) {
-			setup({}, function (err) {
-				should.not.exist(err);
-
-				var sql;
-
-				if (protocol == 'sqlite') {
-					sql = "PRAGMA table_info(?)";
-				} else {
-					sql = "SELECT column_name, data_type FROM information_schema.columns WHERE table_name = ? ORDER BY data_type";
-				}
-
-				db.driver.execQuery(sql, ['account_emails'], function (err, cols) {
-					should.not.exist(err);
-
-					if (protocol == 'sqlite') {
-						should.equal(cols[0].name, 'account_id');
-						should.equal(cols[0].type, 'INTEGER');
-						should.equal(cols[1].name, 'emails_text');
-						should.equal(cols[1].type, 'TEXT');
-					} else if (protocol == 'mysql') {
-						should.equal(cols[0].column_name, 'account_id');
-						should.equal(cols[0].data_type,   'int');
-						should.equal(cols[1].column_name, 'emails_text');
-						should.equal(cols[1].data_type,    'varchar');
-					} else if (protocol == 'postgres') {
-						should.equal(cols[0].column_name, 'account_id');
-						should.equal(cols[0].data_type,   'integer');
-						should.equal(cols[1].column_name, 'emails_text');
-						should.equal(cols[1].data_type,   'text');
-					}
-
-					done();
-				});
-			});
-		});
-
-		it("should add a composite key to the join table if requested", function (done) {
-			setup({ key: true }, function (err) {
-				should.not.exist(err);
-				var sql;
-
-				if (protocol == 'postgres' || protocol === 'redshift') {
-					sql = "" +
-						"SELECT c.column_name, c.data_type " +
-						"FROM  information_schema.table_constraints tc " +
-						"JOIN information_schema.constraint_column_usage AS ccu USING (constraint_schema, constraint_name) " +
-						"JOIN information_schema.columns AS c ON c.table_schema = tc.constraint_schema AND tc.table_name = c.table_name AND ccu.column_name = c.column_name " +
-						"WHERE constraint_type = ? AND tc.table_name = ? " +
-						"ORDER BY column_name";
-
-					db.driver.execQuery(sql, ['PRIMARY KEY', 'account_emails'], function (err, data) {
-						should.not.exist(err);
-
-						should.equal(data.length, 2);
-						should.equal(data[0].column_name, 'account_id');
-						should.equal(data[1].column_name, 'emails_text');
-
-						done()
-					});
-				} else if (protocol == 'mysql') {
-					db.driver.execQuery("SHOW KEYS FROM ?? WHERE Key_name = ?", ['account_emails', 'PRIMARY'], function (err, data) {
-						should.not.exist(err);
-
-						should.equal(data.length, 2);
-						should.equal(data[0].Column_name, 'account_id');
-						should.equal(data[0].Key_name, 'PRIMARY');
-						should.equal(data[1].Column_name, 'emails_text');
-						should.equal(data[1].Key_name, 'PRIMARY');
-
-						done();
-					});
-				} else if (protocol == 'sqlite') {
-					db.driver.execQuery("pragma table_info(??)", ['account_emails'], function (err, data) {
-						should.not.exist(err);
-
-						should.equal(data.length, 2);
-						should.equal(data[0].name, 'account_id');
-						should.equal(data[0].pk, 1);
-						should.equal(data[1].name, 'emails_text');
-						should.equal(data[1].pk, 2);
-
-						done();
-					});
-				}
-			});
-		});
-	});
+            return done();
+          });
+        });
+      });
+
+      it("should allow to specify conditions", function (done) {
+        Person.find({ name: "John" }).first(function (err, John) {
+          should.equal(err, null);
+
+          John.getPets({ name: "Mutt" }, function (err, pets) {
+            should.equal(err, null);
+
+            should(Array.isArray(pets));
+            pets.length.should.equal(1);
+            pets[0].name.should.equal("Mutt");
+
+            return done();
+          });
+        });
+      });
+
+      if (common.protocol() == "mongodb") return;
+
+      it("should return a chain if no callback defined", function (done) {
+        Person.find({ name: "John" }, function (err, people) {
+          should.equal(err, null);
+
+          var chain = people[0].getPets({ name: "Mutt" });
+
+          chain.should.be.a.Object();
+          chain.find.should.be.a.Function();
+          chain.only.should.be.a.Function();
+          chain.limit.should.be.a.Function();
+          chain.order.should.be.a.Function();
+
+          return done();
+        });
+      });
+
+      it("should allow chaining count()", function (done) {
+        Person.find({}, function (err, people) {
+          should.equal(err, null);
+
+          people[1].getPets().count(function (err, count) {
+            should.not.exist(err);
+
+            should.strictEqual(count, 2);
+
+            people[2].getPets().count(function (err, count) {
+              should.not.exist(err);
+
+              should.strictEqual(count, 1);
+
+              people[3].getPets().count(function (err, count) {
+                should.not.exist(err);
+
+                should.strictEqual(count, 0);
+
+                return done();
+              });
+            });
+          });
+        });
+      });
+    });
+
+    describe("hasAccessor", function () {
+      before(setup());
+
+      it("should return true if instance has associated item", function (done) {
+        Pet.find({ name: "Mutt" }, function (err, pets) {
+          should.equal(err, null);
+
+          Person.find({ name: "Jane" }).first(function (err, Jane) {
+            should.equal(err, null);
+
+            Jane.hasPets(pets[0], function (err, has_pets) {
+              should.equal(err, null);
+              has_pets.should.be.true;
+
+              return done();
+            });
+          });
+        });
+      });
+
+      it("should return true if not passing any instance and has associated items", function (done) {
+        Person.find({ name: "Jane" }).first(function (err, Jane) {
+          should.equal(err, null);
+
+          Jane.hasPets(function (err, has_pets) {
+            should.equal(err, null);
+            has_pets.should.be.true;
+
+            return done();
+          });
+        });
+      });
+
+      it("should return true if all passed instances are associated", function (done) {
+        Pet.find(function (err, pets) {
+          Person.find({ name: "John" }).first(function (err, John) {
+            should.equal(err, null);
+
+            John.hasPets(pets, function (err, has_pets) {
+              should.equal(err, null);
+              has_pets.should.be.true;
+
+              return done();
+            });
+          });
+        });
+      });
+
+      it("should return false if any passed instances are not associated", function (done) {
+        Pet.find(function (err, pets) {
+          Person.find({ name: "Jane" }).first(function (err, Jane) {
+            should.equal(err, null);
+
+            Jane.hasPets(pets, function (err, has_pets) {
+              should.equal(err, null);
+              has_pets.should.be.false;
+
+              return done();
+            });
+          });
+        });
+      });
+
+      if (common.protocol() != "mongodb") {
+        it("should return true if join table has duplicate entries", function (done) {
+          Pet.find({ name: ["Mutt", "Deco"] }, function (err, pets) {
+            should.not.exist(err);
+            should.equal(pets.length, 2);
+
+            Person.find({ name: "John" }).first(function (err, John) {
+              should.not.exist(err);
+
+              John.hasPets(pets, function (err, hasPets) {
+                should.equal(err, null);
+                should.equal(hasPets, true);
+
+                db.driver.execQuery(
+                  "INSERT INTO person_pets (person_id, pets_id) VALUES (?,?), (?,?)",
+                  [John.id, pets[0].id, John.id, pets[1].id],
+                  function (err) {
+                    should.not.exist(err);
+
+                    John.hasPets(pets, function (err, hasPets) {
+                      should.equal(err, null);
+                      should.equal(hasPets, true);
+
+                      done()
+                    });
+                  }
+                );
+              });
+            });
+          });
+        });
+      }
+    });
+
+    describe("delAccessor", function () {
+      before(setup());
+
+      it("should accept arguments in different orders", function (done) {
+        Pet.find({ name: "Mutt" }, function (err, pets) {
+          Person.find({ name: "John" }, function (err, people) {
+            should.equal(err, null);
+
+            people[0].removePets(function (err) {
+              should.equal(err, null);
+
+              people[0].getPets(function (err, pets) {
+                should.equal(err, null);
+
+                should(Array.isArray(pets));
+                pets.length.should.equal(1);
+                pets[0].name.should.equal("Deco");
+
+                return done();
+              });
+            }, pets[0]);
+          });
+        });
+      });
+    });
+
+    describe("delAccessor", function () {
+      before(setup());
+
+      it("should remove specific associations if passed", function (done) {
+        Pet.find({ name: "Mutt" }, function (err, pets) {
+          Person.find({ name: "John" }, function (err, people) {
+            should.equal(err, null);
+
+            people[0].removePets(pets[0], function (err) {
+              should.equal(err, null);
+
+              people[0].getPets(function (err, pets) {
+                should.equal(err, null);
+
+                should(Array.isArray(pets));
+                pets.length.should.equal(1);
+                pets[0].name.should.equal("Deco");
+
+                return done();
+              });
+            });
+          });
+        });
+      });
+
+      it("should remove all associations if none passed", function (done) {
+        Person.find({ name: "John" }).first(function (err, John) {
+          should.equal(err, null);
+
+          John.removePets(function (err) {
+            should.equal(err, null);
+
+            John.getPets(function (err, pets) {
+              should.equal(err, null);
+
+              should(Array.isArray(pets));
+              pets.length.should.equal(0);
+
+              return done();
+            });
+          });
+        });
+      });
+    });
+
+    describe("addAccessor", function () {
+      before(setup());
+
+      if (common.protocol() != "mongodb") {
+        it("might add duplicates", function (done) {
+          Pet.find({ name: "Mutt" }, function (err, pets) {
+            Person.find({ name: "Jane" }, function (err, people) {
+              should.equal(err, null);
+
+              people[0].addPets(pets[0], function (err) {
+                should.equal(err, null);
+
+                people[0].getPets("name", function (err, pets) {
+                  should.equal(err, null);
+
+                  should(Array.isArray(pets));
+                  pets.length.should.equal(2);
+                  pets[0].name.should.equal("Mutt");
+                  pets[1].name.should.equal("Mutt");
+
+                  return done();
+                });
+              });
+            });
+          });
+        });
+      }
+
+      it("should keep associations and add new ones", function (done) {
+        Pet.find({ name: "Deco" }).first(function (err, Deco) {
+          Person.find({ name: "Jane" }).first(function (err, Jane) {
+            should.equal(err, null);
+
+            Jane.getPets(function (err, janesPets) {
+              should.not.exist(err);
+
+              var petsAtStart = janesPets.length;
+
+              Jane.addPets(Deco, function (err) {
+                should.equal(err, null);
+
+                Jane.getPets("name", function (err, pets) {
+                  should.equal(err, null);
+
+                  should(Array.isArray(pets));
+                  pets.length.should.equal(petsAtStart + 1);
+                  pets[0].name.should.equal("Deco");
+                  pets[1].name.should.equal("Mutt");
+
+                  return done();
+                });
+              });
+            });
+          });
+        });
+      });
+
+      it("should accept several arguments as associations", function (done) {
+        Pet.find(function (err, pets) {
+          Person.find({ name: "Justin" }).first(function (err, Justin) {
+            should.equal(err, null);
+
+            Justin.addPets(pets[0], pets[1], function (err) {
+              should.equal(err, null);
+
+              Justin.getPets(function (err, pets) {
+                should.equal(err, null);
+
+                should(Array.isArray(pets));
+                pets.length.should.equal(2);
+
+                return done();
+              });
+            });
+          });
+        });
+      });
+
+      it("should accept array as list of associations", function (done) {
+        Pet.create([{ name: 'Ruff' }, { name: 'Spotty' }],function (err, pets) {
+          Person.find({ name: "Justin" }).first(function (err, Justin) {
+            should.equal(err, null);
+
+            Justin.getPets(function (err, justinsPets) {
+              should.equal(err, null);
+
+              var petCount = justinsPets.length;
+
+              Justin.addPets(pets, function (err) {
+                should.equal(err, null);
+
+                Justin.getPets(function (err, justinsPets) {
+                  should.equal(err, null);
+
+                  should(Array.isArray(justinsPets));
+                  // Mongo doesn't like adding duplicates here, so we add new ones.
+                  should.equal(justinsPets.length, petCount + 2);
+
+                  return done();
+                });
+              });
+            });
+          });
+        });
+      });
+
+      it("should throw if no items passed", function (done) {
+        Person.one(function (err, person) {
+          should.equal(err, null);
+
+          (function () {
+            person.addPets(function () {});
+          }).should.throw();
+
+          return done();
+        });
+      });
+    });
+
+    describe("setAccessor", function () {
+      before(setup());
+
+      it("should accept several arguments as associations", function (done) {
+        Pet.find(function (err, pets) {
+          Person.find({ name: "Justin" }).first(function (err, Justin) {
+            should.equal(err, null);
+
+            Justin.setPets(pets[0], pets[1], function (err) {
+              should.equal(err, null);
+
+              Justin.getPets(function (err, pets) {
+                should.equal(err, null);
+
+                should(Array.isArray(pets));
+                pets.length.should.equal(2);
+
+                return done();
+              });
+            });
+          });
+        });
+      });
+
+      it("should accept an array of associations", function (done) {
+        Pet.find(function (err, pets) {
+          Person.find({ name: "Justin" }).first(function (err, Justin) {
+            should.equal(err, null);
+
+            Justin.setPets(pets, function (err) {
+              should.equal(err, null);
+
+              Justin.getPets(function (err, all_pets) {
+                should.equal(err, null);
+
+                should(Array.isArray(all_pets));
+                all_pets.length.should.equal(pets.length);
+
+                return done();
+              });
+            });
+          });
+        });
+      });
+
+      it("should remove all associations if an empty array is passed", function (done) {
+        Person.find({ name: "Justin" }).first(function (err, Justin) {
+          should.equal(err, null);
+          Justin.getPets(function (err, pets) {
+            should.equal(err, null);
+            should.equal(pets.length, 4);
+
+            Justin.setPets([], function (err) {
+              should.equal(err, null);
+
+              Justin.getPets(function (err, pets) {
+                should.equal(err, null);
+                should.equal(pets.length, 0);
+
+                return done();
+              });
+            });
+          });
+        });
+      });
+
+      it("clears current associations", function (done) {
+        Pet.find({ name: "Deco" }, function (err, pets) {
+          var Deco = pets[0];
+
+          Person.find({ name: "Jane" }).first(function (err, Jane) {
+            should.equal(err, null);
+
+            Jane.getPets(function (err, pets) {
+              should.equal(err, null);
+
+              should(Array.isArray(pets));
+              pets.length.should.equal(1);
+              pets[0].name.should.equal("Mutt");
+
+              Jane.setPets(Deco, function (err) {
+                should.equal(err, null);
+
+                Jane.getPets(function (err, pets) {
+                  should.equal(err, null);
+
+                  should(Array.isArray(pets));
+                  pets.length.should.equal(1);
+                  pets[0].name.should.equal(Deco.name);
+
+                  return done();
+                });
+              });
+            });
+          });
+        });
+      });
+    });
+
+    describe("with autoFetch turned on", function () {
+      before(setup({
+        autoFetchPets : true
+      }));
+
+      it("should fetch associations", function (done) {
+        Person.find({ name: "John" }).first(function (err, John) {
+          should.equal(err, null);
+
+          John.should.have.property("pets");
+          should(Array.isArray(John.pets));
+          John.pets.length.should.equal(2);
+
+          return done();
+        });
+      });
+
+      it("should save existing", function (done) {
+        Person.create({ name: 'Bishan' }, function (err) {
+          should.not.exist(err);
+
+          Person.one({ name: 'Bishan' }, function (err, person) {
+            should.not.exist(err);
+
+            person.surname = 'Dominar';
+
+            person.save(function (err) {
+              should.not.exist(err);
+
+              done();
+            });
+          });
+        });
+      });
+
+      it("should not auto save associations which were autofetched", function (done) {
+        Pet.all(function (err, pets) {
+          should.not.exist(err);
+          should.equal(pets.length, 4);
+
+          Person.create({ name: 'Paul' }, function (err, paul) {
+            should.not.exist(err);
+
+            Person.one({ name: 'Paul' }, function (err, paul2) {
+              should.not.exist(err);
+              should.equal(paul2.pets.length, 0);
+
+              paul.setPets(pets, function (err) {
+                should.not.exist(err);
+
+                // reload paul to make sure we have 2 pets
+                Person.one({ name: 'Paul' }, function (err, paul) {
+                  should.not.exist(err);
+                  should.equal(paul.pets.length, 4);
+
+                  // Saving paul2 should NOT auto save associations and hence delete
+                  // the associations we just created.
+                  paul2.save(function (err) {
+                    should.not.exist(err);
+
+                    // let's check paul - pets should still be associated
+                    Person.one({ name: 'Paul' }, function (err, paul) {
+                      should.not.exist(err);
+                      should.equal(paul.pets.length, 4);
+
+                      done();
+                    });
+                  });
+                });
+              });
+            });
+          });
+        });
+      });
+
+      it("should save associations set by the user", function (done) {
+        Person.one({ name: 'John' }, function (err, john) {
+          should.not.exist(err);
+          should.equal(john.pets.length, 2);
+
+          john.pets = [];
+
+          john.save(function (err) {
+            should.not.exist(err);
+
+            // reload john to make sure pets were deleted
+            Person.one({ name: 'John' }, function (err, john) {
+              should.not.exist(err);
+              should.equal(john.pets.length, 0);
+
+              done();
+            });
+          });
+        });
+      });
+
+    });
+  });
+
+  if (protocol == "mongodb") return;
+
+  describe("with non-standard keys", function () {
+    var Email;
+    var Account;
+
+    setup = function (opts, done) {
+      Email = db.define('email', {
+        text         : { type: 'text', key: true, required: true },
+        bounced      : Boolean
+      });
+
+      Account = db.define('account', {
+        name: String
+      });
+
+      Account.hasMany('emails', Email, {}, { key: opts.key });
+
+      helper.dropSync([ Email, Account ], function (err) {
+        should.not.exist(err);
+        done()
+      });
+    };
+
+    it("should place ids in the right place", function (done) {
+      setup({}, function (err) {
+        should.not.exist(err);
+
+        Email.create([{bounced: true, text: 'a@test.com'}, {bounced: false, text: 'z@test.com'}], function (err, emails) {
+          should.not.exist(err);
+
+          Account.create({ name: "Stuff" }, function (err, account) {
+            should.not.exist(err);
+
+            account.addEmails(emails[1], function (err) {
+              should.not.exist(err);
+
+              db.driver.execQuery("SELECT * FROM account_emails", function (err, data) {
+                should.not.exist(err);
+
+                should.equal(data[0].account_id, 1);
+                should.equal(data[0].emails_text, 'z@test.com');
+
+                done();
+              });
+            });
+          });
+        });
+      });
+    });
+
+    it("should generate correct tables", function (done) {
+      setup({}, function (err) {
+        should.not.exist(err);
+
+        var sql;
+
+        if (protocol == 'sqlite') {
+          sql = "PRAGMA table_info(?)";
+        } else {
+          sql = "SELECT column_name, data_type FROM information_schema.columns WHERE table_name = ? ORDER BY data_type";
+        }
+
+        db.driver.execQuery(sql, ['account_emails'], function (err, cols) {
+          should.not.exist(err);
+
+          if (protocol == 'sqlite') {
+            should.equal(cols[0].name, 'account_id');
+            should.equal(cols[0].type, 'INTEGER');
+            should.equal(cols[1].name, 'emails_text');
+            should.equal(cols[1].type, 'TEXT');
+          } else if (protocol == 'mysql') {
+            should.equal(cols[0].column_name, 'account_id');
+            should.equal(cols[0].data_type,   'int');
+            should.equal(cols[1].column_name, 'emails_text');
+            should.equal(cols[1].data_type,    'varchar');
+          } else if (protocol == 'postgres') {
+            should.equal(cols[0].column_name, 'account_id');
+            should.equal(cols[0].data_type,   'integer');
+            should.equal(cols[1].column_name, 'emails_text');
+            should.equal(cols[1].data_type,   'text');
+          }
+
+          done();
+        });
+      });
+    });
+
+    it("should add a composite key to the join table if requested", function (done) {
+      setup({ key: true }, function (err) {
+        should.not.exist(err);
+        var sql;
+
+        if (protocol == 'postgres' || protocol === 'redshift') {
+          sql = "" +
+            "SELECT c.column_name, c.data_type " +
+            "FROM  information_schema.table_constraints tc " +
+            "JOIN information_schema.constraint_column_usage AS ccu USING (constraint_schema, constraint_name) " +
+            "JOIN information_schema.columns AS c ON c.table_schema = tc.constraint_schema AND tc.table_name = c.table_name AND ccu.column_name = c.column_name " +
+            "WHERE constraint_type = ? AND tc.table_name = ? " +
+            "ORDER BY column_name";
+
+          db.driver.execQuery(sql, ['PRIMARY KEY', 'account_emails'], function (err, data) {
+            should.not.exist(err);
+
+            should.equal(data.length, 2);
+            should.equal(data[0].column_name, 'account_id');
+            should.equal(data[1].column_name, 'emails_text');
+
+            done()
+          });
+        } else if (protocol == 'mysql') {
+          db.driver.execQuery("SHOW KEYS FROM ?? WHERE Key_name = ?", ['account_emails', 'PRIMARY'], function (err, data) {
+            should.not.exist(err);
+
+            should.equal(data.length, 2);
+            should.equal(data[0].Column_name, 'account_id');
+            should.equal(data[0].Key_name, 'PRIMARY');
+            should.equal(data[1].Column_name, 'emails_text');
+            should.equal(data[1].Key_name, 'PRIMARY');
+
+            done();
+          });
+        } else if (protocol == 'sqlite') {
+          db.driver.execQuery("pragma table_info(??)", ['account_emails'], function (err, data) {
+            should.not.exist(err);
+
+            should.equal(data.length, 2);
+            should.equal(data[0].name, 'account_id');
+            should.equal(data[0].pk, 1);
+            should.equal(data[1].name, 'emails_text');
+            should.equal(data[1].pk, 2);
+
+            done();
+          });
+        }
+      });
+    });
+  });
 });

--- a/test/integration/association-hasone-required.js
+++ b/test/integration/association-hasone-required.js
@@ -5,85 +5,85 @@ var async  = require('async');
 var _      = require('lodash');
 
 describe("hasOne", function() {
-	var db     = null;
-	var Person = null;
+  var db     = null;
+  var Person = null;
 
-	var setup = function (required) {
-		return function (done) {
-			db.settings.set('instance.identityCache', false);
-			db.settings.set('instance.returnAllErrors', true);
+  var setup = function (required) {
+    return function (done) {
+      db.settings.set('instance.identityCache', false);
+      db.settings.set('instance.returnAllErrors', true);
 
-			Person = db.define('person', {
-				name     : String
-			});
-			Person.hasOne('parent', Person, {
-				required : required,
-				field    : 'parentId'
-			});
+      Person = db.define('person', {
+        name     : String
+      });
+      Person.hasOne('parent', Person, {
+        required : required,
+        field    : 'parentId'
+      });
 
-			return helper.dropSync(Person, done);
-		};
-	};
+      return helper.dropSync(Person, done);
+    };
+  };
 
-	before(function(done) {
-		helper.connect(function (connection) {
-			db = connection;
-			done();
-		});
-	});
+  before(function(done) {
+    helper.connect(function (connection) {
+      db = connection;
+      done();
+    });
+  });
 
-	describe("required", function () {
-		before(setup(true));
+  describe("required", function () {
+    before(setup(true));
 
-		it("should not accept empty association", function (done) {
-			var John = new Person({
-				name     : "John",
-				parentId : null
-			});
-			John.save(function (errors) {
-				should.exist(errors);
-				should.equal(errors.length, 1);
-				should.equal(errors[0].type,     'validation');
-				should.equal(errors[0].msg,      'required');
-				should.equal(errors[0].property, 'parentId');
-				return done();
-			});
-		});
+    it("should not accept empty association", function (done) {
+      var John = new Person({
+        name     : "John",
+        parentId : null
+      });
+      John.save(function (errors) {
+        should.exist(errors);
+        should.equal(errors.length, 1);
+        should.equal(errors[0].type,     'validation');
+        should.equal(errors[0].msg,      'required');
+        should.equal(errors[0].property, 'parentId');
+        return done();
+      });
+    });
 
-		it("should accept association", function (done) {
-			var John = new Person({
-				name     : "John",
-				parentId : 1
-			});
-			John.save(function (err) {
-				should.not.exist(err);
-				return done();
-			});
-		});
-	});
+    it("should accept association", function (done) {
+      var John = new Person({
+        name     : "John",
+        parentId : 1
+      });
+      John.save(function (err) {
+        should.not.exist(err);
+        return done();
+      });
+    });
+  });
 
-	describe("not required", function () {
-		before(setup(false));
+  describe("not required", function () {
+    before(setup(false));
 
-		it("should accept empty association", function (done) {
-			var John = new Person({
-				name : "John"
-			});
-			John.save(function (err) {
-				should.not.exist(err);
-				return done();
-			});
-		});
+    it("should accept empty association", function (done) {
+      var John = new Person({
+        name : "John"
+      });
+      John.save(function (err) {
+        should.not.exist(err);
+        return done();
+      });
+    });
 
-		it("should accept null association", function (done) {
-			var John = new Person({
-				name      : "John",
-				parent_id : null
-			});
-			John.save(function (err) {
-				should.not.exist(err);
-				return done();
-			});
-		});
-	});
+    it("should accept null association", function (done) {
+      var John = new Person({
+        name      : "John",
+        parent_id : null
+      });
+      John.save(function (err) {
+        should.not.exist(err);
+        return done();
+      });
+    });
+  });
 });

--- a/test/integration/association-hasone-reverse.js
+++ b/test/integration/association-hasone-reverse.js
@@ -6,331 +6,331 @@ var common = require('../common');
 var _ = require('lodash');
 
 describe("hasOne", function () {
-	var db = null;
-	var Person = null;
-	var Pet = null;
+  var db = null;
+  var Person = null;
+  var Pet = null;
 
-	var setup = function () {
-		return function (done) {
-			Person = db.define('person', {
-				name: String
-			});
-			Pet = db.define('pet', {
-				name: String
-			});
-			Person.hasOne('pet', Pet, {
-				reverse: 'owners',
-				field: 'pet_id'
-			});
+  var setup = function () {
+    return function (done) {
+      Person = db.define('person', {
+        name: String
+      });
+      Pet = db.define('pet', {
+        name: String
+      });
+      Person.hasOne('pet', Pet, {
+        reverse: 'owners',
+        field: 'pet_id'
+      });
 
-			return helper.dropSync([Person, Pet], function () {
-				// Running in series because in-memory sqlite encounters problems
-				async.series([
-					Person.create.bind(Person, { name: "John Doe" }),
-					Person.create.bind(Person, { name: "Jane Doe" }),
-					Pet.create.bind(Pet, { name: "Deco"  }),
-					Pet.create.bind(Pet, { name: "Fido"  })
-				], done);
-			});
-		};
-	};
+      return helper.dropSync([Person, Pet], function () {
+        // Running in series because in-memory sqlite encounters problems
+        async.series([
+          Person.create.bind(Person, { name: "John Doe" }),
+          Person.create.bind(Person, { name: "Jane Doe" }),
+          Pet.create.bind(Pet, { name: "Deco"  }),
+          Pet.create.bind(Pet, { name: "Fido"  })
+        ], done);
+      });
+    };
+  };
 
-	before(function (done) {
-		helper.connect(function (connection) {
-			db = connection;
-			done();
-		});
-	});
+  before(function (done) {
+    helper.connect(function (connection) {
+      db = connection;
+      done();
+    });
+  });
 
-	describe("reverse", function () {
-		removeHookRun = false;
+  describe("reverse", function () {
+    removeHookRun = false;
 
-		before(setup({
-			hooks: {
-				beforeRemove: function () {
-					removeHookRun = true;
-				}
-			}
-		}));
+    before(setup({
+      hooks: {
+        beforeRemove: function () {
+          removeHookRun = true;
+        }
+      }
+    }));
 
-		it("should create methods in both models", function (done) {
-			var person = Person(1);
-			var pet = Pet(1);
+    it("should create methods in both models", function (done) {
+      var person = Person(1);
+      var pet = Pet(1);
 
-			person.getPet.should.be.a.Function();
-			person.setPet.should.be.a.Function();
-			person.removePet.should.be.a.Function();
-			person.hasPet.should.be.a.Function();
+      person.getPet.should.be.a.Function();
+      person.setPet.should.be.a.Function();
+      person.removePet.should.be.a.Function();
+      person.hasPet.should.be.a.Function();
 
-			pet.getOwners.should.be.a.Function();
-			pet.setOwners.should.be.a.Function();
-			pet.hasOwners.should.be.a.Function();
+      pet.getOwners.should.be.a.Function();
+      pet.setOwners.should.be.a.Function();
+      pet.hasOwners.should.be.a.Function();
 
-			return done();
-		});
+      return done();
+    });
 
-		describe(".getAccessor()", function () {
-			it("should work", function (done) {
-				Person.find({ name: "John Doe" }).first(function (err, John) {
-					Pet.find({ name: "Deco" }).first(function (err, Deco) {
-						Deco.hasOwners(function (err, has_owner) {
-							should.not.exist(err);
-							has_owner.should.be.false;
+    describe(".getAccessor()", function () {
+      it("should work", function (done) {
+        Person.find({ name: "John Doe" }).first(function (err, John) {
+          Pet.find({ name: "Deco" }).first(function (err, Deco) {
+            Deco.hasOwners(function (err, has_owner) {
+              should.not.exist(err);
+              has_owner.should.be.false;
 
-							Deco.setOwners(John, function (err) {
-								should.not.exist(err);
+              Deco.setOwners(John, function (err) {
+                should.not.exist(err);
 
-								Deco.getOwners(function (err, JohnCopy) {
-									should.not.exist(err);
-									should(Array.isArray(JohnCopy));
-									John.should.eql(JohnCopy[0]);
+                Deco.getOwners(function (err, JohnCopy) {
+                  should.not.exist(err);
+                  should(Array.isArray(JohnCopy));
+                  John.should.eql(JohnCopy[0]);
 
-									return done();
-								});
-							});
-						});
-					});
-				});
-			});
+                  return done();
+                });
+              });
+            });
+          });
+        });
+      });
 
-			describe("Chain", function () {
-				before(function (done) {
-					var petParams = [
-						{ name: "Hippo" },
-						{ name: "Finch", owners: [{ name: "Harold" }, { name: "Hagar" }] },
-						{ name: "Fox",   owners: [{ name: "Nelly"  }, { name: "Narnia" }] }
-					];
+      describe("Chain", function () {
+        before(function (done) {
+          var petParams = [
+            { name: "Hippo" },
+            { name: "Finch", owners: [{ name: "Harold" }, { name: "Hagar" }] },
+            { name: "Fox",   owners: [{ name: "Nelly"  }, { name: "Narnia" }] }
+          ];
 
-					Pet.create(petParams, function (err, pets) {
-						should.not.exist(err);
-						should.equal(pets.length, 3);
+          Pet.create(petParams, function (err, pets) {
+            should.not.exist(err);
+            should.equal(pets.length, 3);
 
-						Person.find({ name: ["Harold", "Hagar", "Nelly", "Narnia"] }, function (err, people) {
-							should.not.exist(err);
-							should.exist(people);
-							should.equal(people.length, 4);
+            Person.find({ name: ["Harold", "Hagar", "Nelly", "Narnia"] }, function (err, people) {
+              should.not.exist(err);
+              should.exist(people);
+              should.equal(people.length, 4);
 
-							done();
-						});
-					});
-				});
+              done();
+            });
+          });
+        });
 
-				it("should be returned if no callback is passed", function (done) {
-					Pet.one(function (err, pet) {
-						should.not.exist(err);
-						should.exist(pet);
+        it("should be returned if no callback is passed", function (done) {
+          Pet.one(function (err, pet) {
+            should.not.exist(err);
+            should.exist(pet);
 
-						var chain = pet.getOwners();
+            var chain = pet.getOwners();
 
-						should.equal(typeof chain,     'object');
-						should.equal(typeof chain.run, 'function');
+            should.equal(typeof chain,     'object');
+            should.equal(typeof chain.run, 'function');
 
-						done()
-					});
-				});
+            done()
+          });
+        });
 
-				it(".remove() should not call hooks", function (done) {
-					Pet.one({ name: "Finch" }, function (err, pet) {
-						should.not.exist(err);
-						should.exist(pet);
+        it(".remove() should not call hooks", function (done) {
+          Pet.one({ name: "Finch" }, function (err, pet) {
+            should.not.exist(err);
+            should.exist(pet);
 
-						should.equal(removeHookRun, false);
-						pet.getOwners().remove(function (err) {
-							should.not.exist(err);
-							should.equal(removeHookRun, false);
+            should.equal(removeHookRun, false);
+            pet.getOwners().remove(function (err) {
+              should.not.exist(err);
+              should.equal(removeHookRun, false);
 
-							Person.find({ name: "Harold" }, function (err, items) {
-								should.not.exist(err);
-								should.equal(items.length, 0);
-								done();
-							});
-						});
-					});
-				});
+              Person.find({ name: "Harold" }, function (err, items) {
+                should.not.exist(err);
+                should.equal(items.length, 0);
+                done();
+              });
+            });
+          });
+        });
 
-			});
-		});
+      });
+    });
 
-		it("should be able to set an array of people as the owner", function (done) {
-			Person.find({ name: ["John Doe", "Jane Doe"] }, function (err, owners) {
-				should.not.exist(err);
+    it("should be able to set an array of people as the owner", function (done) {
+      Person.find({ name: ["John Doe", "Jane Doe"] }, function (err, owners) {
+        should.not.exist(err);
 
-				Pet.find({ name: "Fido" }).first(function (err, Fido) {
-					should.not.exist(err);
+        Pet.find({ name: "Fido" }).first(function (err, Fido) {
+          should.not.exist(err);
 
-					Fido.hasOwners(function (err, has_owner) {
-						should.not.exist(err);
-						has_owner.should.be.false;
+          Fido.hasOwners(function (err, has_owner) {
+            should.not.exist(err);
+            has_owner.should.be.false;
 
-						Fido.setOwners(owners, function (err) {
-							should.not.exist(err);
+            Fido.setOwners(owners, function (err) {
+              should.not.exist(err);
 
-							Fido.getOwners(function (err, ownersCopy) {
-								should.not.exist(err);
-								should(Array.isArray(owners));
-								owners.length.should.equal(2);
+              Fido.getOwners(function (err, ownersCopy) {
+                should.not.exist(err);
+                should(Array.isArray(owners));
+                owners.length.should.equal(2);
 
-								// Don't know which order they'll be in.
-								var idProp = common.protocol() == 'mongodb' ? '_id' : 'id'
+                // Don't know which order they'll be in.
+                var idProp = common.protocol() == 'mongodb' ? '_id' : 'id'
 
-								if (owners[0][idProp] == ownersCopy[0][idProp]) {
-									owners[0].should.eql(ownersCopy[0]);
-									owners[1].should.eql(ownersCopy[1]);
-								} else {
-									owners[0].should.eql(ownersCopy[1]);
-									owners[1].should.eql(ownersCopy[0]);
-								}
+                if (owners[0][idProp] == ownersCopy[0][idProp]) {
+                  owners[0].should.eql(ownersCopy[0]);
+                  owners[1].should.eql(ownersCopy[1]);
+                } else {
+                  owners[0].should.eql(ownersCopy[1]);
+                  owners[1].should.eql(ownersCopy[0]);
+                }
 
-								return done();
-							});
-						});
-					});
-				});
-			});
-		});
+                return done();
+              });
+            });
+          });
+        });
+      });
+    });
 
-		// broken in mongo
-		if (common.protocol() != "mongodb") {
-			describe("findBy()", function () {
-				before(setup());
+    // broken in mongo
+    if (common.protocol() != "mongodb") {
+      describe("findBy()", function () {
+        before(setup());
 
-				before(function (done) {
-					Person.one({ name: "Jane Doe" }, function (err, jane) {
-						Pet.one({ name: "Deco" }, function (err, deco) {
-							deco.setOwners(jane, function (err) {
-								should.not.exist(err);
-								done();
-							});
-						});
-					});
-				});
+        before(function (done) {
+          Person.one({ name: "Jane Doe" }, function (err, jane) {
+            Pet.one({ name: "Deco" }, function (err, deco) {
+              deco.setOwners(jane, function (err) {
+                should.not.exist(err);
+                done();
+              });
+            });
+          });
+        });
 
-				it("should throw if no conditions passed", function (done) {
-					(function () {
-						Pet.findByOwners(function () {});
-					}).should.throw();
+        it("should throw if no conditions passed", function (done) {
+          (function () {
+            Pet.findByOwners(function () {});
+          }).should.throw();
 
-					return done();
-				});
+          return done();
+        });
 
-				it("should lookup reverse Model based on associated model properties", function (done) {
-					Pet.findByOwners({
-						name: "Jane Doe"
-					}, function (err, pets) {
-						should.not.exist(err);
-						should.equal(Array.isArray(pets), true);
+        it("should lookup reverse Model based on associated model properties", function (done) {
+          Pet.findByOwners({
+            name: "Jane Doe"
+          }, function (err, pets) {
+            should.not.exist(err);
+            should.equal(Array.isArray(pets), true);
 
-						// This often fails for sqlite on travis
-						if (common.isTravis() && common.protocol() != 'sqlite') {
-							should.equal(pets.length, 1);
-							should.equal(pets[0].name, 'Deco');
-						}
+            // This often fails for sqlite on travis
+            if (common.isTravis() && common.protocol() != 'sqlite') {
+              should.equal(pets.length, 1);
+              should.equal(pets[0].name, 'Deco');
+            }
 
-						return done();
-					});
-				});
+            return done();
+          });
+        });
 
-				it("should return a ChainFind if no callback passed", function (done) {
-					var ChainFind = Pet.findByOwners({
-						name: "John Doe"
-					});
-					ChainFind.run.should.be.a.Function();
+        it("should return a ChainFind if no callback passed", function (done) {
+          var ChainFind = Pet.findByOwners({
+            name: "John Doe"
+          });
+          ChainFind.run.should.be.a.Function();
 
-					return done();
-				});
-			});
-		}
-	});
+          return done();
+        });
+      });
+    }
+  });
 
-	describe("reverse find", function () {
-		it("should be able to find given an association id", function (done) {
-			common.retry(setup(), function (done) {
-				Person.find({ name: "John Doe" }).first(function (err, John) {
-					should.not.exist(err);
-					should.exist(John);
-					Pet.find({ name: "Deco" }).first(function (err, Deco) {
-						should.not.exist(err);
-						should.exist(Deco);
-						Deco.hasOwners(function (err, has_owner) {
-							should.not.exist(err);
-							has_owner.should.be.false;
+  describe("reverse find", function () {
+    it("should be able to find given an association id", function (done) {
+      common.retry(setup(), function (done) {
+        Person.find({ name: "John Doe" }).first(function (err, John) {
+          should.not.exist(err);
+          should.exist(John);
+          Pet.find({ name: "Deco" }).first(function (err, Deco) {
+            should.not.exist(err);
+            should.exist(Deco);
+            Deco.hasOwners(function (err, has_owner) {
+              should.not.exist(err);
+              has_owner.should.be.false;
 
-							Deco.setOwners(John, function (err) {
-								should.not.exist(err);
+              Deco.setOwners(John, function (err) {
+                should.not.exist(err);
 
-								Person.find({ pet_id: Deco[Pet.id[0]] }).first(function (err, owner) {
-									should.not.exist(err);
-									should.exist(owner);
-									should.equal(owner.name, John.name);
-									done();
-								});
+                Person.find({ pet_id: Deco[Pet.id[0]] }).first(function (err, owner) {
+                  should.not.exist(err);
+                  should.exist(owner);
+                  should.equal(owner.name, John.name);
+                  done();
+                });
 
-							});
-						});
-					});
-				});
-			}, 3, done);
-		});
+              });
+            });
+          });
+        });
+      }, 3, done);
+    });
 
-		it("should be able to find given an association instance", function (done) {
-			common.retry(setup(), function (done) {
-				Person.find({ name: "John Doe" }).first(function (err, John) {
-					should.not.exist(err);
-					should.exist(John);
-					Pet.find({ name: "Deco" }).first(function (err, Deco) {
-						should.not.exist(err);
-						should.exist(Deco);
-						Deco.hasOwners(function (err, has_owner) {
-							should.not.exist(err);
-							has_owner.should.be.false;
+    it("should be able to find given an association instance", function (done) {
+      common.retry(setup(), function (done) {
+        Person.find({ name: "John Doe" }).first(function (err, John) {
+          should.not.exist(err);
+          should.exist(John);
+          Pet.find({ name: "Deco" }).first(function (err, Deco) {
+            should.not.exist(err);
+            should.exist(Deco);
+            Deco.hasOwners(function (err, has_owner) {
+              should.not.exist(err);
+              has_owner.should.be.false;
 
-							Deco.setOwners(John, function (err) {
-								should.not.exist(err);
+              Deco.setOwners(John, function (err) {
+                should.not.exist(err);
 
-								Person.find({ pet: Deco }).first(function (err, owner) {
-									should.not.exist(err);
-									should.exist(owner);
-									should.equal(owner.name, John.name);
-									done();
-								});
+                Person.find({ pet: Deco }).first(function (err, owner) {
+                  should.not.exist(err);
+                  should.exist(owner);
+                  should.equal(owner.name, John.name);
+                  done();
+                });
 
-							});
-						});
-					});
-				});
-			}, 3, done);
-		});
+              });
+            });
+          });
+        });
+      }, 3, done);
+    });
 
-		it("should be able to find given a number of association instances with a single primary key", function (done) {
-			common.retry(setup(), function (done) {
-				Person.find({ name: "John Doe" }).first(function (err, John) {
-					should.not.exist(err);
-					should.exist(John);
-					Pet.all(function (err, pets) {
-						should.not.exist(err);
-						should.exist(pets);
-						should.equal(pets.length, 2);
+    it("should be able to find given a number of association instances with a single primary key", function (done) {
+      common.retry(setup(), function (done) {
+        Person.find({ name: "John Doe" }).first(function (err, John) {
+          should.not.exist(err);
+          should.exist(John);
+          Pet.all(function (err, pets) {
+            should.not.exist(err);
+            should.exist(pets);
+            should.equal(pets.length, 2);
 
-						pets[0].hasOwners(function (err, has_owner) {
-							should.not.exist(err);
-							has_owner.should.be.false;
+            pets[0].hasOwners(function (err, has_owner) {
+              should.not.exist(err);
+              has_owner.should.be.false;
 
-							pets[0].setOwners(John, function (err) {
-								should.not.exist(err);
+              pets[0].setOwners(John, function (err) {
+                should.not.exist(err);
 
-								Person.find({ pet: pets }, function (err, owners) {
-									should.not.exist(err);
-									should.exist(owners);
-									owners.length.should.equal(1);
+                Person.find({ pet: pets }, function (err, owners) {
+                  should.not.exist(err);
+                  should.exist(owners);
+                  owners.length.should.equal(1);
 
-									should.equal(owners[0].name, John.name);
-									done();
-								});
-							});
-						});
-					});
-				});
-			}, 3, done);
-		});
-	});
+                  should.equal(owners[0].name, John.name);
+                  done();
+                });
+              });
+            });
+          });
+        });
+      }, 3, done);
+    });
+  });
 });

--- a/test/integration/association-hasone-zeroid.js
+++ b/test/integration/association-hasone-zeroid.js
@@ -5,152 +5,152 @@ var helper = require('../support/spec_helper');
 var ORM    = require('../../');
 
 describe("hasOne", function() {
-	var db     = null;
-	var Person = null;
-	var Pet    = null;
+  var db     = null;
+  var Person = null;
+  var Pet    = null;
 
-	var setup = function (autoFetch) {
-		return function (done) {
-			db.settings.set('instance.identityCache', false);
-			db.settings.set('instance.returnAllErrors', true);
+  var setup = function (autoFetch) {
+    return function (done) {
+      db.settings.set('instance.identityCache', false);
+      db.settings.set('instance.returnAllErrors', true);
 
-			Person = db.define('person', {
-				id        : { type : "integer",  mapsTo: "personID", key: true },
-				firstName : { type : "text",     size:   "255" },
-				lastName  : { type : "text",     size:   "255" }
-			});
+      Person = db.define('person', {
+        id        : { type : "integer",  mapsTo: "personID", key: true },
+        firstName : { type : "text",     size:   "255" },
+        lastName  : { type : "text",     size:   "255" }
+      });
 
-			Pet = db.define('pet', {
-				id      : { type : "integer",  mapsTo: "petID", key: true },
-				petName : { type : "text",     size:   "255" },
-				ownerID : { type : "integer",  size:   "4" }
-			});
+      Pet = db.define('pet', {
+        id      : { type : "integer",  mapsTo: "petID", key: true },
+        petName : { type : "text",     size:   "255" },
+        ownerID : { type : "integer",  size:   "4" }
+      });
 
-			Pet.hasOne('owner', Person, { field: 'ownerID', autoFetch: autoFetch });
+      Pet.hasOne('owner', Person, { field: 'ownerID', autoFetch: autoFetch });
 
-			helper.dropSync([Person, Pet], function(err) {
-				if (err) return done(err);
+      helper.dropSync([Person, Pet], function(err) {
+        if (err) return done(err);
 
-				Pet.create([
-					{
-						id: 10,
-						petName: 'Muttley',
-						owner: {
-							id: 12,
-							firstName: 'Stuey',
-							lastName: 'McG'
-						}
-					},
-					{
-						id: 11,
-						petName: 'Snagglepuss',
-						owner: {
-							id: 0,
-							firstName: 'John',
-							lastName: 'Doe'
-						}
-					}
-				], done);
-			});
-		};
-	};
+        Pet.create([
+          {
+            id: 10,
+            petName: 'Muttley',
+            owner: {
+              id: 12,
+              firstName: 'Stuey',
+              lastName: 'McG'
+            }
+          },
+          {
+            id: 11,
+            petName: 'Snagglepuss',
+            owner: {
+              id: 0,
+              firstName: 'John',
+              lastName: 'Doe'
+            }
+          }
+        ], done);
+      });
+    };
+  };
 
-	before(function(done) {
-		helper.connect(function (connection) {
-			db = connection;
-			done();
-		});
-	});
+  before(function(done) {
+    helper.connect(function (connection) {
+      db = connection;
+      done();
+    });
+  });
 
-	describe("auto fetch", function () {
-		before(setup(true));
+  describe("auto fetch", function () {
+    before(setup(true));
 
-		it("should work for non-zero ownerID ", function (done) {
-			Pet.find({petName: "Muttley"}, function(err, pets) {
-				should.not.exist(err);
+    it("should work for non-zero ownerID ", function (done) {
+      Pet.find({petName: "Muttley"}, function(err, pets) {
+        should.not.exist(err);
 
-				pets[0].petName.should.equal("Muttley");
-				pets[0].should.have.property("id");
-				pets[0].id.should.equal(10);
-				pets[0].ownerID.should.equal(12);
+        pets[0].petName.should.equal("Muttley");
+        pets[0].should.have.property("id");
+        pets[0].id.should.equal(10);
+        pets[0].ownerID.should.equal(12);
 
-				pets[0].should.have.property("owner");
-				pets[0].owner.firstName.should.equal("Stuey");
+        pets[0].should.have.property("owner");
+        pets[0].owner.firstName.should.equal("Stuey");
 
-				return done();
-			});
-		});
+        return done();
+      });
+    });
 
-		it("should work for zero ownerID ", function (done) {
-			Pet.find({petName: "Snagglepuss"}, function(err, pets) {
-				should.not.exist(err);
+    it("should work for zero ownerID ", function (done) {
+      Pet.find({petName: "Snagglepuss"}, function(err, pets) {
+        should.not.exist(err);
 
-				pets[0].petName.should.equal("Snagglepuss");
-				pets[0].should.have.property("id");
-				pets[0].id.should.equal(11);
+        pets[0].petName.should.equal("Snagglepuss");
+        pets[0].should.have.property("id");
+        pets[0].id.should.equal(11);
 
-				db.models.person.all(function (err, people) {
-					return done();
-				});
-			});
-		});
-	});
+        db.models.person.all(function (err, people) {
+          return done();
+        });
+      });
+    });
+  });
 
-	describe("no auto fetch", function () {
-		before(setup(false));
+  describe("no auto fetch", function () {
+    before(setup(false));
 
-		it("should work for non-zero ownerID ", function (done) {
-			Pet.find({petName: "Muttley"}, function(err, pets) {
-				should.not.exist(err);
+    it("should work for non-zero ownerID ", function (done) {
+      Pet.find({petName: "Muttley"}, function(err, pets) {
+        should.not.exist(err);
 
-				pets[0].petName.should.equal("Muttley");
-				pets[0].should.have.property("id");
-				pets[0].id.should.equal(10);
-				pets[0].ownerID.should.equal(12);
+        pets[0].petName.should.equal("Muttley");
+        pets[0].should.have.property("id");
+        pets[0].id.should.equal(10);
+        pets[0].ownerID.should.equal(12);
 
-				pets[0].should.not.have.property("owner");
+        pets[0].should.not.have.property("owner");
 
-				// But we should be able to see if its there
-				pets[0].hasOwner(function(err, result) {
-					should.not.exist(err);
-					should.equal(result, true);
+        // But we should be able to see if its there
+        pets[0].hasOwner(function(err, result) {
+          should.not.exist(err);
+          should.equal(result, true);
 
-					// ...and then get it
-					pets[0].getOwner(function(err, result) {
-						should.not.exist(err);
-						result.firstName.should.equal("Stuey");
+          // ...and then get it
+          pets[0].getOwner(function(err, result) {
+            should.not.exist(err);
+            result.firstName.should.equal("Stuey");
 
-						return done()
-					});
-				});
-			});
-		});
+            return done()
+          });
+        });
+      });
+    });
 
-		it("should work for zero ownerID ", function (done) {
-			Pet.find({petName: "Snagglepuss"}, function(err, pets) {
-				should.not.exist(err);
+    it("should work for zero ownerID ", function (done) {
+      Pet.find({petName: "Snagglepuss"}, function(err, pets) {
+        should.not.exist(err);
 
-				pets[0].petName.should.equal("Snagglepuss");
-				pets[0].should.have.property("id");
-				pets[0].id.should.equal(11);
-				pets[0].ownerID.should.equal(0);
+        pets[0].petName.should.equal("Snagglepuss");
+        pets[0].should.have.property("id");
+        pets[0].id.should.equal(11);
+        pets[0].ownerID.should.equal(0);
 
-				pets[0].should.not.have.property("owner");
+        pets[0].should.not.have.property("owner");
 
-				// But we should be able to see if its there
-				pets[0].hasOwner(function(err, result) {
-					should.not.exist(err);
-					should.equal(result, true);
+        // But we should be able to see if its there
+        pets[0].hasOwner(function(err, result) {
+          should.not.exist(err);
+          should.equal(result, true);
 
-					// ...and then get it
-					pets[0].getOwner(function(err, result) {
-						should.not.exist(err);
-						result.firstName.should.equal("John");
+          // ...and then get it
+          pets[0].getOwner(function(err, result) {
+            should.not.exist(err);
+            result.firstName.should.equal("John");
 
-						return done()
-					});
-				});
-			});
-		});
-	});
+            return done()
+          });
+        });
+      });
+    });
+  });
 });

--- a/test/integration/association-hasone.js
+++ b/test/integration/association-hasone.js
@@ -7,465 +7,465 @@ var common   = require('../common');
 var protocol = common.protocol();
 
 describe("hasOne", function() {
-	var db    = null;
-	var Tree  = null;
-	var Stalk = null;
-	var Leaf  = null;
-	var leafId = null;
-	var treeId = null;
-	var stalkId = null;
-	var holeId  = null;
-
-	var setup = function (opts) {
-		opts = opts || {};
-		return function (done) {
-			db.settings.set('instance.identityCache', false);
-			db.settings.set('instance.returnAllErrors', true);
-			Tree  = db.define("tree",   { type:   { type: 'text'    } });
-			Stalk = db.define("stalk",  { length: { type: 'integer' } });
-			Hole  = db.define("hole",   { width:  { type: 'integer' } });
-			Leaf  = db.define("leaf", {
-				size:   { type: 'integer' },
-				holeId: { type: 'integer', mapsTo: 'hole_id' }
-			}, {
-				validations: opts.validations
-			});
-			Leaf.hasOne('tree',  Tree,  { field: 'treeId', autoFetch: !!opts.autoFetch });
-			Leaf.hasOne('stalk', Stalk, { field: 'stalkId', mapsTo: 'stalk_id' });
-			Leaf.hasOne('hole',  Hole,  { field: 'holeId' });
-
-			return helper.dropSync([Tree, Stalk, Hole, Leaf], function() {
-				Tree.create({ type: 'pine' }, function (err, tree) {
-					should.not.exist(err);
-					treeId = tree[Tree.id];
-					Leaf.create({ size: 14 }, function (err, leaf) {
-						should.not.exist(err);
-						leafId = leaf[Leaf.id];
-						leaf.setTree(tree, function (err) {
-							should.not.exist(err);
-							Stalk.create({ length: 20 }, function (err, stalk) {
-								should.not.exist(err);
-								should.exist(stalk);
-								stalkId = stalk[Stalk.id];
-								Hole.create({ width: 3 }, function (err, hole) {
-									should.not.exist(err);
-									holeId = hole.id;
-									done();
-								});
-							});
-						});
-					});
-				});
-			});
-		};
-	};
-
-	before(function(done) {
-		helper.connect(function (connection) {
-			db = connection;
-			done();
-		});
-	});
-
-	describe("accessors", function () {
-		before(setup());
-
-		it("get should get the association", function (done) {
-			Leaf.one({ size: 14 }, function (err, leaf) {
-				should.not.exist(err);
-				should.exist(leaf);
-				leaf.getTree(function (err, tree) {
-					should.not.exist(err);
-					should.exist(tree);
-					return done();
-				});
-			});
-		});
-
-		it("should return proper instance model", function (done) {
-			Leaf.one({ size: 14 }, function (err, leaf) {
-				leaf.getTree(function (err, tree) {
-					tree.model().should.equal(Tree);
-					return done();
-				});
-			});
-		});
-
-		it("get should get the association with a shell model", function (done) {
-			Leaf(leafId).getTree(function (err, tree) {
-				should.not.exist(err);
-				should.exist(tree);
-				should.equal(tree[Tree.id], treeId);
-				done();
-			});
-		});
-
-		it("has should indicate if there is an association present", function (done) {
-			Leaf.one({ size: 14 }, function (err, leaf) {
-				should.not.exist(err);
-				should.exist(leaf);
-
-				leaf.hasTree(function (err, has) {
-					should.not.exist(err);
-					should.equal(has, true);
-
-					leaf.hasStalk(function (err, has) {
-						should.not.exist(err);
-						should.equal(has, false);
-						return done();
-					});
-				});
-			});
-		});
-
-		it("set should associate another instance", function (done) {
-			Stalk.one({ length: 20 }, function (err, stalk) {
-				should.not.exist(err);
-				should.exist(stalk);
-				Leaf.one({ size: 14 }, function (err, leaf) {
-					should.not.exist(err);
-					should.exist(leaf);
-					should.not.exist(leaf.stalkId);
-					leaf.setStalk(stalk, function (err) {
-						should.not.exist(err);
-						Leaf.one({ size: 14 }, function (err, leaf) {
-							should.not.exist(err);
-							should.equal(leaf.stalkId, stalk[Stalk.id]);
-							done();
-						});
-					});
-				});
-			});
-		});
-
-		it("remove should unassociation another instance", function (done) {
-			Stalk.one({ length: 20 }, function (err, stalk) {
-				should.not.exist(err);
-				should.exist(stalk);
-				Leaf.one({ size: 14 }, function (err, leaf) {
-					should.not.exist(err);
-					should.exist(leaf);
-					should.exist(leaf.stalkId);
-					leaf.removeStalk(function (err) {
-						should.not.exist(err);
-						Leaf.one({ size: 14 }, function (err, leaf) {
-							should.not.exist(err);
-							should.equal(leaf.stalkId, null);
-							done();
-						});
-					});
-				});
-			});
-		});
-	});
-
-	[false, true].forEach(function (af) {
-		describe("with autofetch = " + af, function () {
-			before(setup({autoFetch: af}));
-
-			describe("autofetching", function() {
-				it((af ? "should" : "shouldn't") + " be done", function (done) {
-					Leaf.one({}, function (err, leaf) {
-						should.not.exist(err);
-						should.equal(typeof leaf.tree, af ? 'object' : 'undefined');
-
-						return done();
-					});
-				});
-			});
-
-			describe("associating by parent id", function () {
-				var tree = null;
-
-				before(function(done) {
-					Tree.create({type: "cyprus"},  function (err, item) {
-						should.not.exist(err);
-						tree = item;
-
-						return done();
-					});
-				});
-
-				it("should work when calling Instance.save", function (done) {
-					leaf = new Leaf({size: 4, treeId: tree[Tree.id]});
-					leaf.save(function(err, leaf) {
-						should.not.exist(err);
-
-						Leaf.get(leaf[Leaf.id], function(err, fetchedLeaf) {
-							should.not.exist(err);
-							should.exist(fetchedLeaf);
-							should.equal(fetchedLeaf.treeId, leaf.treeId);
-
-							return done();
-						});
-					});
-				});
-
-				it("should work when calling Instance.save after initially setting parentId to null", function(done) {
-					leaf = new Leaf({size: 4, treeId: null});
-					leaf.treeId = tree[Tree.id];
-					leaf.save(function(err, leaf) {
-						should.not.exist(err);
-
-						Leaf.get(leaf[Leaf.id], function(err, fetchedLeaf) {
-							should.not.exist(err);
-							should.exist(fetchedLeaf);
-							should.equal(fetchedLeaf.treeId, leaf.treeId);
-
-							return done();
-						});
-					});
-				});
-
-				it("should work when specifying parentId in the save call", function (done) {
-					leaf = new Leaf({size: 4});
-					leaf.save({ treeId: tree[Tree.id] }, function(err, leaf) {
-						should.not.exist(err);
-
-						should.exist(leaf.treeId);
-
-						Leaf.get(leaf[Leaf.id], function(err, fetchedLeaf) {
-							should.not.exist(err);
-							should.exist(fetchedLeaf);
-							should.equal(fetchedLeaf.treeId, leaf.treeId);
-
-							return done();
-						});
-					});
-				});
-
-				it("should work when calling Model.create", function (done) {
-					Leaf.create({size: 4, treeId: tree[Tree.id]}, function (err, leaf) {
-						should.not.exist(err);
-
-						Leaf.get(leaf[Leaf.id], function(err, fetchedLeaf) {
-							should.not.exist(err);
-
-							should.exist(fetchedLeaf);
-							should.equal(fetchedLeaf.treeId, leaf.treeId);
-
-							return done();
-						});
-					});
-				});
-
-				it("shouldn't cause an infinite loop when getting and saving with no changes", function (done) {
-					Leaf.get(leafId, function (err, leaf) {
-						should.not.exist(err);
-
-						leaf.save( function (err) {
-							should.not.exist(err);
-							done();
-						});
-					});
-				});
-
-				it("shouldn't cause an infinite loop when getting and saving with changes", function (done) {
-					Leaf.get(leafId, function (err, leaf) {
-						should.not.exist(err);
-
-						leaf.save({ size: 14 }, function (err) {
-							should.not.exist(err);
-							done();
-						});
-					});
-				});
-			});
-		});
-	});
-
-	describe("validations", function () {
-		before(setup({validations: { stalkId: ORM.validators.rangeNumber(undefined, 50) }}));
-
-		it("should allow validating parentId", function (done) {
-			Leaf.one({ size: 14 }, function (err, leaf) {
-				should.not.exist(err);
-				should.exist(leaf);
-
-				leaf.save({ stalkId: 51	}, function( err, item ) {
-					should(Array.isArray(err));
-					should.equal(err.length, 1);
-					should.equal(err[0].msg, 'out-of-range-number');
-
-					done();
-				});
-			});
-		});
-	});
-
-	describe("if not passing another Model", function () {
-		it("should use same model", function (done) {
-			db.settings.set('instance.identityCache', false);
-			db.settings.set('instance.returnAllErrors', true);
-
-			var Person = db.define("person", {
-				name : String
-			});
-			Person.hasOne("parent", {
-				autoFetch : true
-			});
-
-			helper.dropSync(Person, function () {
-				var child = new Person({
-					name : "Child"
-				});
-				child.setParent(new Person({ name: "Parent" }), function (err) {
-					should.equal(err, null);
-
-					return done();
-				});
-			});
-		});
-	});
-
-	describe("association name letter case", function () {
-		it("should be kept", function (done) {
-			db.settings.set('instance.identityCache', false);
-			db.settings.set('instance.returnAllErrors', true);
-
-			var Person = db.define("person", {
-				name : String
-			});
-			Person.hasOne("topParent", Person);
-
-			helper.dropSync(Person, function () {
-				Person.create({
-					name : "Child"
-				}, function (err, person) {
-					should.equal(err, null);
-
-					Person.get(person[Person.id], function (err, person) {
-						should.equal(err, null);
-
-						person.setTopParent.should.be.a.Function();
-						person.removeTopParent.should.be.a.Function();
-						person.hasTopParent.should.be.a.Function();
-
-						return done();
-					});
-				});
-			});
-		});
-	});
-
-	describe("findBy()", function () {
-		before(setup());
-
-		it("should throw if no conditions passed", function (done) {
-			(function () {
-				Leaf.findByTree(function () {});
-			}).should.throw();
-
-			return done();
-		});
-
-		it("should lookup in Model based on associated model properties", function (done) {
-			Leaf.findByTree({
-				type: "pine"
-			}, function (err, leafs) {
-				should.equal(err, null);
-				should(Array.isArray(leafs));
-				should(leafs.length == 1);
-
-				return done();
-			});
-		});
-
-		it("should return a ChainFind if no callback passed", function (done) {
-			var ChainFind = Leaf.findByTree({
-				type: "pine"
-			});
-			ChainFind.run.should.be.a.Function();
-
-			return done();
-		});
-	});
-
-	if (protocol != "mongodb") {
-		describe("mapsTo", function () {
-			describe("with `mapsTo` set via `hasOne`", function () {
-				var leaf = null;
-
-				before(setup());
-
-				before(function (done) {
-					Leaf.create({ size: 444, stalkId: stalkId, holeId: holeId }, function (err, lf) {
-						should.not.exist(err);
-						leaf = lf;
-						done();
-					});
-				});
-
-				it("should have correct fields in the DB", function (done) {
-					var sql = db.driver.query.select()
-					  .from('leaf')
-					  .select('size', 'stalk_id')
-					  .where({ size: 444 })
-					  .build();
-
-					db.driver.execQuery(sql, function (err, rows) {
-						should.not.exist(err);
-
-						should.equal(rows[0].size, 444);
-						should.equal(rows[0].stalk_id, 1);
-
-						done();
-		      });
-				});
-
-				it("should get parent", function (done) {
-					leaf.getStalk(function (err, stalk) {
-						should.not.exist(err);
-
-						should.exist(stalk);
-						should.equal(stalk.id, stalkId);
-						should.equal(stalk.length, 20);
-						done();
-					});
-				});
-			});
-
-			describe("with `mapsTo` set via property definition", function () {
-				var leaf = null;
-
-				before(setup());
-
-				before(function (done) {
-					Leaf.create({ size: 444, stalkId: stalkId, holeId: holeId }, function (err, lf) {
-						should.not.exist(err);
-						leaf = lf;
-						done();
-					});
-				});
-
-				it("should have correct fields in the DB", function (done) {
-					var sql = db.driver.query.select()
-					  .from('leaf')
-					  .select('size', 'hole_id')
-					  .where({ size: 444 })
-					  .build();
-
-					db.driver.execQuery(sql, function (err, rows) {
-						should.not.exist(err);
-
-						should.equal(rows[0].size, 444);
-						should.equal(rows[0].hole_id, 1);
-
-						done();
-		      });
-				});
-
-				it("should get parent", function (done) {
-					leaf.getHole(function (err, hole) {
-						should.not.exist(err);
-
-						should.exist(hole);
-						should.equal(hole.id, stalkId);
-						should.equal(hole.width, 3);
-						done();
-					});
-				});
-			});
-		});
-	};
+  var db    = null;
+  var Tree  = null;
+  var Stalk = null;
+  var Leaf  = null;
+  var leafId = null;
+  var treeId = null;
+  var stalkId = null;
+  var holeId  = null;
+
+  var setup = function (opts) {
+    opts = opts || {};
+    return function (done) {
+      db.settings.set('instance.identityCache', false);
+      db.settings.set('instance.returnAllErrors', true);
+      Tree  = db.define("tree",   { type:   { type: 'text'    } });
+      Stalk = db.define("stalk",  { length: { type: 'integer' } });
+      Hole  = db.define("hole",   { width:  { type: 'integer' } });
+      Leaf  = db.define("leaf", {
+        size:   { type: 'integer' },
+        holeId: { type: 'integer', mapsTo: 'hole_id' }
+      }, {
+        validations: opts.validations
+      });
+      Leaf.hasOne('tree',  Tree,  { field: 'treeId', autoFetch: !!opts.autoFetch });
+      Leaf.hasOne('stalk', Stalk, { field: 'stalkId', mapsTo: 'stalk_id' });
+      Leaf.hasOne('hole',  Hole,  { field: 'holeId' });
+
+      return helper.dropSync([Tree, Stalk, Hole, Leaf], function() {
+        Tree.create({ type: 'pine' }, function (err, tree) {
+          should.not.exist(err);
+          treeId = tree[Tree.id];
+          Leaf.create({ size: 14 }, function (err, leaf) {
+            should.not.exist(err);
+            leafId = leaf[Leaf.id];
+            leaf.setTree(tree, function (err) {
+              should.not.exist(err);
+              Stalk.create({ length: 20 }, function (err, stalk) {
+                should.not.exist(err);
+                should.exist(stalk);
+                stalkId = stalk[Stalk.id];
+                Hole.create({ width: 3 }, function (err, hole) {
+                  should.not.exist(err);
+                  holeId = hole.id;
+                  done();
+                });
+              });
+            });
+          });
+        });
+      });
+    };
+  };
+
+  before(function(done) {
+    helper.connect(function (connection) {
+      db = connection;
+      done();
+    });
+  });
+
+  describe("accessors", function () {
+    before(setup());
+
+    it("get should get the association", function (done) {
+      Leaf.one({ size: 14 }, function (err, leaf) {
+        should.not.exist(err);
+        should.exist(leaf);
+        leaf.getTree(function (err, tree) {
+          should.not.exist(err);
+          should.exist(tree);
+          return done();
+        });
+      });
+    });
+
+    it("should return proper instance model", function (done) {
+      Leaf.one({ size: 14 }, function (err, leaf) {
+        leaf.getTree(function (err, tree) {
+          tree.model().should.equal(Tree);
+          return done();
+        });
+      });
+    });
+
+    it("get should get the association with a shell model", function (done) {
+      Leaf(leafId).getTree(function (err, tree) {
+        should.not.exist(err);
+        should.exist(tree);
+        should.equal(tree[Tree.id], treeId);
+        done();
+      });
+    });
+
+    it("has should indicate if there is an association present", function (done) {
+      Leaf.one({ size: 14 }, function (err, leaf) {
+        should.not.exist(err);
+        should.exist(leaf);
+
+        leaf.hasTree(function (err, has) {
+          should.not.exist(err);
+          should.equal(has, true);
+
+          leaf.hasStalk(function (err, has) {
+            should.not.exist(err);
+            should.equal(has, false);
+            return done();
+          });
+        });
+      });
+    });
+
+    it("set should associate another instance", function (done) {
+      Stalk.one({ length: 20 }, function (err, stalk) {
+        should.not.exist(err);
+        should.exist(stalk);
+        Leaf.one({ size: 14 }, function (err, leaf) {
+          should.not.exist(err);
+          should.exist(leaf);
+          should.not.exist(leaf.stalkId);
+          leaf.setStalk(stalk, function (err) {
+            should.not.exist(err);
+            Leaf.one({ size: 14 }, function (err, leaf) {
+              should.not.exist(err);
+              should.equal(leaf.stalkId, stalk[Stalk.id]);
+              done();
+            });
+          });
+        });
+      });
+    });
+
+    it("remove should unassociation another instance", function (done) {
+      Stalk.one({ length: 20 }, function (err, stalk) {
+        should.not.exist(err);
+        should.exist(stalk);
+        Leaf.one({ size: 14 }, function (err, leaf) {
+          should.not.exist(err);
+          should.exist(leaf);
+          should.exist(leaf.stalkId);
+          leaf.removeStalk(function (err) {
+            should.not.exist(err);
+            Leaf.one({ size: 14 }, function (err, leaf) {
+              should.not.exist(err);
+              should.equal(leaf.stalkId, null);
+              done();
+            });
+          });
+        });
+      });
+    });
+  });
+
+  [false, true].forEach(function (af) {
+    describe("with autofetch = " + af, function () {
+      before(setup({autoFetch: af}));
+
+      describe("autofetching", function() {
+        it((af ? "should" : "shouldn't") + " be done", function (done) {
+          Leaf.one({}, function (err, leaf) {
+            should.not.exist(err);
+            should.equal(typeof leaf.tree, af ? 'object' : 'undefined');
+
+            return done();
+          });
+        });
+      });
+
+      describe("associating by parent id", function () {
+        var tree = null;
+
+        before(function(done) {
+          Tree.create({type: "cyprus"},  function (err, item) {
+            should.not.exist(err);
+            tree = item;
+
+            return done();
+          });
+        });
+
+        it("should work when calling Instance.save", function (done) {
+          leaf = new Leaf({size: 4, treeId: tree[Tree.id]});
+          leaf.save(function(err, leaf) {
+            should.not.exist(err);
+
+            Leaf.get(leaf[Leaf.id], function(err, fetchedLeaf) {
+              should.not.exist(err);
+              should.exist(fetchedLeaf);
+              should.equal(fetchedLeaf.treeId, leaf.treeId);
+
+              return done();
+            });
+          });
+        });
+
+        it("should work when calling Instance.save after initially setting parentId to null", function(done) {
+          leaf = new Leaf({size: 4, treeId: null});
+          leaf.treeId = tree[Tree.id];
+          leaf.save(function(err, leaf) {
+            should.not.exist(err);
+
+            Leaf.get(leaf[Leaf.id], function(err, fetchedLeaf) {
+              should.not.exist(err);
+              should.exist(fetchedLeaf);
+              should.equal(fetchedLeaf.treeId, leaf.treeId);
+
+              return done();
+            });
+          });
+        });
+
+        it("should work when specifying parentId in the save call", function (done) {
+          leaf = new Leaf({size: 4});
+          leaf.save({ treeId: tree[Tree.id] }, function(err, leaf) {
+            should.not.exist(err);
+
+            should.exist(leaf.treeId);
+
+            Leaf.get(leaf[Leaf.id], function(err, fetchedLeaf) {
+              should.not.exist(err);
+              should.exist(fetchedLeaf);
+              should.equal(fetchedLeaf.treeId, leaf.treeId);
+
+              return done();
+            });
+          });
+        });
+
+        it("should work when calling Model.create", function (done) {
+          Leaf.create({size: 4, treeId: tree[Tree.id]}, function (err, leaf) {
+            should.not.exist(err);
+
+            Leaf.get(leaf[Leaf.id], function(err, fetchedLeaf) {
+              should.not.exist(err);
+
+              should.exist(fetchedLeaf);
+              should.equal(fetchedLeaf.treeId, leaf.treeId);
+
+              return done();
+            });
+          });
+        });
+
+        it("shouldn't cause an infinite loop when getting and saving with no changes", function (done) {
+          Leaf.get(leafId, function (err, leaf) {
+            should.not.exist(err);
+
+            leaf.save( function (err) {
+              should.not.exist(err);
+              done();
+            });
+          });
+        });
+
+        it("shouldn't cause an infinite loop when getting and saving with changes", function (done) {
+          Leaf.get(leafId, function (err, leaf) {
+            should.not.exist(err);
+
+            leaf.save({ size: 14 }, function (err) {
+              should.not.exist(err);
+              done();
+            });
+          });
+        });
+      });
+    });
+  });
+
+  describe("validations", function () {
+    before(setup({validations: { stalkId: ORM.validators.rangeNumber(undefined, 50) }}));
+
+    it("should allow validating parentId", function (done) {
+      Leaf.one({ size: 14 }, function (err, leaf) {
+        should.not.exist(err);
+        should.exist(leaf);
+
+        leaf.save({ stalkId: 51  }, function( err, item ) {
+          should(Array.isArray(err));
+          should.equal(err.length, 1);
+          should.equal(err[0].msg, 'out-of-range-number');
+
+          done();
+        });
+      });
+    });
+  });
+
+  describe("if not passing another Model", function () {
+    it("should use same model", function (done) {
+      db.settings.set('instance.identityCache', false);
+      db.settings.set('instance.returnAllErrors', true);
+
+      var Person = db.define("person", {
+        name : String
+      });
+      Person.hasOne("parent", {
+        autoFetch : true
+      });
+
+      helper.dropSync(Person, function () {
+        var child = new Person({
+          name : "Child"
+        });
+        child.setParent(new Person({ name: "Parent" }), function (err) {
+          should.equal(err, null);
+
+          return done();
+        });
+      });
+    });
+  });
+
+  describe("association name letter case", function () {
+    it("should be kept", function (done) {
+      db.settings.set('instance.identityCache', false);
+      db.settings.set('instance.returnAllErrors', true);
+
+      var Person = db.define("person", {
+        name : String
+      });
+      Person.hasOne("topParent", Person);
+
+      helper.dropSync(Person, function () {
+        Person.create({
+          name : "Child"
+        }, function (err, person) {
+          should.equal(err, null);
+
+          Person.get(person[Person.id], function (err, person) {
+            should.equal(err, null);
+
+            person.setTopParent.should.be.a.Function();
+            person.removeTopParent.should.be.a.Function();
+            person.hasTopParent.should.be.a.Function();
+
+            return done();
+          });
+        });
+      });
+    });
+  });
+
+  describe("findBy()", function () {
+    before(setup());
+
+    it("should throw if no conditions passed", function (done) {
+      (function () {
+        Leaf.findByTree(function () {});
+      }).should.throw();
+
+      return done();
+    });
+
+    it("should lookup in Model based on associated model properties", function (done) {
+      Leaf.findByTree({
+        type: "pine"
+      }, function (err, leafs) {
+        should.equal(err, null);
+        should(Array.isArray(leafs));
+        should(leafs.length == 1);
+
+        return done();
+      });
+    });
+
+    it("should return a ChainFind if no callback passed", function (done) {
+      var ChainFind = Leaf.findByTree({
+        type: "pine"
+      });
+      ChainFind.run.should.be.a.Function();
+
+      return done();
+    });
+  });
+
+  if (protocol != "mongodb") {
+    describe("mapsTo", function () {
+      describe("with `mapsTo` set via `hasOne`", function () {
+        var leaf = null;
+
+        before(setup());
+
+        before(function (done) {
+          Leaf.create({ size: 444, stalkId: stalkId, holeId: holeId }, function (err, lf) {
+            should.not.exist(err);
+            leaf = lf;
+            done();
+          });
+        });
+
+        it("should have correct fields in the DB", function (done) {
+          var sql = db.driver.query.select()
+            .from('leaf')
+            .select('size', 'stalk_id')
+            .where({ size: 444 })
+            .build();
+
+          db.driver.execQuery(sql, function (err, rows) {
+            should.not.exist(err);
+
+            should.equal(rows[0].size, 444);
+            should.equal(rows[0].stalk_id, 1);
+
+            done();
+          });
+        });
+
+        it("should get parent", function (done) {
+          leaf.getStalk(function (err, stalk) {
+            should.not.exist(err);
+
+            should.exist(stalk);
+            should.equal(stalk.id, stalkId);
+            should.equal(stalk.length, 20);
+            done();
+          });
+        });
+      });
+
+      describe("with `mapsTo` set via property definition", function () {
+        var leaf = null;
+
+        before(setup());
+
+        before(function (done) {
+          Leaf.create({ size: 444, stalkId: stalkId, holeId: holeId }, function (err, lf) {
+            should.not.exist(err);
+            leaf = lf;
+            done();
+          });
+        });
+
+        it("should have correct fields in the DB", function (done) {
+          var sql = db.driver.query.select()
+            .from('leaf')
+            .select('size', 'hole_id')
+            .where({ size: 444 })
+            .build();
+
+          db.driver.execQuery(sql, function (err, rows) {
+            should.not.exist(err);
+
+            should.equal(rows[0].size, 444);
+            should.equal(rows[0].hole_id, 1);
+
+            done();
+          });
+        });
+
+        it("should get parent", function (done) {
+          leaf.getHole(function (err, hole) {
+            should.not.exist(err);
+
+            should.exist(hole);
+            should.equal(hole.id, stalkId);
+            should.equal(hole.width, 3);
+            done();
+          });
+        });
+      });
+    });
+  };
 });

--- a/test/integration/big.js
+++ b/test/integration/big.js
@@ -5,52 +5,52 @@ var ORM      = require('../../');
 var common   = require('../common');
 
 describe("Big data sets", function () {
-	var db = null;
-	var Like = null;
+  var db = null;
+  var Like = null;
 
-	before(function (done) {
-		helper.connect(function (connection) {
-			db = connection;
+  before(function (done) {
+    helper.connect(function (connection) {
+      db = connection;
 
-			return done();
-		});
-	});
+      return done();
+    });
+  });
 
-	after(function () {
-		return db.close();
-	});
+  after(function () {
+    return db.close();
+  });
 
-	// TODO: Fix
-	xdescribe("Chain.remove() with 50,000 records", function () {
-		this.timeout(60000);
+  // TODO: Fix
+  xdescribe("Chain.remove() with 50,000 records", function () {
+    this.timeout(60000);
 
-		before(function (done) {
-			Like = db.define("like", { t: { type: 'integer' } });
+    before(function (done) {
+      Like = db.define("like", { t: { type: 'integer' } });
 
-			helper.dropSync(Like, function (err) {
-				should.not.exist(err);
+      helper.dropSync(Like, function (err) {
+        should.not.exist(err);
 
-				async.times(5000, function (n, cb) {
-					db.driver.execQuery(
-						"INSERT INTO ?? (??) VALUES (?),(?),(?),(?),(?),(?),(?),(?),(?),(?)",
-						['like', 't', 1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
-						function (err) {
-							should.not.exist(err);
-							cb();
-						}
-					);
-				}, function (err) {
-					should.not.exist(err);
-					done()
-				});
-			});
-		});
+        async.times(5000, function (n, cb) {
+          db.driver.execQuery(
+            "INSERT INTO ?? (??) VALUES (?),(?),(?),(?),(?),(?),(?),(?),(?),(?)",
+            ['like', 't', 1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+            function (err) {
+              should.not.exist(err);
+              cb();
+            }
+          );
+        }, function (err) {
+          should.not.exist(err);
+          done()
+        });
+      });
+    });
 
-		it("should work", function (done) {
-			Like.find().remove(function (err) {
-				should.not.exist(err);
-				done();
-			});
-		});
-	});
+    it("should work", function (done) {
+      Like.find().remove(function (err) {
+        should.not.exist(err);
+        done();
+      });
+    });
+  });
 });

--- a/test/integration/db.js
+++ b/test/integration/db.js
@@ -4,290 +4,290 @@ var ORM    = require('../../');
 var common = require('../common');
 
 describe("db.use()", function () {
-	var db = null;
+  var db = null;
 
-	before(function (done) {
-		helper.connect(function (connection) {
-			db = connection;
+  before(function (done) {
+    helper.connect(function (connection) {
+      db = connection;
 
-			return done();
-		});
-	});
+      return done();
+    });
+  });
 
-	after(function () {
-		return db.close();
-	});
+  after(function () {
+    return db.close();
+  });
 
-	it("should be able to register a plugin", function (done) {
-		var MyPlugin = require("../support/my_plugin");
-		var opts     = {
-			option       : true,
-			calledDefine : false
-		};
+  it("should be able to register a plugin", function (done) {
+    var MyPlugin = require("../support/my_plugin");
+    var opts     = {
+      option       : true,
+      calledDefine : false
+    };
 
-		db.use(MyPlugin, opts);
+    db.use(MyPlugin, opts);
 
-		var MyModel = db.define("my_model", { // db.define should call plugin.define method
-			property: String
-		});
+    var MyModel = db.define("my_model", { // db.define should call plugin.define method
+      property: String
+    });
 
-		opts.calledDefine.should.be.true;
+    opts.calledDefine.should.be.true;
 
-		return done();
-	});
+    return done();
+  });
 
-	it("a plugin should be able to catch models before defining them", function (done) {
-		var MyPlugin = require("../support/my_plugin");
-		var opts     = {
-			option       : true,
-			calledDefine : false,
-			beforeDefine : function (name, props, opts) {
-				props.otherprop = Number;
-			}
-		};
+  it("a plugin should be able to catch models before defining them", function (done) {
+    var MyPlugin = require("../support/my_plugin");
+    var opts     = {
+      option       : true,
+      calledDefine : false,
+      beforeDefine : function (name, props, opts) {
+        props.otherprop = Number;
+      }
+    };
 
-		db.use(MyPlugin, opts);
+    db.use(MyPlugin, opts);
 
-		var MyModel = db.define("my_model", { // db.define should call plugin.define method
-			property: String
-		});
+    var MyModel = db.define("my_model", { // db.define should call plugin.define method
+      property: String
+    });
 
-		opts.calledDefine.should.be.true;
-		MyModel.properties.should.have.property("otherprop");
+    opts.calledDefine.should.be.true;
+    MyModel.properties.should.have.property("otherprop");
 
-		return done();
-	});
+    return done();
+  });
 
-	it("should be able to register a plugin as string", function (done) {
-		var opts     = {
-			option       : true,
-			calledDefine : false
-		};
+  it("should be able to register a plugin as string", function (done) {
+    var opts     = {
+      option       : true,
+      calledDefine : false
+    };
 
-		db.use("../support/my_plugin", opts);
+    db.use("../support/my_plugin", opts);
 
-		var MyModel = db.define("my_model", { // db.define should call plugin.define method
-			property: String
-		});
+    var MyModel = db.define("my_model", { // db.define should call plugin.define method
+      property: String
+    });
 
-		opts.calledDefine.should.be.true;
+    opts.calledDefine.should.be.true;
 
-		return done();
-	});
+    return done();
+  });
 });
 
 describe("db.define()", function() {
-	var db = null;
+  var db = null;
 
-	before(function (done) {
-		helper.connect(function (connection) {
-			db = connection;
+  before(function (done) {
+    helper.connect(function (connection) {
+      db = connection;
 
-			return done();
-		});
-	});
+      return done();
+    });
+  });
 
-	after(function () {
-		return db.close();
-	});
+  after(function () {
+    return db.close();
+  });
 
-	it("should use setting model.namePrefix as table prefix if defined", function (done) {
-		db.settings.set("model.namePrefix", "orm_");
+  it("should use setting model.namePrefix as table prefix if defined", function (done) {
+    db.settings.set("model.namePrefix", "orm_");
 
-		var Person = db.define("person", {
-			name: String
-		});
+    var Person = db.define("person", {
+      name: String
+    });
 
-		Person.table.should.equal("orm_person");
+    Person.table.should.equal("orm_person");
 
-		return done();
-	});
+    return done();
+  });
 });
 
 describe("db.load()", function () {
-	var db = null;
+  var db = null;
 
-	before(function (done) {
-		helper.connect(function (connection) {
-			db = connection;
+  before(function (done) {
+    helper.connect(function (connection) {
+      db = connection;
 
-			return done();
-		});
-	});
+      return done();
+    });
+  });
 
-	after(function () {
-		return db.close();
-	});
+  after(function () {
+    return db.close();
+  });
 
-	it("should require a file based on relative path", function (done) {
-		db.load("../support/spec_load", function () {
-			db.models.should.have.property("person");
-			db.models.should.have.property("pet");
+  it("should require a file based on relative path", function (done) {
+    db.load("../support/spec_load", function () {
+      db.models.should.have.property("person");
+      db.models.should.have.property("pet");
 
-			return done();
-		});
-	});
+      return done();
+    });
+  });
 });
 
 describe("db.load()", function () {
-	var db = null;
+  var db = null;
 
-	before(function (done) {
-		helper.connect(function (connection) {
-			db = connection;
+  before(function (done) {
+    helper.connect(function (connection) {
+      db = connection;
 
-			return done();
-		});
-	});
+      return done();
+    });
+  });
 
-	after(function () {
-		return db.close();
-	});
+  after(function () {
+    return db.close();
+  });
 
-	it("should be able to load more than one file", function (done) {
-		db.load("../support/spec_load_second", "../support/spec_load_third", function () {
-			db.models.should.have.property("person");
-			db.models.should.have.property("pet");
+  it("should be able to load more than one file", function (done) {
+    db.load("../support/spec_load_second", "../support/spec_load_third", function () {
+      db.models.should.have.property("person");
+      db.models.should.have.property("pet");
 
-			return done();
-		});
-	});
+      return done();
+    });
+  });
 });
 
 describe("db.load()", function () {
-	var db = null;
+  var db = null;
 
-	before(function (done) {
-		helper.connect(function (connection) {
-			db = connection;
+  before(function (done) {
+    helper.connect(function (connection) {
+      db = connection;
 
-			return done();
-		});
-	});
+      return done();
+    });
+  });
 
-	after(function () {
-		return db.close();
-	});
+  after(function () {
+    return db.close();
+  });
 
-	it("should be able to load more than one file passed as Array", function (done) {
-		db.load([ "../support/spec_load_second", "../support/spec_load_third" ], function () {
-			db.models.should.have.property("person");
-			db.models.should.have.property("pet");
+  it("should be able to load more than one file passed as Array", function (done) {
+    db.load([ "../support/spec_load_second", "../support/spec_load_third" ], function () {
+      db.models.should.have.property("person");
+      db.models.should.have.property("pet");
 
-			return done();
-		});
-	});
+      return done();
+    });
+  });
 });
 
 describe("db.serial()", function () {
-	var db = null;
+  var db = null;
 
-	before(function (done) {
-		helper.connect(function (connection) {
-			db = connection;
+  before(function (done) {
+    helper.connect(function (connection) {
+      db = connection;
 
-			return done();
-		});
-	});
+      return done();
+    });
+  });
 
-	after(function () {
-		return db.close();
-	});
+  after(function () {
+    return db.close();
+  });
 
-	it("should be able to execute chains in serial", function (done) {
-		var Person = db.define("person", {
-			name    : String,
-			surname : String
-		});
-		helper.dropSync(Person, function () {
-			Person.create([
-				{ name : "John", surname : "Doe" },
-				{ name : "Jane", surname : "Doe" }
-			], function () {
-				db.serial(
-					Person.find({ surname : "Doe" }),
-					Person.find({ name    : "John" })
-				).get(function (err, DoeFamily, JohnDoe) {
-					should.equal(err, null);
+  it("should be able to execute chains in serial", function (done) {
+    var Person = db.define("person", {
+      name    : String,
+      surname : String
+    });
+    helper.dropSync(Person, function () {
+      Person.create([
+        { name : "John", surname : "Doe" },
+        { name : "Jane", surname : "Doe" }
+      ], function () {
+        db.serial(
+          Person.find({ surname : "Doe" }),
+          Person.find({ name    : "John" })
+        ).get(function (err, DoeFamily, JohnDoe) {
+          should.equal(err, null);
 
-					should(Array.isArray(DoeFamily));
-					should(Array.isArray(JohnDoe));
+          should(Array.isArray(DoeFamily));
+          should(Array.isArray(JohnDoe));
 
-					DoeFamily.length.should.equal(2);
-					JohnDoe.length.should.equal(1);
+          DoeFamily.length.should.equal(2);
+          JohnDoe.length.should.equal(1);
 
-					DoeFamily[0].surname.should.equal("Doe");
-					DoeFamily[1].surname.should.equal("Doe");
+          DoeFamily[0].surname.should.equal("Doe");
+          DoeFamily[1].surname.should.equal("Doe");
 
-					JohnDoe[0].name.should.equal("John");
+          JohnDoe[0].name.should.equal("John");
 
-					return done();
-				});
-			});
-		});
-	});
+          return done();
+        });
+      });
+    });
+  });
 });
 
 describe("db.driver", function () {
-	var db = null;
+  var db = null;
 
-	before(function (done) {
-		helper.connect(function (connection) {
-			db = connection;
+  before(function (done) {
+    helper.connect(function (connection) {
+      db = connection;
 
-			var Log = db.define('log', {
-				what : { type: 'text' },
-				when : { type: 'date', time: true },
-				who  : { type: 'text' }
-			});
+      var Log = db.define('log', {
+        what : { type: 'text' },
+        when : { type: 'date', time: true },
+        who  : { type: 'text' }
+      });
 
-			helper.dropSync(Log, function (err) {
-				if (err) return done(err);
+      helper.dropSync(Log, function (err) {
+        if (err) return done(err);
 
-				Log.create([
-					{ what: "password reset", when: new Date('2013/04/07 12:33:05'), who: "jane" },
-					{ what: "user login",     when: new Date('2013/04/07 13:01:44'), who: "jane" },
-					{ what: "user logout",    when: new Date('2013/05/12 04:09:31'), who: "john" }
-				], done);
-			});
-		});
-	});
+        Log.create([
+          { what: "password reset", when: new Date('2013/04/07 12:33:05'), who: "jane" },
+          { what: "user login",     when: new Date('2013/04/07 13:01:44'), who: "jane" },
+          { what: "user logout",    when: new Date('2013/05/12 04:09:31'), who: "john" }
+        ], done);
+      });
+    });
+  });
 
-	after(function () {
-		return db.close();
-	});
+  after(function () {
+    return db.close();
+  });
 
-	it("should be available", function () {
-		should.exist(db.driver);
-	});
+  it("should be available", function () {
+    should.exist(db.driver);
+  });
 
-	if (common.protocol() == "mongodb") return;
+  if (common.protocol() == "mongodb") return;
 
-	describe("query", function () {
-		it("should be available", function () {
-			should.exist(db.driver.query);
-		});
+  describe("query", function () {
+    it("should be available", function () {
+      should.exist(db.driver.query);
+    });
 
-		describe("#execQuery", function () {
-			it("should execute sql queries", function (done) {
-				db.driver.execQuery("SELECT id FROM log", function (err, data) {
-					should.not.exist(err);
+    describe("#execQuery", function () {
+      it("should execute sql queries", function (done) {
+        db.driver.execQuery("SELECT id FROM log", function (err, data) {
+          should.not.exist(err);
 
-					should(JSON.stringify(data) == JSON.stringify([{ id: 1 }, { id: 2 }, { id: 3 }]));
-					done();
-				});
-			});
+          should(JSON.stringify(data) == JSON.stringify([{ id: 1 }, { id: 2 }, { id: 3 }]));
+          done();
+        });
+      });
 
-			it("should escape sql queries", function (done) {
-				var query = "SELECT log.?? FROM log WHERE log.?? LIKE ? AND log.?? > ?";
-				var args  = ['what', 'who', 'jane', 'when', new Date('2013/04/07 12:40:00')];
-				db.driver.execQuery(query, args, function (err, data) {
-					should.not.exist(err);
+      it("should escape sql queries", function (done) {
+        var query = "SELECT log.?? FROM log WHERE log.?? LIKE ? AND log.?? > ?";
+        var args  = ['what', 'who', 'jane', 'when', new Date('2013/04/07 12:40:00')];
+        db.driver.execQuery(query, args, function (err, data) {
+          should.not.exist(err);
 
-					should(JSON.stringify(data) == JSON.stringify([{ "what": "user login" }]));
-					done();
-				});
-			});
-		});
-	});
+          should(JSON.stringify(data) == JSON.stringify([{ "what": "user login" }]));
+          done();
+        });
+      });
+    });
+  });
 });

--- a/test/integration/drivers/postgres_spec.js
+++ b/test/integration/drivers/postgres_spec.js
@@ -7,221 +7,221 @@ var common = require('../../common');
 if (common.protocol() != "postgres") return;
 
 describe("Postgres driver", function() {
-	describe("#valueToProperty", function () {
-		var driver = null;
+  describe("#valueToProperty", function () {
+    var driver = null;
 
-		beforeEach(function () {
-			driver = new Driver({}, {}, {});
-		});
+    beforeEach(function () {
+      driver = new Driver({}, {}, {});
+    });
 
-		describe("numbers", function () {
-			describe("floats", function () {
-				function valueToProperty (value) {
-					return driver.valueToProperty(value, { type: 'number' });
-				}
+    describe("numbers", function () {
+      describe("floats", function () {
+        function valueToProperty (value) {
+          return driver.valueToProperty(value, { type: 'number' });
+        }
 
-				it("should pass on empty string", function () {
-					should.strictEqual(valueToProperty(''), '');
-				});
+        it("should pass on empty string", function () {
+          should.strictEqual(valueToProperty(''), '');
+        });
 
-				it("should pass on text", function () {
-					should.strictEqual(valueToProperty('fff'), 'fff');
-				});
+        it("should pass on text", function () {
+          should.strictEqual(valueToProperty('fff'), 'fff');
+        });
 
-				it("should pass on numbers", function () {
-					should.strictEqual(valueToProperty(1.2), 1.2);
-				});
+        it("should pass on numbers", function () {
+          should.strictEqual(valueToProperty(1.2), 1.2);
+        });
 
-				it("should parse numbers in strings", function () {
-					should.strictEqual(valueToProperty('1.2'), 1.2);
-					should.strictEqual(valueToProperty('1.200 '), 1.2);
-				});
+        it("should parse numbers in strings", function () {
+          should.strictEqual(valueToProperty('1.2'), 1.2);
+          should.strictEqual(valueToProperty('1.200 '), 1.2);
+        });
 
-				it("should support non finite numbers", function () {
-					should.strictEqual(valueToProperty( 'Infinity'),  Infinity);
-					should.strictEqual(valueToProperty('-Infinity'), -Infinity);
-					should.strictEqual(isNaN(valueToProperty('NaN')), true);
-				});
-			});
+        it("should support non finite numbers", function () {
+          should.strictEqual(valueToProperty( 'Infinity'),  Infinity);
+          should.strictEqual(valueToProperty('-Infinity'), -Infinity);
+          should.strictEqual(isNaN(valueToProperty('NaN')), true);
+        });
+      });
 
-			describe("integers", function () {
-				function valueToProperty (value) {
-					return driver.valueToProperty(value, { type: 'integer' });
-				}
+      describe("integers", function () {
+        function valueToProperty (value) {
+          return driver.valueToProperty(value, { type: 'integer' });
+        }
 
-				it("should pass on empty string", function () {
-					should.strictEqual(valueToProperty(''), '');
-				});
+        it("should pass on empty string", function () {
+          should.strictEqual(valueToProperty(''), '');
+        });
 
-				it("should pass on text", function () {
-					should.strictEqual(valueToProperty('fff'), 'fff');
-				});
+        it("should pass on text", function () {
+          should.strictEqual(valueToProperty('fff'), 'fff');
+        });
 
-				it("should pass on non finite numbers as text", function () {
-					should.strictEqual(valueToProperty( 'Infinity'),  'Infinity');
-					should.strictEqual(valueToProperty('-Infinity'), '-Infinity');
-					should.strictEqual(valueToProperty('NaN'), 'NaN');
-				});
+        it("should pass on non finite numbers as text", function () {
+          should.strictEqual(valueToProperty( 'Infinity'),  'Infinity');
+          should.strictEqual(valueToProperty('-Infinity'), '-Infinity');
+          should.strictEqual(valueToProperty('NaN'), 'NaN');
+        });
 
-				it("should pass on numbers", function () {
-					should.strictEqual(valueToProperty(1.2), 1.2);
-				});
+        it("should pass on numbers", function () {
+          should.strictEqual(valueToProperty(1.2), 1.2);
+        });
 
-				it("should parse integers in strings", function () {
-					should.strictEqual(valueToProperty('1.2'), 1);
-					should.strictEqual(valueToProperty('1.200 '), 1);
-				});
-			});
+        it("should parse integers in strings", function () {
+          should.strictEqual(valueToProperty('1.2'), 1);
+          should.strictEqual(valueToProperty('1.200 '), 1);
+        });
+      });
 
-			describe("dates with non local timezone", function () {
-				beforeEach(function () {
-					driver = new Driver({ timezone: 'Z' }, {}, {});
-				});
+      describe("dates with non local timezone", function () {
+        beforeEach(function () {
+          driver = new Driver({ timezone: 'Z' }, {}, {});
+        });
 
-				function valueToProperty (value) {
-					return driver.valueToProperty(value, { type: 'date' });
-				}
+        function valueToProperty (value) {
+          return driver.valueToProperty(value, { type: 'date' });
+        }
 
-				it("should accept null", function () {
-					should.strictEqual(valueToProperty(null), null);
-				});
+        it("should accept null", function () {
+          should.strictEqual(valueToProperty(null), null);
+        });
 
-				it("should work", function () {
-					should.strictEqual(_.isDate(valueToProperty(new Date())), true);
-				});
+        it("should work", function () {
+          should.strictEqual(_.isDate(valueToProperty(new Date())), true);
+        });
 
-				describe("calculations", function () {
-					it("should offset time, relative to timezone", function () {
-						d = new Date();
+        describe("calculations", function () {
+          it("should offset time, relative to timezone", function () {
+            d = new Date();
 
-						expected  = d.getTime() - d.getTimezoneOffset() * 60000;
-						converted = valueToProperty(d).getTime();
+            expected  = d.getTime() - d.getTimezoneOffset() * 60000;
+            converted = valueToProperty(d).getTime();
 
-						should.equal(converted, expected);
-					});
-				});
-			});
-		});
-	});
+            should.equal(converted, expected);
+          });
+        });
+      });
+    });
+  });
 
-	describe("#propertyToValue", function () {
-		describe("type object", function () {
-			function evaluate (input) {
-				var driver = new Driver({}, {}, {});
-				return driver.propertyToValue(input, { type: 'object' });
-			}
+  describe("#propertyToValue", function () {
+    describe("type object", function () {
+      function evaluate (input) {
+        var driver = new Driver({}, {}, {});
+        return driver.propertyToValue(input, { type: 'object' });
+      }
 
-			it("should not change null", function () {
-				should.strictEqual(evaluate(null), null);
-			});
+      it("should not change null", function () {
+        should.strictEqual(evaluate(null), null);
+      });
 
-			it("should not change buffer", function () {
-				var b = new Buffer('abc');
-				should.strictEqual(evaluate(b), b);
-			});
+      it("should not change buffer", function () {
+        var b = new Buffer('abc');
+        should.strictEqual(evaluate(b), b);
+      });
 
-			it("should encode everything else as a Buffer", function () {
-				var input = { abc: 123 };
-				var out = evaluate(input);
+      it("should encode everything else as a Buffer", function () {
+        var input = { abc: 123 };
+        var out = evaluate(input);
 
-				should(out instanceof Buffer);
-				should.equal(JSON.stringify(input), out.toString());
-			});
-		});
+        should(out instanceof Buffer);
+        should.equal(JSON.stringify(input), out.toString());
+      });
+    });
 
-		describe("date", function () {
-			function evaluate (input, opts) {
-				if (!opts) opts = {};
-				var driver = new Driver(opts.config, {}, {});
-				return driver.propertyToValue(input, { type: 'date' });
-			}
+    describe("date", function () {
+      function evaluate (input, opts) {
+        if (!opts) opts = {};
+        var driver = new Driver(opts.config, {}, {});
+        return driver.propertyToValue(input, { type: 'date' });
+      }
 
-			it("should do nothing when timezone isn't configured", function () {
-				var input = new Date();
-				var inputStr = input.toString();
-				var out = evaluate(input);
+      it("should do nothing when timezone isn't configured", function () {
+        var input = new Date();
+        var inputStr = input.toString();
+        var out = evaluate(input);
 
-				should.strictEqual(input, out);
-				should.equal(inputStr, out.toString());
-			});
+        should.strictEqual(input, out);
+        should.equal(inputStr, out.toString());
+      });
 
-			it("should work with null dates", function () {
-				should.strictEqual(evaluate(null, { config: { timezone: 'Z' }}), null);
-			});
+      it("should work with null dates", function () {
+        should.strictEqual(evaluate(null, { config: { timezone: 'Z' }}), null);
+      });
 
-			it("should work with date objects", function () {
-				should.strictEqual(_.isDate(evaluate(new Date(), { config: { timezone: 'Z' }})), true);
-			});
+      it("should work with date objects", function () {
+        should.strictEqual(_.isDate(evaluate(new Date(), { config: { timezone: 'Z' }})), true);
+      });
 
-			describe("calculations", function () {
-				it("should offset time, relative to timezone", function () {
-					d = new Date();
+      describe("calculations", function () {
+        it("should offset time, relative to timezone", function () {
+          d = new Date();
 
-					expected = d.getTime() + d.getTimezoneOffset() * 60000;
-					converted = evaluate(d, { config: { timezone: 'Z' }}).getTime();
+          expected = d.getTime() + d.getTimezoneOffset() * 60000;
+          converted = evaluate(d, { config: { timezone: 'Z' }}).getTime();
 
-					should.equal(converted, expected);
-				});
-			});
-		});
+          should.equal(converted, expected);
+        });
+      });
+    });
 
-		describe("type point", function () {
-			function evaluate (input) {
-				var driver = new Driver({}, {}, {});
-				return driver.propertyToValue(input, { type: 'point' });
-			}
+    describe("type point", function () {
+      function evaluate (input) {
+        var driver = new Driver({}, {}, {});
+        return driver.propertyToValue(input, { type: 'point' });
+      }
 
-			it("should encode correctly", function () {
-				var out = evaluate({ x: 5, y: 7 });
+      it("should encode correctly", function () {
+        var out = evaluate({ x: 5, y: 7 });
 
-				should(out instanceof Function);
-				should.equal(out(), "POINT(5, 7)");
-			});
-		});
+        should(out instanceof Function);
+        should.equal(out(), "POINT(5, 7)");
+      });
+    });
 
-		describe("custom type", function () {
-			var customType = {
-				propertyToValue: function (input) {
-					return input + ' QWERTY';
-				}
-			};
+    describe("custom type", function () {
+      var customType = {
+        propertyToValue: function (input) {
+          return input + ' QWERTY';
+        }
+      };
 
-			function evaluate (input, customTypes) {
-				var driver = new Driver({}, {}, {});
-				if (customType) {
-					for (var k in customTypes) {
-						driver.customTypes[k] = customTypes[k];
-					}
-				}
-				return driver.propertyToValue(input, { type: 'qwerty' });
-			}
+      function evaluate (input, customTypes) {
+        var driver = new Driver({}, {}, {});
+        if (customType) {
+          for (var k in customTypes) {
+            driver.customTypes[k] = customTypes[k];
+          }
+        }
+        return driver.propertyToValue(input, { type: 'qwerty' });
+      }
 
-			it("should do custom type conversion if provided", function () {
-				var opts = { qwerty: customType };
-				var out = evaluate('f', opts);
+      it("should do custom type conversion if provided", function () {
+        var opts = { qwerty: customType };
+        var out = evaluate('f', opts);
 
-				should.equal(out, 'f QWERTY');
-			});
+        should.equal(out, 'f QWERTY');
+      });
 
-			it("should not do custom type conversion if not provided", function () {
-				var opts = { qwerty: {} };
-				var out = evaluate('f', opts);
+      it("should not do custom type conversion if not provided", function () {
+        var opts = { qwerty: {} };
+        var out = evaluate('f', opts);
 
-				should.equal(out, 'f');
-			});
-		});
+        should.equal(out, 'f');
+      });
+    });
 
-		it("should do nothing for other types", function () {
-			function evaluate (input, type) {
-				var driver = new Driver({}, {}, {});
-				return driver.propertyToValue(input, { type: type });
-			}
+    it("should do nothing for other types", function () {
+      function evaluate (input, type) {
+        var driver = new Driver({}, {}, {});
+        return driver.propertyToValue(input, { type: type });
+      }
 
-			should.strictEqual(evaluate('abc', { type: 'string' }), 'abc');
-			should.strictEqual(evaluate(42, { type: 'number' }), 42);
-			should.strictEqual(evaluate(undefined, { type: 'bleh' }), undefined);
-		});
+      should.strictEqual(evaluate('abc', { type: 'string' }), 'abc');
+      should.strictEqual(evaluate(42, { type: 'number' }), 42);
+      should.strictEqual(evaluate(undefined, { type: 'bleh' }), undefined);
+    });
 
-	});
+  });
 
 });

--- a/test/integration/drivers/sqlite_spec.js
+++ b/test/integration/drivers/sqlite_spec.js
@@ -7,132 +7,132 @@ var common = require('../../common');
 if (common.protocol() != "sqlite") return;
 
 describe("Sqlite driver", function() {
-	describe("#valueToProperty", function () {
-		var driver = null;
+  describe("#valueToProperty", function () {
+    var driver = null;
 
-		before(function () {
-			driver = new Driver({}, {}, {});
-		});
+    before(function () {
+      driver = new Driver({}, {}, {});
+    });
 
-		describe("numbers", function () {
-			describe("floats", function () {
-				function valueToProperty (value) {
-					return driver.valueToProperty(value, { type: 'number' });
-				}
+    describe("numbers", function () {
+      describe("floats", function () {
+        function valueToProperty (value) {
+          return driver.valueToProperty(value, { type: 'number' });
+        }
 
-				it("should pass on empty string", function () {
-					should.strictEqual(valueToProperty(''), '');
-				});
+        it("should pass on empty string", function () {
+          should.strictEqual(valueToProperty(''), '');
+        });
 
-				it("should pass on text", function () {
-					should.strictEqual(valueToProperty('fff'), 'fff');
-				});
+        it("should pass on text", function () {
+          should.strictEqual(valueToProperty('fff'), 'fff');
+        });
 
-				it("should pass on numbers", function () {
-					should.strictEqual(valueToProperty(1.2), 1.2);
-				});
+        it("should pass on numbers", function () {
+          should.strictEqual(valueToProperty(1.2), 1.2);
+        });
 
-				it("should parse numbers in strings", function () {
-					should.strictEqual(valueToProperty('1.2'), 1.2);
-					should.strictEqual(valueToProperty('1.200 '), 1.2);
-				});
+        it("should parse numbers in strings", function () {
+          should.strictEqual(valueToProperty('1.2'), 1.2);
+          should.strictEqual(valueToProperty('1.200 '), 1.2);
+        });
 
-				it("should support non finite numbers", function () {
-					should.strictEqual(valueToProperty( 'Infinity'),  Infinity);
-					should.strictEqual(valueToProperty('-Infinity'), -Infinity);
-					should.strictEqual(isNaN(valueToProperty('NaN')), true);
-				});
-			});
+        it("should support non finite numbers", function () {
+          should.strictEqual(valueToProperty( 'Infinity'),  Infinity);
+          should.strictEqual(valueToProperty('-Infinity'), -Infinity);
+          should.strictEqual(isNaN(valueToProperty('NaN')), true);
+        });
+      });
 
-			describe("integers", function () {
-				function valueToProperty (value) {
-					return driver.valueToProperty(value, { type: 'integer' });
-				}
+      describe("integers", function () {
+        function valueToProperty (value) {
+          return driver.valueToProperty(value, { type: 'integer' });
+        }
 
-				it("should pass on empty string", function () {
-					should.strictEqual(valueToProperty(''), '');
-				});
+        it("should pass on empty string", function () {
+          should.strictEqual(valueToProperty(''), '');
+        });
 
-				it("should pass on text", function () {
-					should.strictEqual(valueToProperty('fff'), 'fff');
-				});
+        it("should pass on text", function () {
+          should.strictEqual(valueToProperty('fff'), 'fff');
+        });
 
-				it("should pass on non finite numbers as text", function () {
-					should.strictEqual(valueToProperty( 'Infinity'),  'Infinity');
-					should.strictEqual(valueToProperty('-Infinity'), '-Infinity');
-					should.strictEqual(valueToProperty('NaN'), 'NaN');
-				});
+        it("should pass on non finite numbers as text", function () {
+          should.strictEqual(valueToProperty( 'Infinity'),  'Infinity');
+          should.strictEqual(valueToProperty('-Infinity'), '-Infinity');
+          should.strictEqual(valueToProperty('NaN'), 'NaN');
+        });
 
-				it("should pass on numbers", function () {
-					should.strictEqual(valueToProperty(1.2), 1.2);
-				});
+        it("should pass on numbers", function () {
+          should.strictEqual(valueToProperty(1.2), 1.2);
+        });
 
-				it("should parse integers in strings", function () {
-					should.strictEqual(valueToProperty('1.2'), 1);
-					should.strictEqual(valueToProperty('1.200 '), 1);
-				});
-			});
-		});
-	});
+        it("should parse integers in strings", function () {
+          should.strictEqual(valueToProperty('1.2'), 1);
+          should.strictEqual(valueToProperty('1.200 '), 1);
+        });
+      });
+    });
+  });
 
-	describe("db", function () {
-		var db = null;
-		var Person = null;
+  describe("db", function () {
+    var db = null;
+    var Person = null;
 
-		before(function (done) {
-			helper.connect(function (connection) {
-				db = connection;
+    before(function (done) {
+      helper.connect(function (connection) {
+        db = connection;
 
-				Person = db.define("person", {
-					name: String
-				});
+        Person = db.define("person", {
+          name: String
+        });
 
-				return helper.dropSync([ Person ], done);
-			});
-		});
+        return helper.dropSync([ Person ], done);
+      });
+    });
 
-		after(function () {
-			return db.close();
-		});
+    after(function () {
+      return db.close();
+    });
 
-		describe("#clear", function () {
-			beforeEach(function (done) {
-				Person.create([{ name: 'John' }, { name: 'Jane' }], function (err) {
-					Person.count(function (err, count) {
-						should.not.exist(err);
-						should.equal(count, 2);
-						done();
-					});
-				});
-			});
+    describe("#clear", function () {
+      beforeEach(function (done) {
+        Person.create([{ name: 'John' }, { name: 'Jane' }], function (err) {
+          Person.count(function (err, count) {
+            should.not.exist(err);
+            should.equal(count, 2);
+            done();
+          });
+        });
+      });
 
-			it("should drop all items", function (done) {
-				Person.clear(function (err) {
-					should.not.exist(err);
+      it("should drop all items", function (done) {
+        Person.clear(function (err) {
+          should.not.exist(err);
 
-					Person.count(function (err, count) {
-						should.not.exist(err);
-						should.equal(count, 0);
-						done();
-					});
-				});
-			});
+          Person.count(function (err, count) {
+            should.not.exist(err);
+            should.equal(count, 0);
+            done();
+          });
+        });
+      });
 
-			it("should reset id sequence", function (done) {
-				Person.clear(function (err) {
-					should.not.exist(err);
-					db.driver.execQuery("SELECT * FROM ?? WHERE ?? = ?", ['sqlite_sequence', 'name', Person.table], function (err, data) {
-						should.not.exist(err);
+      it("should reset id sequence", function (done) {
+        Person.clear(function (err) {
+          should.not.exist(err);
+          db.driver.execQuery("SELECT * FROM ?? WHERE ?? = ?", ['sqlite_sequence', 'name', Person.table], function (err, data) {
+            should.not.exist(err);
 
-						Person.create({ name: 'Bob' }, function (err, person) {
-							should.not.exist(err);
-							should.equal(person.id, 1);
+            Person.create({ name: 'Bob' }, function (err, person) {
+              should.not.exist(err);
+              should.equal(person.id, 1);
 
-							done();
-						});
-					});
-				});
-			});
-		});
-	});
+              done();
+            });
+          });
+        });
+      });
+    });
+  });
 });

--- a/test/integration/error_spec.js
+++ b/test/integration/error_spec.js
@@ -3,58 +3,58 @@ var ORMError = require('../../lib/Error');
 var path     = require('path');
 
 describe("Error", function () {
-	describe("constructor", function () {
-		it("should inherit from native Error", function () {
-			var e = new ORMError("Test message", 'PARAM_MISMATCH');
-			should(e instanceof Error);
-		});
+  describe("constructor", function () {
+    it("should inherit from native Error", function () {
+      var e = new ORMError("Test message", 'PARAM_MISMATCH');
+      should(e instanceof Error);
+    });
 
-		it("should have a valid stack", function () {
-			try {
-				throw new ORMError("Test message", 'PARAM_MISMATCH');
-			} catch (e) {
-				var stackArr = e.stack.split('\n');
-				// [0] is ''
-				should(stackArr[1].indexOf(path.join('test', 'integration', 'error_spec.js')) > 0);
-			}
-		});
+    it("should have a valid stack", function () {
+      try {
+        throw new ORMError("Test message", 'PARAM_MISMATCH');
+      } catch (e) {
+        var stackArr = e.stack.split('\n');
+        // [0] is ''
+        should(stackArr[1].indexOf(path.join('test', 'integration', 'error_spec.js')) > 0);
+      }
+    });
 
-		it("should have the right name", function () {
-			var e = new ORMError("Test message", 'PARAM_MISMATCH');
-			should.equal(e.name, 'ORMError');
-		});
+    it("should have the right name", function () {
+      var e = new ORMError("Test message", 'PARAM_MISMATCH');
+      should.equal(e.name, 'ORMError');
+    });
 
-		it("should throw on invalid code", function () {
-			(function () {
-				var e = new ORMError("Test message", 'FLYING_SQUIRRELS');
-			}).should.throw("Invalid error code: FLYING_SQUIRRELS");
-		});
+    it("should throw on invalid code", function () {
+      (function () {
+        var e = new ORMError("Test message", 'FLYING_SQUIRRELS');
+      }).should.throw("Invalid error code: FLYING_SQUIRRELS");
+    });
 
-		it("should assign the code", function () {
-			var e = new ORMError("Test message", 'PARAM_MISMATCH');
-			should.equal(e.code, 6);
-		});
+    it("should assign the code", function () {
+      var e = new ORMError("Test message", 'PARAM_MISMATCH');
+      should.equal(e.code, 6);
+    });
 
-		it("should assign literal code", function () {
-			var e = new ORMError("Test message", 'PARAM_MISMATCH');
-			should.equal(e.literalCode, 'PARAM_MISMATCH');
-		});
+    it("should assign literal code", function () {
+      var e = new ORMError("Test message", 'PARAM_MISMATCH');
+      should.equal(e.literalCode, 'PARAM_MISMATCH');
+    });
 
-		it("should assign extra params", function () {
-			var e = new ORMError("Test message", 'PARAM_MISMATCH', { details: "something" });
-			should.equal(e.details, "something");
-		});
+    it("should assign extra params", function () {
+      var e = new ORMError("Test message", 'PARAM_MISMATCH', { details: "something" });
+      should.equal(e.details, "something");
+    });
 
-		it("should stringify nicely", function () {
-			var e = new ORMError("Test message", 'PARAM_MISMATCH');
-			should.equal(e.toString(), "[ORMError PARAM_MISMATCH: Test message]");
-		});
-	});
+    it("should stringify nicely", function () {
+      var e = new ORMError("Test message", 'PARAM_MISMATCH');
+      should.equal(e.toString(), "[ORMError PARAM_MISMATCH: Test message]");
+    });
+  });
 
-	describe("codes", function () {
-		it("should be exposed", function () {
-			should.exist(ORMError.codes);
-			should.equal(ORMError.codes['NOT_FOUND'], 2);
-		});
-	});
+  describe("codes", function () {
+    it("should be exposed", function () {
+      should.exist(ORMError.codes);
+      should.equal(ORMError.codes['NOT_FOUND'], 2);
+    });
+  });
 });

--- a/test/integration/event.js
+++ b/test/integration/event.js
@@ -3,95 +3,95 @@ var helper   = require('../support/spec_helper');
 var ORM      = require('../../');
 
 describe("Event", function() {
-	var db = null;
-	var Person = null;
+  var db = null;
+  var Person = null;
 
-	var triggeredHooks = {};
+  var triggeredHooks = {};
 
-	var checkHook = function (hook) {
-		triggeredHooks[hook] = false;
+  var checkHook = function (hook) {
+    triggeredHooks[hook] = false;
 
-		return function () {
-			triggeredHooks[hook] = Date.now();
-		};
-	};
+    return function () {
+      triggeredHooks[hook] = Date.now();
+    };
+  };
 
-	var setup = function (hooks) {
-		return function (done) {
-			Person = db.define("person", {
-				name   : { type: "text", required: true }
-			});
+  var setup = function (hooks) {
+    return function (done) {
+      Person = db.define("person", {
+        name   : { type: "text", required: true }
+      });
 
-			return helper.dropSync(Person, done);
-		};
-	};
+      return helper.dropSync(Person, done);
+    };
+  };
 
-	before(function (done) {
-		helper.connect(function (connection) {
-			db = connection;
+  before(function (done) {
+    helper.connect(function (connection) {
+      db = connection;
 
-			return done();
-		});
-	});
+      return done();
+    });
+  });
 
-	after(function () {
-		return db.close();
-	});
+  after(function () {
+    return db.close();
+  });
 
-	describe("save", function () {
-		before(setup());
+  describe("save", function () {
+    before(setup());
 
-		it("should trigger when saving an instance", function (done) {
-			var triggered = false;
-			var John = new Person({
-				name : "John Doe"
-			});
+    it("should trigger when saving an instance", function (done) {
+      var triggered = false;
+      var John = new Person({
+        name : "John Doe"
+      });
 
-			John.on("save", function () {
-				triggered = true;
-			});
+      John.on("save", function () {
+        triggered = true;
+      });
 
-			triggered.should.be.false;
+      triggered.should.be.false;
 
-			John.save(function () {
-				triggered.should.be.true;
+      John.save(function () {
+        triggered.should.be.true;
 
-				return done();
-			});
-		});
+        return done();
+      });
+    });
 
-		it("should trigger when saving an instance even if it fails", function (done) {
-			var triggered = false;
-			var John = new Person();
+    it("should trigger when saving an instance even if it fails", function (done) {
+      var triggered = false;
+      var John = new Person();
 
-			John.on("save", function (err) {
-				triggered = true;
+      John.on("save", function (err) {
+        triggered = true;
 
-				err.should.be.a.Object();
-				err.should.have.property("msg", "required");
-			});
+        err.should.be.a.Object();
+        err.should.have.property("msg", "required");
+      });
 
-			triggered.should.be.false;
+      triggered.should.be.false;
 
-			John.save(function () {
-				triggered.should.be.true;
+      John.save(function () {
+        triggered.should.be.true;
 
-				return done();
-			});
-		});
+        return done();
+      });
+    });
 
-		it("should be writable for mocking", function (done) {
-			var triggered = false;
-			var John = new Person();
+    it("should be writable for mocking", function (done) {
+      var triggered = false;
+      var John = new Person();
 
-			John.on = function(event, cb) {
-				triggered = true;
-			};
-			triggered.should.be.false;
+      John.on = function(event, cb) {
+        triggered = true;
+      };
+      triggered.should.be.false;
 
-			John.on("mocked", function (err) {} );
-			triggered.should.be.true;
-			done();
-		});
-	});
+      John.on("mocked", function (err) {} );
+      triggered.should.be.true;
+      done();
+    });
+  });
 });

--- a/test/integration/hook.js
+++ b/test/integration/hook.js
@@ -64,10 +64,6 @@ describe("Hook", function() {
     return db.close();
   });
 
-  // there are a lot of timeouts in this suite and Travis or other test runners can
-  // have hickups that could force this suite to timeout to the default value (2 secs)
-  this.timeout(30000);
-
   describe("after Model creation", function () {
     before(setup({}));
 
@@ -181,8 +177,6 @@ describe("Hook", function() {
       }));
 
       it("should wait for hook to finish", function (done) {
-        this.timeout(800);
-
         Person.create([{ name: "John Doe" }], function () {
           beforeCreate.should.be.true;
 
@@ -200,8 +194,6 @@ describe("Hook", function() {
         }));
 
         it("should trigger error", function (done) {
-          this.timeout(800);
-
           Person.create([{ name: "John Doe" }], function (err) {
             err.should.be.a.Object();
             err.message.should.equal("beforeCreate-error");
@@ -301,8 +293,6 @@ describe("Hook", function() {
       }));
 
       it("should wait for hook to finish", function (done) {
-        this.timeout(800);
-
         Person.create([{ name: "John Doe" }], function () {
           beforeSave.should.be.true;
 
@@ -324,8 +314,6 @@ describe("Hook", function() {
         }));
 
         it("should trigger error when creating", function (done) {
-          this.timeout(800);
-
           Person.create([{ name: "Jane Doe" }], function (err) {
             err.should.be.a.Object();
             err.message.should.equal("beforeSave-error");
@@ -335,8 +323,6 @@ describe("Hook", function() {
         });
 
         it("should trigger error when saving", function (done) {
-          this.timeout(800);
-
           Person.create([{ name: "John Doe" }], function (err, John) {
             should.equal(err, null);
 
@@ -429,7 +415,6 @@ describe("Hook", function() {
 
     describe("if hook method has 1 argument", function () {
       var beforeValidation = false;
-      this.timeout(800);
 
       before(setup({
         beforeValidation : function (next) {
@@ -508,8 +493,6 @@ describe("Hook", function() {
       }));
 
       it("should wait for hook to finish", function (done) {
-        this.timeout(800);
-
         Person.create([{ name: "John Doe" }], function (err, items) {
           afterLoad.should.be.true;
 
@@ -525,8 +508,6 @@ describe("Hook", function() {
         }));
 
         it("should return error", function (done) {
-          this.timeout(800);
-
           Person.create([{ name: "John Doe" }], function (err, items) {
             err.should.exist;
             err.message.should.equal("AFTERLOAD_FAIL");
@@ -569,8 +550,6 @@ describe("Hook", function() {
       }));
 
       it("should wait for hook to finish", function (done) {
-        this.timeout(800);
-
         Person.create([{ name: "John Doe" }], function (err, items) {
           afterAutoFetch.should.be.true;
 
@@ -586,8 +565,6 @@ describe("Hook", function() {
         }));
 
         it("should return error", function (done) {
-          this.timeout(800);
-
           Person.create([{ name: "John Doe" }], function (err, items) {
             err.should.exist;
             err.message.should.equal("AFTERAUTOFETCH_FAIL");
@@ -628,8 +605,6 @@ describe("Hook", function() {
       }));
 
       it("should wait for hook to finish", function (done) {
-        this.timeout(800);
-
         Person.create([{ name: "John Doe" }], function (err, items) {
           items[0].remove(function () {
             beforeRemove.should.be.true;
@@ -650,8 +625,6 @@ describe("Hook", function() {
         }));
 
         it("should trigger error", function (done) {
-          this.timeout(800);
-
           Person.create([{ name: "John Doe" }], function (err, items) {
             items[0].remove(function (err) {
               err.should.be.a.Object();

--- a/test/integration/hook.js
+++ b/test/integration/hook.js
@@ -5,741 +5,741 @@ var async    = require('async');
 var ORM      = require('../../');
 
 describe("Hook", function() {
-	var db = null;
-	var Person = null;
-	var triggeredHooks = {};
-	var getTimestamp; // Calling it 'getTime' causes strangeness.
-
-	getTimestamp = function () { return Date.now(); };
-	// this next lines are failing...
-	// if (process.hrtime) {
-	// 	getTimestamp = function () { return parseFloat(process.hrtime().join('.')); };
-	// } else {
-	// 	getTimestamp = function () { return Date.now(); };
-	// }
-
-	var checkHook = function (hook) {
-		triggeredHooks[hook] = false;
-
-		return function () {
-			triggeredHooks[hook] = getTimestamp();
-		};
-	};
-
-	var setup = function (hooks) {
-		if (typeof hooks == "undefined") {
-			hooks = {
-				afterCreate      : checkHook("afterCreate"),
-				beforeCreate     : checkHook("beforeCreate"),
-				afterSave        : checkHook("afterSave"),
-				beforeSave       : checkHook("beforeSave"),
-				beforeValidation : checkHook("beforeValidation"),
-				beforeRemove     : checkHook("beforeRemove"),
-				afterRemove      : checkHook("afterRemove")
-			};
-		}
-
-		return function (done) {
-			Person = db.define("person", {
-				name   : String
-			}, {
-				hooks  : hooks
-			});
-
-			Person.settings.set("instance.returnAllErrors", false);
-
-			return helper.dropSync(Person, done);
-		};
-	};
-
-	before(function (done) {
-		helper.connect(function (connection) {
-			db = connection;
-
-			return done();
-		});
-	});
-
-	after(function () {
-		return db.close();
-	});
-
-	// there are a lot of timeouts in this suite and Travis or other test runners can
-	// have hickups that could force this suite to timeout to the default value (2 secs)
-	this.timeout(30000);
-
-	describe("after Model creation", function () {
-		before(setup({}));
-
-		it("can be changed", function (done) {
-			var triggered = false;
-
-			Person.afterCreate(function () {
-				triggered = true;
-			});
-			Person.create([{ name: "John Doe" }], function () {
-				triggered.should.be.true;
-
-				return done();
-			});
-		});
-
-		it("can be removed", function (done) {
-			var triggered = false;
-
-			Person.afterCreate(function () {
-				triggered = true;
-			});
-			Person.create([{ name: "John Doe" }], function () {
-				triggered.should.be.true;
-
-				triggered = false;
-
-				Person.afterCreate(); // clears hook
-
-				Person.create([{ name: "Jane Doe" }], function () {
-					triggered.should.be.false;
-
-					return done();
-				});
-			});
-		});
-	});
-
-	describe("beforeCreate", function () {
-		before(setup());
-
-		it("should trigger before creating instance", function (done) {
-			Person.create([{ name: "John Doe" }], function () {
-				triggeredHooks.afterCreate.should.be.a.Number();
-				triggeredHooks.beforeCreate.should.be.a.Number();
-				triggeredHooks.beforeCreate.should.not.be.above(triggeredHooks.afterCreate);
-
-				return done();
-			});
-		});
-
-		it("should allow modification of instance", function (done) {
-		    Person.beforeCreate(function (next) {
-		        this.name = "Hook Worked";
-		        next();
-		    });
-
-		    Person.create([{ }], function (err, people) {
-		        should.not.exist(err);
-		        should.exist(people);
-		        should.equal(people.length, 1);
-		        should.equal(people[0].name, "Hook Worked");
-
-		        // garantee it was correctly saved on database
-		        Person.one({ name: "Hook Worked" }, function (err, person) {
-		        	should.not.exist(err);
-		        	should.exist(person);
-
-		        	return done();
-		        });
-		    });
-		});
-
-		describe("when setting properties", function () {
-			before(setup({
-				beforeCreate : function () {
-					this.name = "Jane Doe";
-				}
-			}));
-
-			it("should not be discarded", function (done) {
-				Person.create([{ }], function (err, items) {
-					should.equal(err, null);
-
-					items.should.be.a.Object();
-					items.should.have.property("length", 1);
-					items[0].name.should.equal("Jane Doe");
-
-					// ensure it was really saved
-					Person.find({ name: "Hook Worked" }, { identityCache: false }, 1, function (err, people) {
-						should.not.exist(err);
-						should(Array.isArray(people));
-
-						return done();
-					});
-				});
-			});
-		});
-
-		describe("if hook method has 1 argument", function () {
-			var beforeCreate = false;
-
-			before(setup({
-				beforeCreate : function (next) {
-					setTimeout(function () {
-						beforeCreate = true;
-
-						return next();
-					}.bind(this), 200);
-				}
-			}));
-
-			it("should wait for hook to finish", function (done) {
-				this.timeout(800);
-
-				Person.create([{ name: "John Doe" }], function () {
-					beforeCreate.should.be.true;
-
-					return done();
-				});
-			});
-
-			describe("if hook triggers error", function () {
-				before(setup({
-					beforeCreate : function (next) {
-						setTimeout(function () {
-							return next(new Error('beforeCreate-error'));
-						}, 200);
-					}
-				}));
-
-				it("should trigger error", function (done) {
-					this.timeout(800);
-
-					Person.create([{ name: "John Doe" }], function (err) {
-						err.should.be.a.Object();
-						err.message.should.equal("beforeCreate-error");
-
-						return done();
-					});
-				});
-			});
-		});
-	});
-
-	describe("afterCreate", function () {
-		before(setup());
-
-		it("should trigger after creating instance", function (done) {
-			Person.create([{ name: "John Doe" }], function () {
-				triggeredHooks.afterCreate.should.be.a.Number();
-				triggeredHooks.beforeCreate.should.be.a.Number();
-				triggeredHooks.afterCreate.should.not.be.below(triggeredHooks.beforeCreate);
-
-				return done();
-			});
-		});
-	});
-
-	describe("beforeSave", function () {
-		before(setup());
-
-		it("should trigger before saving an instance", function (done) {
-			Person.create([{ name: "John Doe" }], function () {
-				triggeredHooks.afterSave.should.be.a.Number();
-				triggeredHooks.beforeSave.should.be.a.Number();
-				triggeredHooks.beforeSave.should.not.be.above(triggeredHooks.afterSave);
-
-				return done();
-			});
-		});
-
-		it("should allow modification of instance", function (done) {
-		    Person.beforeSave(function () {
-		        this.name = "Hook Worked";
-		    });
-
-		    Person.create([{ name: "John Doe" }], function (err, people) {
-		        should.not.exist(err);
-		        should.exist(people);
-		        should.equal(people.length, 1);
-		        should.equal(people[0].name, "Hook Worked");
-
-				// garantee it was correctly saved on database
-				Person.find({ name: "Hook Worked" }, { identityCache: false }, 1, function (err, people) {
-					should.not.exist(err);
-					should(Array.isArray(people));
-
-					return done();
-				});
-		    });
-		});
-
-		describe("when setting properties", function () {
-			before(setup({
-				beforeSave : function () {
-					this.name = "Jane Doe";
-				}
-			}));
-
-			it("should not be discarded", function (done) {
-				Person.create([{ }], function (err, items) {
-					should.equal(err, null);
-
-					items.should.be.a.Object();
-					items.should.have.property("length", 1);
-					items[0].name.should.equal("Jane Doe");
-
-					// ensure it was really saved
-					Person.get(items[0][Person.id], function (err, Item) {
-						should.equal(err, null);
-						Item.name.should.equal("Jane Doe");
-
-						return done();
-					});
-				});
-			});
-		});
-
-		describe("if hook method has 1 argument", function () {
-			var beforeSave = false;
-
-			before(setup({
-				beforeSave : function (next) {
-					setTimeout(function () {
-						beforeSave = true;
-
-						return next();
-					}.bind(this), 200);
-				}
-			}));
-
-			it("should wait for hook to finish", function (done) {
-				this.timeout(800);
-
-				Person.create([{ name: "John Doe" }], function () {
-					beforeSave.should.be.true;
-
-					return done();
-				});
-
-			});
-
-			describe("if hook triggers error", function () {
-				before(setup({
-					beforeSave : function (next) {
-						if (this.name == "John Doe") {
-							return next();
-						}
-						setTimeout(function () {
-							return next(new Error('beforeSave-error'));
-						}, 200);
-					}
-				}));
-
-				it("should trigger error when creating", function (done) {
-					this.timeout(800);
-
-					Person.create([{ name: "Jane Doe" }], function (err) {
-						err.should.be.a.Object();
-						err.message.should.equal("beforeSave-error");
-
-						return done();
-					});
-				});
-
-				it("should trigger error when saving", function (done) {
-					this.timeout(800);
-
-					Person.create([{ name: "John Doe" }], function (err, John) {
-						should.equal(err, null);
-
-						John[0].name = "Jane Doe";
-						John[0].save(function (err) {
-							err.should.be.a.Object();
-							err.message.should.equal("beforeSave-error");
-
-							return done();
-						});
-					});
-				});
-			});
-		});
-	});
-
-	describe("afterSave", function () {
-		beforeEach(setup());
-
-		it("should trigger after creating an instance", function (done) {
-			Person.create({ name: "John Doe" }, function (err, john) {
-				should.not.exist(err);
-
-				triggeredHooks.afterSave.should.be.a.Number();
-				triggeredHooks.beforeSave.should.be.a.Number();
-				triggeredHooks.afterSave.should.not.be.below(triggeredHooks.beforeSave);
-				done();
-			});
-		});
-
-		it("should trigger after saving an instance", function (done) {
-			Person.create({ name: "John Doe" }, function (err, john) {
-				should.not.exist(err);
-
-				john.name = "John Doe 2";
-
-				triggeredHooks = {};
-				john.save(function (err) {
-					triggeredHooks.afterSave.should.be.a.Number();
-					triggeredHooks.beforeSave.should.be.a.Number();
-					triggeredHooks.afterSave.should.not.be.below(triggeredHooks.beforeSave);
-					done();
-				});
-			});
-		});
-
-		it("should not trigger after saving an unchanged instance", function (done) {
-			Person.create({ name: "Edger" }, function (err, edger) {
-				should.not.exist(err);
-
-				triggeredHooks = {};
-				edger.save(function (err) {
-					should.not.exist(err);
-					should.not.exist(triggeredHooks.afterSave);
-					done();
-				});
-			});
-		});
-	});
-
-	describe("beforeValidation", function () {
-		before(setup());
-
-		it("should trigger before instance validation", function (done) {
-			Person.create([{ name: "John Doe" }], function () {
-				triggeredHooks.beforeValidation.should.be.a.Number();
-				triggeredHooks.beforeCreate.should.be.a.Number();
-				triggeredHooks.beforeSave.should.be.a.Number();
-				triggeredHooks.beforeValidation.should.not.be.above(triggeredHooks.beforeCreate);
-				triggeredHooks.beforeValidation.should.not.be.above(triggeredHooks.beforeSave);
-
-				return done();
-			});
-		});
-
-
-		it("should allow modification of instance", function (done) {
-		    Person.beforeValidation(function () {
-		        this.name = "Hook Worked";
-		    });
-
-		    Person.create([{ name: "John Doe" }], function (err, people) {
-		        should.not.exist(err);
-		        should.exist(people);
-		        should.equal(people.length, 1);
-		        should.equal(people[0].name, "Hook Worked");
-		        done();
-		    });
-		});
-
-		describe("if hook method has 1 argument", function () {
-			var beforeValidation = false;
-			this.timeout(800);
-
-			before(setup({
-				beforeValidation : function (next) {
-					setTimeout(function () {
-						beforeValidation = true;
-
-						if (!this.name) return next("Name is missing");
-
-						return next();
-					}.bind(this), 200);
-				}
-			}));
-
-			beforeEach(function () {
-				beforeValidation = false;
-			});
-
-			it("should wait for hook to finish", function (done) {
-				Person.create([{ name: "John Doe" }], function () {
-					beforeValidation.should.be.true;
-
-					return done();
-				});
-			});
-
-			it("should trigger error if hook passes an error", function (done) {
-				Person.create([{ name: "" }], function (err) {
-					beforeValidation.should.be.true;
-
-					err.should.equal("Name is missing");
-
-					return done();
-				});
-			});
-
-			it("should trigger when calling #validate", function (done) {
-				var person = new Person();
-
-				person.validate(function (err, validationErrors) {
-					beforeValidation.should.be.true;
-
-					return done();
-				});
-			});
-		});
-	});
-
-	describe("afterLoad", function () {
-		var afterLoad = false;
-
-		before(setup({
-			afterLoad: function () {
-				afterLoad = true;
-			}
-		}));
-
-		it("should trigger when defining a model", function (done) {
-			var John = new Person({ name: "John" });
-
-			afterLoad.should.be.true;
-
-			return done();
-		});
-
-		describe("if hook method has 1 argument", function () {
-			var afterLoad = false;
-
-			before(setup({
-				afterLoad : function (next) {
-					setTimeout(function () {
-						afterLoad = true;
-
-						return next();
-					}.bind(this), 200);
-				}
-			}));
-
-			it("should wait for hook to finish", function (done) {
-				this.timeout(800);
-
-				Person.create([{ name: "John Doe" }], function (err, items) {
-					afterLoad.should.be.true;
-
-					return done();
-				});
-			});
-
-			describe("if hook returns an error", function () {
-				before(setup({
-					afterLoad : function (next) {
-						return next(new Error("AFTERLOAD_FAIL"));
-					}
-				}));
-
-				it("should return error", function (done) {
-					this.timeout(800);
-
-					Person.create([{ name: "John Doe" }], function (err, items) {
-						err.should.exist;
-						err.message.should.equal("AFTERLOAD_FAIL");
-
-						return done();
-					});
-				});
-			});
-		});
-	});
-
-	describe("afterAutoFetch", function () {
-		var afterAutoFetch = false;
-
-		before(setup({
-			afterAutoFetch: function () {
-				afterAutoFetch = true;
-			}
-		}));
-
-		it("should trigger when defining a model", function (done) {
-			var John = new Person({ name: "John" });
-
-			afterAutoFetch.should.be.true;
-
-			return done();
-		});
-
-		describe("if hook method has 1 argument", function () {
-			var afterAutoFetch = false;
-
-			before(setup({
-				afterAutoFetch : function (next) {
-					setTimeout(function () {
-						afterAutoFetch = true;
-
-						return next();
-					}.bind(this), 200);
-				}
-			}));
-
-			it("should wait for hook to finish", function (done) {
-				this.timeout(800);
-
-				Person.create([{ name: "John Doe" }], function (err, items) {
-					afterAutoFetch.should.be.true;
-
-					return done();
-				});
-			});
-
-			describe("if hook returns an error", function () {
-				before(setup({
-					afterAutoFetch : function (next) {
-						return next(new Error("AFTERAUTOFETCH_FAIL"));
-					}
-				}));
-
-				it("should return error", function (done) {
-					this.timeout(800);
-
-					Person.create([{ name: "John Doe" }], function (err, items) {
-						err.should.exist;
-						err.message.should.equal("AFTERAUTOFETCH_FAIL");
-
-						return done();
-					});
-				});
-			});
-		});
-	});
-
-	describe("beforeRemove", function () {
-		before(setup());
-
-		it("should trigger before removing an instance", function (done) {
-			Person.create([{ name: "John Doe" }], function (err, items) {
-				items[0].remove(function () {
-					triggeredHooks.afterRemove.should.be.a.Number();
-					triggeredHooks.beforeRemove.should.be.a.Number();
-					triggeredHooks.beforeRemove.should.not.be.above(triggeredHooks.afterRemove);
-
-					return done();
-				});
-			});
-		});
-
-		describe("if hook method has 1 argument", function () {
-			var beforeRemove = false;
-
-			before(setup({
-				beforeRemove : function (next) {
-					setTimeout(function () {
-						beforeRemove = true;
-
-						return next();
-					}.bind(this), 200);
-				}
-			}));
-
-			it("should wait for hook to finish", function (done) {
-				this.timeout(800);
-
-				Person.create([{ name: "John Doe" }], function (err, items) {
-					items[0].remove(function () {
-						beforeRemove.should.be.true;
-
-						return done();
-					});
-				});
-
-			});
-
-			describe("if hook triggers error", function () {
-				before(setup({
-					beforeRemove : function (next) {
-						setTimeout(function () {
-							return next(new Error('beforeRemove-error'));
-						}, 200);
-					}
-				}));
-
-				it("should trigger error", function (done) {
-					this.timeout(800);
-
-					Person.create([{ name: "John Doe" }], function (err, items) {
-						items[0].remove(function (err) {
-							err.should.be.a.Object();
-							err.message.should.equal("beforeRemove-error");
-
-							return done();
-						});
-					});
-				});
-			});
-		});
-	});
-
-	describe("afterRemove", function () {
-		before(setup());
-
-		it("should trigger after removing an instance", function (done) {
-			Person.create([{ name: "John Doe" }], function (err, items) {
-				items[0].remove(function () {
-					triggeredHooks.afterRemove.should.be.a.Number();
-					triggeredHooks.beforeRemove.should.be.a.Number();
-					triggeredHooks.afterRemove.should.not.be.below(triggeredHooks.beforeRemove);
-
-					return done();
-				});
-			});
-		});
-	});
-
-	describe("if model has autoSave", function () {
-		before(function (done) {
-			Person = db.define("person", {
-				name    : String,
-				surname : String
-			}, {
-				autoSave  : true,
-				hooks     : {
-					afterSave : checkHook("afterSave")
-				}
-			});
-
-			Person.settings.set("instance.returnAllErrors", false);
-
-			return helper.dropSync(Person, done);
-		});
-
-		it("should trigger for single property changes", function (done) {
-			Person.create({ name : "John", surname : "Doe" }, function (err, John) {
-				should.equal(err, null);
-
-				triggeredHooks.afterSave.should.be.a.Number();
-				triggeredHooks.afterSave = false;
-
-				John.surname = "Dean";
-
-				setTimeout(function () {
-					triggeredHooks.afterSave.should.be.a.Number();
-
-					return done();
-				}, 200);
-			});
-		});
-	});
-
-	describe("instance modifications", function () {
-	    before(setup({
-	        beforeValidation: function () {
-	            should.equal(this.name, "John Doe");
-	            this.name = "beforeValidation";
-	        },
-	        beforeCreate: function () {
-	            should.equal(this.name, "beforeValidation");
-	            this.name = "beforeCreate";
-	        },
-	        beforeSave: function () {
-	            should.equal(this.name, "beforeCreate");
-	            this.name = "beforeSave";
-	        }
-	    }));
-
-	    it("should propagate down hooks", function (done) {
-	        Person.create([{ name: "John Doe" }], function (err, people) {
-	            should.not.exist(err);
-	            should.exist(people);
-	            should.equal(people.length, 1);
-	            should.equal(people[0].name, "beforeSave");
-	            done();
-	        });
-	    });
-	});
+  var db = null;
+  var Person = null;
+  var triggeredHooks = {};
+  var getTimestamp; // Calling it 'getTime' causes strangeness.
+
+  getTimestamp = function () { return Date.now(); };
+  // this next lines are failing...
+  // if (process.hrtime) {
+  //   getTimestamp = function () { return parseFloat(process.hrtime().join('.')); };
+  // } else {
+  //   getTimestamp = function () { return Date.now(); };
+  // }
+
+  var checkHook = function (hook) {
+    triggeredHooks[hook] = false;
+
+    return function () {
+      triggeredHooks[hook] = getTimestamp();
+    };
+  };
+
+  var setup = function (hooks) {
+    if (typeof hooks == "undefined") {
+      hooks = {
+        afterCreate      : checkHook("afterCreate"),
+        beforeCreate     : checkHook("beforeCreate"),
+        afterSave        : checkHook("afterSave"),
+        beforeSave       : checkHook("beforeSave"),
+        beforeValidation : checkHook("beforeValidation"),
+        beforeRemove     : checkHook("beforeRemove"),
+        afterRemove      : checkHook("afterRemove")
+      };
+    }
+
+    return function (done) {
+      Person = db.define("person", {
+        name   : String
+      }, {
+        hooks  : hooks
+      });
+
+      Person.settings.set("instance.returnAllErrors", false);
+
+      return helper.dropSync(Person, done);
+    };
+  };
+
+  before(function (done) {
+    helper.connect(function (connection) {
+      db = connection;
+
+      return done();
+    });
+  });
+
+  after(function () {
+    return db.close();
+  });
+
+  // there are a lot of timeouts in this suite and Travis or other test runners can
+  // have hickups that could force this suite to timeout to the default value (2 secs)
+  this.timeout(30000);
+
+  describe("after Model creation", function () {
+    before(setup({}));
+
+    it("can be changed", function (done) {
+      var triggered = false;
+
+      Person.afterCreate(function () {
+        triggered = true;
+      });
+      Person.create([{ name: "John Doe" }], function () {
+        triggered.should.be.true;
+
+        return done();
+      });
+    });
+
+    it("can be removed", function (done) {
+      var triggered = false;
+
+      Person.afterCreate(function () {
+        triggered = true;
+      });
+      Person.create([{ name: "John Doe" }], function () {
+        triggered.should.be.true;
+
+        triggered = false;
+
+        Person.afterCreate(); // clears hook
+
+        Person.create([{ name: "Jane Doe" }], function () {
+          triggered.should.be.false;
+
+          return done();
+        });
+      });
+    });
+  });
+
+  describe("beforeCreate", function () {
+    before(setup());
+
+    it("should trigger before creating instance", function (done) {
+      Person.create([{ name: "John Doe" }], function () {
+        triggeredHooks.afterCreate.should.be.a.Number();
+        triggeredHooks.beforeCreate.should.be.a.Number();
+        triggeredHooks.beforeCreate.should.not.be.above(triggeredHooks.afterCreate);
+
+        return done();
+      });
+    });
+
+    it("should allow modification of instance", function (done) {
+        Person.beforeCreate(function (next) {
+            this.name = "Hook Worked";
+            next();
+        });
+
+        Person.create([{ }], function (err, people) {
+            should.not.exist(err);
+            should.exist(people);
+            should.equal(people.length, 1);
+            should.equal(people[0].name, "Hook Worked");
+
+            // garantee it was correctly saved on database
+            Person.one({ name: "Hook Worked" }, function (err, person) {
+              should.not.exist(err);
+              should.exist(person);
+
+              return done();
+            });
+        });
+    });
+
+    describe("when setting properties", function () {
+      before(setup({
+        beforeCreate : function () {
+          this.name = "Jane Doe";
+        }
+      }));
+
+      it("should not be discarded", function (done) {
+        Person.create([{ }], function (err, items) {
+          should.equal(err, null);
+
+          items.should.be.a.Object();
+          items.should.have.property("length", 1);
+          items[0].name.should.equal("Jane Doe");
+
+          // ensure it was really saved
+          Person.find({ name: "Hook Worked" }, { identityCache: false }, 1, function (err, people) {
+            should.not.exist(err);
+            should(Array.isArray(people));
+
+            return done();
+          });
+        });
+      });
+    });
+
+    describe("if hook method has 1 argument", function () {
+      var beforeCreate = false;
+
+      before(setup({
+        beforeCreate : function (next) {
+          setTimeout(function () {
+            beforeCreate = true;
+
+            return next();
+          }.bind(this), 200);
+        }
+      }));
+
+      it("should wait for hook to finish", function (done) {
+        this.timeout(800);
+
+        Person.create([{ name: "John Doe" }], function () {
+          beforeCreate.should.be.true;
+
+          return done();
+        });
+      });
+
+      describe("if hook triggers error", function () {
+        before(setup({
+          beforeCreate : function (next) {
+            setTimeout(function () {
+              return next(new Error('beforeCreate-error'));
+            }, 200);
+          }
+        }));
+
+        it("should trigger error", function (done) {
+          this.timeout(800);
+
+          Person.create([{ name: "John Doe" }], function (err) {
+            err.should.be.a.Object();
+            err.message.should.equal("beforeCreate-error");
+
+            return done();
+          });
+        });
+      });
+    });
+  });
+
+  describe("afterCreate", function () {
+    before(setup());
+
+    it("should trigger after creating instance", function (done) {
+      Person.create([{ name: "John Doe" }], function () {
+        triggeredHooks.afterCreate.should.be.a.Number();
+        triggeredHooks.beforeCreate.should.be.a.Number();
+        triggeredHooks.afterCreate.should.not.be.below(triggeredHooks.beforeCreate);
+
+        return done();
+      });
+    });
+  });
+
+  describe("beforeSave", function () {
+    before(setup());
+
+    it("should trigger before saving an instance", function (done) {
+      Person.create([{ name: "John Doe" }], function () {
+        triggeredHooks.afterSave.should.be.a.Number();
+        triggeredHooks.beforeSave.should.be.a.Number();
+        triggeredHooks.beforeSave.should.not.be.above(triggeredHooks.afterSave);
+
+        return done();
+      });
+    });
+
+    it("should allow modification of instance", function (done) {
+        Person.beforeSave(function () {
+            this.name = "Hook Worked";
+        });
+
+        Person.create([{ name: "John Doe" }], function (err, people) {
+            should.not.exist(err);
+            should.exist(people);
+            should.equal(people.length, 1);
+            should.equal(people[0].name, "Hook Worked");
+
+        // garantee it was correctly saved on database
+        Person.find({ name: "Hook Worked" }, { identityCache: false }, 1, function (err, people) {
+          should.not.exist(err);
+          should(Array.isArray(people));
+
+          return done();
+        });
+        });
+    });
+
+    describe("when setting properties", function () {
+      before(setup({
+        beforeSave : function () {
+          this.name = "Jane Doe";
+        }
+      }));
+
+      it("should not be discarded", function (done) {
+        Person.create([{ }], function (err, items) {
+          should.equal(err, null);
+
+          items.should.be.a.Object();
+          items.should.have.property("length", 1);
+          items[0].name.should.equal("Jane Doe");
+
+          // ensure it was really saved
+          Person.get(items[0][Person.id], function (err, Item) {
+            should.equal(err, null);
+            Item.name.should.equal("Jane Doe");
+
+            return done();
+          });
+        });
+      });
+    });
+
+    describe("if hook method has 1 argument", function () {
+      var beforeSave = false;
+
+      before(setup({
+        beforeSave : function (next) {
+          setTimeout(function () {
+            beforeSave = true;
+
+            return next();
+          }.bind(this), 200);
+        }
+      }));
+
+      it("should wait for hook to finish", function (done) {
+        this.timeout(800);
+
+        Person.create([{ name: "John Doe" }], function () {
+          beforeSave.should.be.true;
+
+          return done();
+        });
+
+      });
+
+      describe("if hook triggers error", function () {
+        before(setup({
+          beforeSave : function (next) {
+            if (this.name == "John Doe") {
+              return next();
+            }
+            setTimeout(function () {
+              return next(new Error('beforeSave-error'));
+            }, 200);
+          }
+        }));
+
+        it("should trigger error when creating", function (done) {
+          this.timeout(800);
+
+          Person.create([{ name: "Jane Doe" }], function (err) {
+            err.should.be.a.Object();
+            err.message.should.equal("beforeSave-error");
+
+            return done();
+          });
+        });
+
+        it("should trigger error when saving", function (done) {
+          this.timeout(800);
+
+          Person.create([{ name: "John Doe" }], function (err, John) {
+            should.equal(err, null);
+
+            John[0].name = "Jane Doe";
+            John[0].save(function (err) {
+              err.should.be.a.Object();
+              err.message.should.equal("beforeSave-error");
+
+              return done();
+            });
+          });
+        });
+      });
+    });
+  });
+
+  describe("afterSave", function () {
+    beforeEach(setup());
+
+    it("should trigger after creating an instance", function (done) {
+      Person.create({ name: "John Doe" }, function (err, john) {
+        should.not.exist(err);
+
+        triggeredHooks.afterSave.should.be.a.Number();
+        triggeredHooks.beforeSave.should.be.a.Number();
+        triggeredHooks.afterSave.should.not.be.below(triggeredHooks.beforeSave);
+        done();
+      });
+    });
+
+    it("should trigger after saving an instance", function (done) {
+      Person.create({ name: "John Doe" }, function (err, john) {
+        should.not.exist(err);
+
+        john.name = "John Doe 2";
+
+        triggeredHooks = {};
+        john.save(function (err) {
+          triggeredHooks.afterSave.should.be.a.Number();
+          triggeredHooks.beforeSave.should.be.a.Number();
+          triggeredHooks.afterSave.should.not.be.below(triggeredHooks.beforeSave);
+          done();
+        });
+      });
+    });
+
+    it("should not trigger after saving an unchanged instance", function (done) {
+      Person.create({ name: "Edger" }, function (err, edger) {
+        should.not.exist(err);
+
+        triggeredHooks = {};
+        edger.save(function (err) {
+          should.not.exist(err);
+          should.not.exist(triggeredHooks.afterSave);
+          done();
+        });
+      });
+    });
+  });
+
+  describe("beforeValidation", function () {
+    before(setup());
+
+    it("should trigger before instance validation", function (done) {
+      Person.create([{ name: "John Doe" }], function () {
+        triggeredHooks.beforeValidation.should.be.a.Number();
+        triggeredHooks.beforeCreate.should.be.a.Number();
+        triggeredHooks.beforeSave.should.be.a.Number();
+        triggeredHooks.beforeValidation.should.not.be.above(triggeredHooks.beforeCreate);
+        triggeredHooks.beforeValidation.should.not.be.above(triggeredHooks.beforeSave);
+
+        return done();
+      });
+    });
+
+
+    it("should allow modification of instance", function (done) {
+        Person.beforeValidation(function () {
+            this.name = "Hook Worked";
+        });
+
+        Person.create([{ name: "John Doe" }], function (err, people) {
+            should.not.exist(err);
+            should.exist(people);
+            should.equal(people.length, 1);
+            should.equal(people[0].name, "Hook Worked");
+            done();
+        });
+    });
+
+    describe("if hook method has 1 argument", function () {
+      var beforeValidation = false;
+      this.timeout(800);
+
+      before(setup({
+        beforeValidation : function (next) {
+          setTimeout(function () {
+            beforeValidation = true;
+
+            if (!this.name) return next("Name is missing");
+
+            return next();
+          }.bind(this), 200);
+        }
+      }));
+
+      beforeEach(function () {
+        beforeValidation = false;
+      });
+
+      it("should wait for hook to finish", function (done) {
+        Person.create([{ name: "John Doe" }], function () {
+          beforeValidation.should.be.true;
+
+          return done();
+        });
+      });
+
+      it("should trigger error if hook passes an error", function (done) {
+        Person.create([{ name: "" }], function (err) {
+          beforeValidation.should.be.true;
+
+          err.should.equal("Name is missing");
+
+          return done();
+        });
+      });
+
+      it("should trigger when calling #validate", function (done) {
+        var person = new Person();
+
+        person.validate(function (err, validationErrors) {
+          beforeValidation.should.be.true;
+
+          return done();
+        });
+      });
+    });
+  });
+
+  describe("afterLoad", function () {
+    var afterLoad = false;
+
+    before(setup({
+      afterLoad: function () {
+        afterLoad = true;
+      }
+    }));
+
+    it("should trigger when defining a model", function (done) {
+      var John = new Person({ name: "John" });
+
+      afterLoad.should.be.true;
+
+      return done();
+    });
+
+    describe("if hook method has 1 argument", function () {
+      var afterLoad = false;
+
+      before(setup({
+        afterLoad : function (next) {
+          setTimeout(function () {
+            afterLoad = true;
+
+            return next();
+          }.bind(this), 200);
+        }
+      }));
+
+      it("should wait for hook to finish", function (done) {
+        this.timeout(800);
+
+        Person.create([{ name: "John Doe" }], function (err, items) {
+          afterLoad.should.be.true;
+
+          return done();
+        });
+      });
+
+      describe("if hook returns an error", function () {
+        before(setup({
+          afterLoad : function (next) {
+            return next(new Error("AFTERLOAD_FAIL"));
+          }
+        }));
+
+        it("should return error", function (done) {
+          this.timeout(800);
+
+          Person.create([{ name: "John Doe" }], function (err, items) {
+            err.should.exist;
+            err.message.should.equal("AFTERLOAD_FAIL");
+
+            return done();
+          });
+        });
+      });
+    });
+  });
+
+  describe("afterAutoFetch", function () {
+    var afterAutoFetch = false;
+
+    before(setup({
+      afterAutoFetch: function () {
+        afterAutoFetch = true;
+      }
+    }));
+
+    it("should trigger when defining a model", function (done) {
+      var John = new Person({ name: "John" });
+
+      afterAutoFetch.should.be.true;
+
+      return done();
+    });
+
+    describe("if hook method has 1 argument", function () {
+      var afterAutoFetch = false;
+
+      before(setup({
+        afterAutoFetch : function (next) {
+          setTimeout(function () {
+            afterAutoFetch = true;
+
+            return next();
+          }.bind(this), 200);
+        }
+      }));
+
+      it("should wait for hook to finish", function (done) {
+        this.timeout(800);
+
+        Person.create([{ name: "John Doe" }], function (err, items) {
+          afterAutoFetch.should.be.true;
+
+          return done();
+        });
+      });
+
+      describe("if hook returns an error", function () {
+        before(setup({
+          afterAutoFetch : function (next) {
+            return next(new Error("AFTERAUTOFETCH_FAIL"));
+          }
+        }));
+
+        it("should return error", function (done) {
+          this.timeout(800);
+
+          Person.create([{ name: "John Doe" }], function (err, items) {
+            err.should.exist;
+            err.message.should.equal("AFTERAUTOFETCH_FAIL");
+
+            return done();
+          });
+        });
+      });
+    });
+  });
+
+  describe("beforeRemove", function () {
+    before(setup());
+
+    it("should trigger before removing an instance", function (done) {
+      Person.create([{ name: "John Doe" }], function (err, items) {
+        items[0].remove(function () {
+          triggeredHooks.afterRemove.should.be.a.Number();
+          triggeredHooks.beforeRemove.should.be.a.Number();
+          triggeredHooks.beforeRemove.should.not.be.above(triggeredHooks.afterRemove);
+
+          return done();
+        });
+      });
+    });
+
+    describe("if hook method has 1 argument", function () {
+      var beforeRemove = false;
+
+      before(setup({
+        beforeRemove : function (next) {
+          setTimeout(function () {
+            beforeRemove = true;
+
+            return next();
+          }.bind(this), 200);
+        }
+      }));
+
+      it("should wait for hook to finish", function (done) {
+        this.timeout(800);
+
+        Person.create([{ name: "John Doe" }], function (err, items) {
+          items[0].remove(function () {
+            beforeRemove.should.be.true;
+
+            return done();
+          });
+        });
+
+      });
+
+      describe("if hook triggers error", function () {
+        before(setup({
+          beforeRemove : function (next) {
+            setTimeout(function () {
+              return next(new Error('beforeRemove-error'));
+            }, 200);
+          }
+        }));
+
+        it("should trigger error", function (done) {
+          this.timeout(800);
+
+          Person.create([{ name: "John Doe" }], function (err, items) {
+            items[0].remove(function (err) {
+              err.should.be.a.Object();
+              err.message.should.equal("beforeRemove-error");
+
+              return done();
+            });
+          });
+        });
+      });
+    });
+  });
+
+  describe("afterRemove", function () {
+    before(setup());
+
+    it("should trigger after removing an instance", function (done) {
+      Person.create([{ name: "John Doe" }], function (err, items) {
+        items[0].remove(function () {
+          triggeredHooks.afterRemove.should.be.a.Number();
+          triggeredHooks.beforeRemove.should.be.a.Number();
+          triggeredHooks.afterRemove.should.not.be.below(triggeredHooks.beforeRemove);
+
+          return done();
+        });
+      });
+    });
+  });
+
+  describe("if model has autoSave", function () {
+    before(function (done) {
+      Person = db.define("person", {
+        name    : String,
+        surname : String
+      }, {
+        autoSave  : true,
+        hooks     : {
+          afterSave : checkHook("afterSave")
+        }
+      });
+
+      Person.settings.set("instance.returnAllErrors", false);
+
+      return helper.dropSync(Person, done);
+    });
+
+    it("should trigger for single property changes", function (done) {
+      Person.create({ name : "John", surname : "Doe" }, function (err, John) {
+        should.equal(err, null);
+
+        triggeredHooks.afterSave.should.be.a.Number();
+        triggeredHooks.afterSave = false;
+
+        John.surname = "Dean";
+
+        setTimeout(function () {
+          triggeredHooks.afterSave.should.be.a.Number();
+
+          return done();
+        }, 200);
+      });
+    });
+  });
+
+  describe("instance modifications", function () {
+      before(setup({
+          beforeValidation: function () {
+              should.equal(this.name, "John Doe");
+              this.name = "beforeValidation";
+          },
+          beforeCreate: function () {
+              should.equal(this.name, "beforeValidation");
+              this.name = "beforeCreate";
+          },
+          beforeSave: function () {
+              should.equal(this.name, "beforeCreate");
+              this.name = "beforeSave";
+          }
+      }));
+
+      it("should propagate down hooks", function (done) {
+          Person.create([{ name: "John Doe" }], function (err, people) {
+              should.not.exist(err);
+              should.exist(people);
+              should.equal(people.length, 1);
+              should.equal(people[0].name, "beforeSave");
+              done();
+          });
+      });
+  });
 });

--- a/test/integration/instance.js
+++ b/test/integration/instance.js
@@ -1,466 +1,466 @@
-var should	= require('should');
-var helper	= require('../support/spec_helper');
+var should  = require('should');
+var helper  = require('../support/spec_helper');
 var common  = require('../common');
-var ORM			= require('../../');
+var ORM      = require('../../');
 
 describe("Model instance", function() {
-	var db = null;
-	var Person = null;
-	var protocol = common.protocol();
-
-	var setup = function () {
-		return function (done) {
-			db.settings.set('instance.returnAllErrors', true);
-
-			Person = db.define("person", {
-				name   : String,
-				age    : { type: 'integer', required: false },
-				height : { type: 'integer', required: false },
-				weight : { type: 'number',  required: false, enumerable: true },
-				secret : { type: 'text',  required: false, enumerable: false },
-				data   : { type: 'object',  required: false }
-			}, {
-				identityCache: false,
-				validations: {
-					age: ORM.validators.rangeNumber(0, 150)
-				}
-			});
-
-			return helper.dropSync(Person, function () {
-				Person.create([{
-					name: "Jeremy Doe"
-				}, {
-					name: "John Doe"
-				}, {
-					name: "Jane Doe"
-				}], done);
-			});
-		};
-	};
-
-	before(function (done) {
-		this.timeout(4000);
-
-		helper.connect(function (connection) {
-			db = connection;
-
-			setup()(function (err) {
-				return done();
-			});
-		});
-	});
-
-	after(function () {
-		return db.close();
-	});
-
-	describe("#save", function () {
-		var main_item, item;
-
-		before(function (done) {
-			main_item = db.define("main_item", {
-				name      : String
-			}, {
-				auteFetch : true
-			});
-			item = db.define("item", {
-				name      : String
-			}, {
-				identityCache  : false
-			});
-			item.hasOne("main_item", main_item, {
-				reverse   : "items",
-				autoFetch : true
-			});
-
-			return helper.dropSync([ main_item, item ], function () {
-				main_item.create({
-					name : "Main Item"
-				}, function (err, mainItem) {
-					item.create({
-						name : "Item"
-					}, function (err, Item) {
-						mainItem.setItems(Item, function (err) {
-							should.not.exist(err);
-
-							return done();
-						});
-					});
-				});
-			});
-		});
-
-		it("should have a saving state to avoid loops", function (done) {
-			main_item.find({ name : "Main Item" }).first(function (err, mainItem) {
-				mainItem.save({ name : "new name" }, function (err) {
-					should.not.exist(err);
-					return done();
-				});
-			});
-		});
-	});
-
-	describe("#isInstance", function () {
-		it("should always return true for instances", function (done) {
-			should.equal((new Person).isInstance, true);
-			should.equal((Person(4)).isInstance, true);
-
-			Person.find().first(function (err, item) {
-				should.not.exist(err);
-				should.equal(item.isInstance, true);
-				return done();
-			});
-		});
-
-		it("should be false for all other objects", function () {
-			should.notEqual({}.isInstance, true);
-			should.notEqual([].isInstance, true);
-		});
-	});
-
-	describe("#isPersisted", function () {
-		it("should return true for persisted instances", function (done) {
-			Person.find().first(function (err, item) {
-				should.not.exist(err);
-				should.equal(item.isPersisted(), true);
-				return done();
-			});
-		});
-
-		it("should return true for shell instances", function () {
-			should.equal(Person(4).isPersisted(), true);
-		});
-
-		it("should return false for new instances", function () {
-			should.equal((new Person).isPersisted(), false);
-		});
-
-		it("should be writable for mocking", function() {
-			var person = new Person()
-			var triggered = false;
-			person.isPersisted = function() {
-				triggered = true;
-			};
-			person.isPersisted()
-			triggered.should.be.true;
-		});
-	});
-
-	describe("#set", function () {
-		var person = null;
-		var data = null;
-
-		function clone(obj) { return JSON.parse(JSON.stringify(obj)) };
-
-		beforeEach(function (done) {
-			data = {
-				a: {
-					b: {
-						c: 3,
-						d: 4
-					}
-				},
-				e: 5
-			};
-			Person.create({ name: 'Dilbert', data: data }, function (err, p) {
-				if (err) return done(err);
-
-				person = p;
-				done();
-			});
-		});
-
-		it("should do nothing with flat paths when setting to same value", function () {
-			should.equal(person.saved(), true);
-			person.set('name', 'Dilbert');
-			should.equal(person.name, 'Dilbert');
-			should.equal(person.saved(), true);
-		});
-
-		it("should mark as dirty with flat paths when setting to different value", function () {
-			should.equal(person.saved(), true);
-			person.set('name', 'Dogbert');
-			should.equal(person.name, 'Dogbert');
-			should.equal(person.saved(), false);
-			should.equal(person.__opts.changes.join(','), 'name');
-		});
-
-		it("should do nothin with deep paths when setting to same value", function () {
-			should.equal(person.saved(), true);
-			person.set('data.e', 5);
-
-			var expected = clone(data);
-			expected.e = 5;
-
-			should.equal(JSON.stringify(person.data), JSON.stringify(expected));
-			should.equal(person.saved(), true);
-		});
-
-		it("should mark as dirty with deep paths when setting to different value", function () {
-			should.equal(person.saved(), true);
-			person.set('data.e', 6);
-
-			var expected = clone(data);
-			expected.e = 6;
-
-			should.equal(JSON.stringify(person.data), JSON.stringify(expected));
-			should.equal(person.saved(), false);
-			should.equal(person.__opts.changes.join(','), 'data');
-		});
-
-		it("should do nothing with deeper paths when setting to same value", function () {
-			should.equal(person.saved(), true);
-			person.set('data.a.b.d', 4);
-
-			var expected = clone(data);
-			expected.a.b.d = 4;
-
-			should.equal(JSON.stringify(person.data), JSON.stringify(expected));
-			should.equal(person.saved(), true);
-		});
-
-		it("should mark as dirty with deeper paths when setting to different value", function () {
-			should.equal(person.saved(), true);
-			person.set('data.a.b.d', 6);
-
-			var expected = clone(data);
-			expected.a.b.d = 6;
-
-			should.equal(JSON.stringify(person.data), JSON.stringify(expected));
-			should.equal(person.saved(), false);
-			should.equal(person.__opts.changes.join(','), 'data');
-		});
-
-		it("should mark as dirty with array path when setting to different value", function () {
-			should.equal(person.saved(), true);
-			person.set(['data', 'a', 'b', 'd'], 6);
-
-			var expected = clone(data);
-			expected.a.b.d = 6;
-
-			should.equal(JSON.stringify(person.data), JSON.stringify(expected));
-			should.equal(person.saved(), false);
-			should.equal(person.__opts.changes.join(','), 'data');
-		});
-
-		it("should do nothing with invalid paths", function () {
-			should.equal(person.saved(), true);
-			person.set('data.a.b.d.y.z', 1);
-			person.set('data.y.z', 1);
-			person.set('z', 1);
-			person.set(4, 1);
-			person.set(null, 1);
-			person.set(undefined, 1);
-			should.equal(person.saved(), true);
-		});
-	});
-
-	describe("#markAsDirty", function () {
-		var person = null;
-
-		beforeEach(function (done) {
-			Person.create({ name: 'John', age: 44, data: { a: 1 } }, function (err, p) {
-				if (err) return cb(err);
-
-				person = p;
-				done();
-			});
-		});
-
-		it("should mark individual properties as dirty", function () {
-			should.equal(person.saved(), true);
-			person.markAsDirty('name');
-			should.equal(person.saved(), false);
-			should.equal(person.__opts.changes.join(','), 'name');
-			person.markAsDirty('data');
-			should.equal(person.__opts.changes.join(','), 'name,data');
-		});
-	});
-
-	describe("#dirtyProperties", function () {
-		var person = null;
-
-		beforeEach(function (done) {
-			Person.create({ name: 'John', age: 44, data: { a: 1 } }, function (err, p) {
-				if (err) return cb(err);
-
-				person = p;
-				done();
-			});
-		});
-
-		it("should mark individual properties as dirty", function () {
-			should.equal(person.saved(), true);
-			person.markAsDirty('name');
-			person.markAsDirty('data');
-			should.equal(person.saved(), false);
-			should.equal(person.dirtyProperties.join(','), 'name,data');
-		});
-	});
-
-	describe("#isShell", function () {
-		it("should return true for shell models", function () {
-			should.equal(Person(4).isShell(), true);
-		});
-
-		it("should return false for new models", function () {
-			should.equal((new Person).isShell(), false);
-		});
-
-		it("should return false for existing models", function (done) {
-			Person.find().first(function (err, item) {
-				should.not.exist(err);
-				should.equal(item.isShell(), false);
-				return done();
-			});
-		});
-	});
-
-	describe("#validate", function () {
-		it("should return validation errors if invalid", function (done) {
-			var person = new Person({ age: -1 });
-
-			person.validate(function (err, validationErrors) {
-				should.not.exist(err);
-				should.equal(Array.isArray(validationErrors), true);
-
-				return done();
-			});
-		});
-
-		it("should return false if valid", function (done) {
-			var person = new Person({ name: 'Janette' });
-
-			person.validate(function (err, validationErrors) {
-				should.not.exist(err);
-				should.equal(validationErrors, false);
-
-				return done();
-			});
-		});
-	});
-
-	describe("properties", function () {
-		describe("Number", function () {
-			it("should be saved for valid numbers, using both save & create", function (done) {
-				var person1 = new Person({ height: 190 });
-
-				person1.save(function (err) {
-					should.not.exist(err);
-
-					Person.create({ height: 170 }, function (err, person2) {
-						should.not.exist(err);
-
-						Person.get(person1[Person.id], function (err, item) {
-							should.not.exist(err);
-							should.equal(item.height, 190);
-
-							Person.get(person2[Person.id], function (err, item) {
-								should.not.exist(err);
-								should.equal(item.height, 170);
-								done();
-							});
-						});
-					});
-				});
-			});
-
-			if (protocol == 'postgres') {
-				// Only postgres raises propper errors.
-				// Sqlite & Mysql fail silently and insert nulls.
-				it("should raise an error for NaN integers", function (done) {
-					var person = new Person({ height: NaN });
-
-					person.save(function (err) {
-						should.exist(err);
-						var msg = {
-							postgres : 'invalid input syntax for integer: "NaN"'
-						}[protocol];
-
-						should.equal(err.message, msg);
-
-						done();
-					});
-				});
-
-				it("should raise an error for Infinity integers", function (done) {
-					var person = new Person({ height: Infinity });
-
-					person.save(function (err) {
-						should.exist(err);
-						var msg = {
-							postgres : 'invalid input syntax for integer: "Infinity"'
-						}[protocol];
-
-						should.equal(err.message, msg);
-
-						done();
-					});
-				});
-
-				it("should raise an error for nonsensical integers, for both save & create", function (done) {
-					var person = new Person({ height: 'bugz' });
-
-					person.save(function (err) {
-						should.exist(err);
-						var msg = {
-							postgres : 'invalid input syntax for integer: "bugz"'
-						}[protocol];
-
-						should.equal(err.message, msg);
-
-						Person.create({ height: 'bugz' }, function (err, instance) {
-							should.exist(err);
-							should.equal(err.message, msg);
-
-							done();
-						});
-					});
-				});
-			}
-
-			if (protocol != 'mysql') {
-				// Mysql doesn't support IEEE floats (NaN, Infinity, -Infinity)
-				it("should store NaN & Infinite floats", function (done) {
-					var person = new Person({ weight: NaN });
-
-					person.save(function (err) {
-						should.not.exist(err);
-
-						Person.get(person[Person.id], function (err, person) {
-							should.not.exist(err);
-							should(isNaN(person.weight));
-
-							person.save({ weight: Infinity, name: 'black hole' }, function (err) {
-								should.not.exist(err);
-
-								Person.get(person[Person.id], function (err, person) {
-									should.not.exist(err);
-									should.strictEqual(person.weight, Infinity);
-
-									done();
-								});
-							});
-						});
-					});
-				});
-			}
-		});
-
-		describe("Enumerable", function () {
-			it("should not stringify properties marked as not enumerable", function (done) {
-				Person.create({ name: 'Dilbert', secret: 'dogbert', weight: 100, data: {data: 3} }, function (err, p) {
-					if (err) return done(err);
-
-					var result = JSON.parse(JSON.stringify(p));
-					should.not.exist(result.secret);
-					should.exist(result.weight);
-					should.exist(result.data);
-					should.exist(result.name);
-
-					done();
-				});
-			});
-		});
-	});
+  var db = null;
+  var Person = null;
+  var protocol = common.protocol();
+
+  var setup = function () {
+    return function (done) {
+      db.settings.set('instance.returnAllErrors', true);
+
+      Person = db.define("person", {
+        name   : String,
+        age    : { type: 'integer', required: false },
+        height : { type: 'integer', required: false },
+        weight : { type: 'number',  required: false, enumerable: true },
+        secret : { type: 'text',  required: false, enumerable: false },
+        data   : { type: 'object',  required: false }
+      }, {
+        identityCache: false,
+        validations: {
+          age: ORM.validators.rangeNumber(0, 150)
+        }
+      });
+
+      return helper.dropSync(Person, function () {
+        Person.create([{
+          name: "Jeremy Doe"
+        }, {
+          name: "John Doe"
+        }, {
+          name: "Jane Doe"
+        }], done);
+      });
+    };
+  };
+
+  before(function (done) {
+    this.timeout(4000);
+
+    helper.connect(function (connection) {
+      db = connection;
+
+      setup()(function (err) {
+        return done();
+      });
+    });
+  });
+
+  after(function () {
+    return db.close();
+  });
+
+  describe("#save", function () {
+    var main_item, item;
+
+    before(function (done) {
+      main_item = db.define("main_item", {
+        name      : String
+      }, {
+        auteFetch : true
+      });
+      item = db.define("item", {
+        name      : String
+      }, {
+        identityCache  : false
+      });
+      item.hasOne("main_item", main_item, {
+        reverse   : "items",
+        autoFetch : true
+      });
+
+      return helper.dropSync([ main_item, item ], function () {
+        main_item.create({
+          name : "Main Item"
+        }, function (err, mainItem) {
+          item.create({
+            name : "Item"
+          }, function (err, Item) {
+            mainItem.setItems(Item, function (err) {
+              should.not.exist(err);
+
+              return done();
+            });
+          });
+        });
+      });
+    });
+
+    it("should have a saving state to avoid loops", function (done) {
+      main_item.find({ name : "Main Item" }).first(function (err, mainItem) {
+        mainItem.save({ name : "new name" }, function (err) {
+          should.not.exist(err);
+          return done();
+        });
+      });
+    });
+  });
+
+  describe("#isInstance", function () {
+    it("should always return true for instances", function (done) {
+      should.equal((new Person).isInstance, true);
+      should.equal((Person(4)).isInstance, true);
+
+      Person.find().first(function (err, item) {
+        should.not.exist(err);
+        should.equal(item.isInstance, true);
+        return done();
+      });
+    });
+
+    it("should be false for all other objects", function () {
+      should.notEqual({}.isInstance, true);
+      should.notEqual([].isInstance, true);
+    });
+  });
+
+  describe("#isPersisted", function () {
+    it("should return true for persisted instances", function (done) {
+      Person.find().first(function (err, item) {
+        should.not.exist(err);
+        should.equal(item.isPersisted(), true);
+        return done();
+      });
+    });
+
+    it("should return true for shell instances", function () {
+      should.equal(Person(4).isPersisted(), true);
+    });
+
+    it("should return false for new instances", function () {
+      should.equal((new Person).isPersisted(), false);
+    });
+
+    it("should be writable for mocking", function() {
+      var person = new Person()
+      var triggered = false;
+      person.isPersisted = function() {
+        triggered = true;
+      };
+      person.isPersisted()
+      triggered.should.be.true;
+    });
+  });
+
+  describe("#set", function () {
+    var person = null;
+    var data = null;
+
+    function clone(obj) { return JSON.parse(JSON.stringify(obj)) };
+
+    beforeEach(function (done) {
+      data = {
+        a: {
+          b: {
+            c: 3,
+            d: 4
+          }
+        },
+        e: 5
+      };
+      Person.create({ name: 'Dilbert', data: data }, function (err, p) {
+        if (err) return done(err);
+
+        person = p;
+        done();
+      });
+    });
+
+    it("should do nothing with flat paths when setting to same value", function () {
+      should.equal(person.saved(), true);
+      person.set('name', 'Dilbert');
+      should.equal(person.name, 'Dilbert');
+      should.equal(person.saved(), true);
+    });
+
+    it("should mark as dirty with flat paths when setting to different value", function () {
+      should.equal(person.saved(), true);
+      person.set('name', 'Dogbert');
+      should.equal(person.name, 'Dogbert');
+      should.equal(person.saved(), false);
+      should.equal(person.__opts.changes.join(','), 'name');
+    });
+
+    it("should do nothin with deep paths when setting to same value", function () {
+      should.equal(person.saved(), true);
+      person.set('data.e', 5);
+
+      var expected = clone(data);
+      expected.e = 5;
+
+      should.equal(JSON.stringify(person.data), JSON.stringify(expected));
+      should.equal(person.saved(), true);
+    });
+
+    it("should mark as dirty with deep paths when setting to different value", function () {
+      should.equal(person.saved(), true);
+      person.set('data.e', 6);
+
+      var expected = clone(data);
+      expected.e = 6;
+
+      should.equal(JSON.stringify(person.data), JSON.stringify(expected));
+      should.equal(person.saved(), false);
+      should.equal(person.__opts.changes.join(','), 'data');
+    });
+
+    it("should do nothing with deeper paths when setting to same value", function () {
+      should.equal(person.saved(), true);
+      person.set('data.a.b.d', 4);
+
+      var expected = clone(data);
+      expected.a.b.d = 4;
+
+      should.equal(JSON.stringify(person.data), JSON.stringify(expected));
+      should.equal(person.saved(), true);
+    });
+
+    it("should mark as dirty with deeper paths when setting to different value", function () {
+      should.equal(person.saved(), true);
+      person.set('data.a.b.d', 6);
+
+      var expected = clone(data);
+      expected.a.b.d = 6;
+
+      should.equal(JSON.stringify(person.data), JSON.stringify(expected));
+      should.equal(person.saved(), false);
+      should.equal(person.__opts.changes.join(','), 'data');
+    });
+
+    it("should mark as dirty with array path when setting to different value", function () {
+      should.equal(person.saved(), true);
+      person.set(['data', 'a', 'b', 'd'], 6);
+
+      var expected = clone(data);
+      expected.a.b.d = 6;
+
+      should.equal(JSON.stringify(person.data), JSON.stringify(expected));
+      should.equal(person.saved(), false);
+      should.equal(person.__opts.changes.join(','), 'data');
+    });
+
+    it("should do nothing with invalid paths", function () {
+      should.equal(person.saved(), true);
+      person.set('data.a.b.d.y.z', 1);
+      person.set('data.y.z', 1);
+      person.set('z', 1);
+      person.set(4, 1);
+      person.set(null, 1);
+      person.set(undefined, 1);
+      should.equal(person.saved(), true);
+    });
+  });
+
+  describe("#markAsDirty", function () {
+    var person = null;
+
+    beforeEach(function (done) {
+      Person.create({ name: 'John', age: 44, data: { a: 1 } }, function (err, p) {
+        if (err) return cb(err);
+
+        person = p;
+        done();
+      });
+    });
+
+    it("should mark individual properties as dirty", function () {
+      should.equal(person.saved(), true);
+      person.markAsDirty('name');
+      should.equal(person.saved(), false);
+      should.equal(person.__opts.changes.join(','), 'name');
+      person.markAsDirty('data');
+      should.equal(person.__opts.changes.join(','), 'name,data');
+    });
+  });
+
+  describe("#dirtyProperties", function () {
+    var person = null;
+
+    beforeEach(function (done) {
+      Person.create({ name: 'John', age: 44, data: { a: 1 } }, function (err, p) {
+        if (err) return cb(err);
+
+        person = p;
+        done();
+      });
+    });
+
+    it("should mark individual properties as dirty", function () {
+      should.equal(person.saved(), true);
+      person.markAsDirty('name');
+      person.markAsDirty('data');
+      should.equal(person.saved(), false);
+      should.equal(person.dirtyProperties.join(','), 'name,data');
+    });
+  });
+
+  describe("#isShell", function () {
+    it("should return true for shell models", function () {
+      should.equal(Person(4).isShell(), true);
+    });
+
+    it("should return false for new models", function () {
+      should.equal((new Person).isShell(), false);
+    });
+
+    it("should return false for existing models", function (done) {
+      Person.find().first(function (err, item) {
+        should.not.exist(err);
+        should.equal(item.isShell(), false);
+        return done();
+      });
+    });
+  });
+
+  describe("#validate", function () {
+    it("should return validation errors if invalid", function (done) {
+      var person = new Person({ age: -1 });
+
+      person.validate(function (err, validationErrors) {
+        should.not.exist(err);
+        should.equal(Array.isArray(validationErrors), true);
+
+        return done();
+      });
+    });
+
+    it("should return false if valid", function (done) {
+      var person = new Person({ name: 'Janette' });
+
+      person.validate(function (err, validationErrors) {
+        should.not.exist(err);
+        should.equal(validationErrors, false);
+
+        return done();
+      });
+    });
+  });
+
+  describe("properties", function () {
+    describe("Number", function () {
+      it("should be saved for valid numbers, using both save & create", function (done) {
+        var person1 = new Person({ height: 190 });
+
+        person1.save(function (err) {
+          should.not.exist(err);
+
+          Person.create({ height: 170 }, function (err, person2) {
+            should.not.exist(err);
+
+            Person.get(person1[Person.id], function (err, item) {
+              should.not.exist(err);
+              should.equal(item.height, 190);
+
+              Person.get(person2[Person.id], function (err, item) {
+                should.not.exist(err);
+                should.equal(item.height, 170);
+                done();
+              });
+            });
+          });
+        });
+      });
+
+      if (protocol == 'postgres') {
+        // Only postgres raises propper errors.
+        // Sqlite & Mysql fail silently and insert nulls.
+        it("should raise an error for NaN integers", function (done) {
+          var person = new Person({ height: NaN });
+
+          person.save(function (err) {
+            should.exist(err);
+            var msg = {
+              postgres : 'invalid input syntax for integer: "NaN"'
+            }[protocol];
+
+            should.equal(err.message, msg);
+
+            done();
+          });
+        });
+
+        it("should raise an error for Infinity integers", function (done) {
+          var person = new Person({ height: Infinity });
+
+          person.save(function (err) {
+            should.exist(err);
+            var msg = {
+              postgres : 'invalid input syntax for integer: "Infinity"'
+            }[protocol];
+
+            should.equal(err.message, msg);
+
+            done();
+          });
+        });
+
+        it("should raise an error for nonsensical integers, for both save & create", function (done) {
+          var person = new Person({ height: 'bugz' });
+
+          person.save(function (err) {
+            should.exist(err);
+            var msg = {
+              postgres : 'invalid input syntax for integer: "bugz"'
+            }[protocol];
+
+            should.equal(err.message, msg);
+
+            Person.create({ height: 'bugz' }, function (err, instance) {
+              should.exist(err);
+              should.equal(err.message, msg);
+
+              done();
+            });
+          });
+        });
+      }
+
+      if (protocol != 'mysql') {
+        // Mysql doesn't support IEEE floats (NaN, Infinity, -Infinity)
+        it("should store NaN & Infinite floats", function (done) {
+          var person = new Person({ weight: NaN });
+
+          person.save(function (err) {
+            should.not.exist(err);
+
+            Person.get(person[Person.id], function (err, person) {
+              should.not.exist(err);
+              should(isNaN(person.weight));
+
+              person.save({ weight: Infinity, name: 'black hole' }, function (err) {
+                should.not.exist(err);
+
+                Person.get(person[Person.id], function (err, person) {
+                  should.not.exist(err);
+                  should.strictEqual(person.weight, Infinity);
+
+                  done();
+                });
+              });
+            });
+          });
+        });
+      }
+    });
+
+    describe("Enumerable", function () {
+      it("should not stringify properties marked as not enumerable", function (done) {
+        Person.create({ name: 'Dilbert', secret: 'dogbert', weight: 100, data: {data: 3} }, function (err, p) {
+          if (err) return done(err);
+
+          var result = JSON.parse(JSON.stringify(p));
+          should.not.exist(result.secret);
+          should.exist(result.weight);
+          should.exist(result.data);
+          should.exist(result.name);
+
+          done();
+        });
+      });
+    });
+  });
 });

--- a/test/integration/instance.js
+++ b/test/integration/instance.js
@@ -39,8 +39,6 @@ describe("Model instance", function() {
   };
 
   before(function (done) {
-    this.timeout(4000);
-
     helper.connect(function (connection) {
       db = connection;
 

--- a/test/integration/model-aggregate.js
+++ b/test/integration/model-aggregate.js
@@ -3,275 +3,275 @@ var helper   = require('../support/spec_helper');
 var ORM      = require('../../');
 
 describe("Model.aggregate()", function() {
-	var db = null;
-	var Person = null;
-
-	var setup = function () {
-		return function (done) {
-			Person = db.define("person", {
-				name   : String
-			});
-
-			return helper.dropSync(Person, function () {
-				Person.create([{
-					id  : 1,
-					name: "John Doe"
-				}, {
-					id  : 2,
-					name: "Jane Doe"
-				}, {
-					id  : 3,
-					name: "John Doe"
-				}], done);
-			});
-		};
-	};
-
-	before(function (done) {
-		helper.connect(function (connection) {
-			db = connection;
-
-			return done();
-		});
-	});
-
-	after(function () {
-		return db.close();
-	});
-
-	describe("with multiple methods", function () {
-		before(setup());
-
-		it("should return value for everyone of them", function (done) {
-			Person.aggregate().count('id').min('id').max('id').get(function (err, count, min, max) {
-				should.equal(err, null);
-
-				count.should.equal(3);
-				min.should.equal(1);
-				max.should.equal(3);
-
-				return done();
-			});
-		});
-	});
-
-	describe("with call()", function () {
-		before(setup());
-
-		it("should accept a function", function (done) {
-			Person.aggregate().call('COUNT').get(function (err, count) {
-				should.equal(err, null);
-
-				count.should.equal(3);
+  var db = null;
+  var Person = null;
+
+  var setup = function () {
+    return function (done) {
+      Person = db.define("person", {
+        name   : String
+      });
+
+      return helper.dropSync(Person, function () {
+        Person.create([{
+          id  : 1,
+          name: "John Doe"
+        }, {
+          id  : 2,
+          name: "Jane Doe"
+        }, {
+          id  : 3,
+          name: "John Doe"
+        }], done);
+      });
+    };
+  };
+
+  before(function (done) {
+    helper.connect(function (connection) {
+      db = connection;
+
+      return done();
+    });
+  });
+
+  after(function () {
+    return db.close();
+  });
+
+  describe("with multiple methods", function () {
+    before(setup());
+
+    it("should return value for everyone of them", function (done) {
+      Person.aggregate().count('id').min('id').max('id').get(function (err, count, min, max) {
+        should.equal(err, null);
+
+        count.should.equal(3);
+        min.should.equal(1);
+        max.should.equal(3);
+
+        return done();
+      });
+    });
+  });
+
+  describe("with call()", function () {
+    before(setup());
+
+    it("should accept a function", function (done) {
+      Person.aggregate().call('COUNT').get(function (err, count) {
+        should.equal(err, null);
+
+        count.should.equal(3);
 
-				return done();
-			});
-		});
+        return done();
+      });
+    });
 
-		it("should accept arguments to the funciton as an Array", function (done) {
-			Person.aggregate().call('COUNT', [ 'id' ]).get(function (err, count) {
-				should.equal(err, null);
+    it("should accept arguments to the funciton as an Array", function (done) {
+      Person.aggregate().call('COUNT', [ 'id' ]).get(function (err, count) {
+        should.equal(err, null);
 
-				count.should.equal(3);
-
-				return done();
-			});
-		});
-
-		describe("if function is DISTINCT", function () {
-			it("should work as calling .distinct() directly", function (done) {
-				Person.aggregate().call('DISTINCT', [ 'name' ]).as('name').order('name').get(function (err, rows) {
-					should.equal(err, null);
+        count.should.equal(3);
+
+        return done();
+      });
+    });
+
+    describe("if function is DISTINCT", function () {
+      it("should work as calling .distinct() directly", function (done) {
+        Person.aggregate().call('DISTINCT', [ 'name' ]).as('name').order('name').get(function (err, rows) {
+          should.equal(err, null);
 
-					should(Array.isArray(rows));
-					rows.length.should.equal(2);
+          should(Array.isArray(rows));
+          rows.length.should.equal(2);
 
-					rows[0].should.equal('Jane Doe');
-					rows[1].should.equal('John Doe');
-
-					return done();
-				});
-			});
-		});
-	});
+          rows[0].should.equal('Jane Doe');
+          rows[1].should.equal('John Doe');
+
+          return done();
+        });
+      });
+    });
+  });
 
-	describe("with as() without previous aggregates", function () {
-		before(setup());
-
-		it("should throw", function (done) {
-			Person.aggregate().as.should.throw();
-
-			return done();
-		});
-	});
+  describe("with as() without previous aggregates", function () {
+    before(setup());
+
+    it("should throw", function (done) {
+      Person.aggregate().as.should.throw();
+
+      return done();
+    });
+  });
 
-	describe("with select() without arguments", function () {
-		before(setup());
+  describe("with select() without arguments", function () {
+    before(setup());
 
-		it("should throw", function (done) {
-			Person.aggregate().select.should.throw();
+    it("should throw", function (done) {
+      Person.aggregate().select.should.throw();
 
-			return done();
-		});
-	});
+      return done();
+    });
+  });
 
-	describe("with select() with arguments", function () {
-		before(setup());
+  describe("with select() with arguments", function () {
+    before(setup());
 
-		it("should use them as properties if 1st argument is Array", function (done) {
-			Person.aggregate().select([ 'id' ]).count('id').groupBy('id').get(function (err, people) {
-				should.equal(err, null);
+    it("should use them as properties if 1st argument is Array", function (done) {
+      Person.aggregate().select([ 'id' ]).count('id').groupBy('id').get(function (err, people) {
+        should.equal(err, null);
 
-				should(Array.isArray(people));
-				people.length.should.be.above(0);
+        should(Array.isArray(people));
+        people.length.should.be.above(0);
 
-				people[0].should.be.a.Object();
-				people[0].should.have.property("id");
-				people[0].should.not.have.property("name");
+        people[0].should.be.a.Object();
+        people[0].should.have.property("id");
+        people[0].should.not.have.property("name");
 
-				return done();
-			});
-		});
+        return done();
+      });
+    });
 
-		it("should use them as properties", function (done) {
-			Person.aggregate().select('id').count().groupBy('id').get(function (err, people) {
-				should.equal(err, null);
+    it("should use them as properties", function (done) {
+      Person.aggregate().select('id').count().groupBy('id').get(function (err, people) {
+        should.equal(err, null);
 
-				should(Array.isArray(people));
-				people.length.should.be.above(0);
+        should(Array.isArray(people));
+        people.length.should.be.above(0);
 
-				people[0].should.be.a.Object();
-				people[0].should.have.property("id");
-				people[0].should.not.have.property("name");
+        people[0].should.be.a.Object();
+        people[0].should.have.property("id");
+        people[0].should.not.have.property("name");
 
-				return done();
-			});
-		});
-	});
+        return done();
+      });
+    });
+  });
 
-	describe("with get() without callback", function () {
-		before(setup());
+  describe("with get() without callback", function () {
+    before(setup());
 
-		it("should throw", function (done) {
-			Person.aggregate().count('id').get.should.throw();
+    it("should throw", function (done) {
+      Person.aggregate().count('id').get.should.throw();
 
-			return done();
-		});
-	});
+      return done();
+    });
+  });
 
-	describe("with get() without aggregates", function () {
-		before(setup());
+  describe("with get() without aggregates", function () {
+    before(setup());
 
-		it("should throw", function (done) {
-			(function () {
-				Person.aggregate().get(function () {});
-			}).should.throw();
+    it("should throw", function (done) {
+      (function () {
+        Person.aggregate().get(function () {});
+      }).should.throw();
 
-			return done();
-		});
-	});
+      return done();
+    });
+  });
 
-	describe("with distinct()", function () {
-		before(setup());
+  describe("with distinct()", function () {
+    before(setup());
 
-		it("should return a list of distinct properties", function (done) {
-			Person.aggregate().distinct('name').get(function (err, names) {
-				should.equal(err, null);
+    it("should return a list of distinct properties", function (done) {
+      Person.aggregate().distinct('name').get(function (err, names) {
+        should.equal(err, null);
 
-				names.should.be.a.Object();
-				names.should.have.property("length", 2);
+        names.should.be.a.Object();
+        names.should.have.property("length", 2);
 
-				return done();
-			});
-		});
+        return done();
+      });
+    });
 
-		describe("with limit(1)", function () {
-			it("should return only one value", function (done) {
-				Person.aggregate().distinct('name').limit(1).order("name").get(function (err, names) {
-					should.equal(err, null);
+    describe("with limit(1)", function () {
+      it("should return only one value", function (done) {
+        Person.aggregate().distinct('name').limit(1).order("name").get(function (err, names) {
+          should.equal(err, null);
 
-					names.should.be.a.Object();
-					names.should.have.property("length", 1);
-					names[0].should.equal("Jane Doe");
+          names.should.be.a.Object();
+          names.should.have.property("length", 1);
+          names[0].should.equal("Jane Doe");
 
-					return done();
-				});
-			});
-		});
+          return done();
+        });
+      });
+    });
 
-		describe("with limit(1, 1)", function () {
-			it("should return only one value", function (done) {
-				Person.aggregate().distinct('name').limit(1, 1).order("name").get(function (err, names) {
-					should.equal(err, null);
+    describe("with limit(1, 1)", function () {
+      it("should return only one value", function (done) {
+        Person.aggregate().distinct('name').limit(1, 1).order("name").get(function (err, names) {
+          should.equal(err, null);
 
-					names.should.be.a.Object();
-					names.should.have.property("length", 1);
-					names[0].should.equal("John Doe");
+          names.should.be.a.Object();
+          names.should.have.property("length", 1);
+          names[0].should.equal("John Doe");
 
-					return done();
-				});
-			});
-		});
-	});
+          return done();
+        });
+      });
+    });
+  });
 
-	describe("with groupBy()", function () {
-		before(setup());
+  describe("with groupBy()", function () {
+    before(setup());
 
-		it("should return items grouped by property", function (done) {
-			Person.aggregate().count().groupBy('name').get(function (err, rows) {
-				should.equal(err, null);
+    it("should return items grouped by property", function (done) {
+      Person.aggregate().count().groupBy('name').get(function (err, rows) {
+        should.equal(err, null);
 
-				rows.should.be.a.Object();
-				rows.should.have.property("length", 2);
+        rows.should.be.a.Object();
+        rows.should.have.property("length", 2);
 
-				(rows[0].count + rows[1].count).should.equal(3); // 1 + 2
+        (rows[0].count + rows[1].count).should.equal(3); // 1 + 2
 
-				return done();
-			});
-		});
+        return done();
+      });
+    });
 
-		describe("with order()", function () {
-			before(setup());
+    describe("with order()", function () {
+      before(setup());
 
-			it("should order items", function (done) {
-				Person.aggregate().count().groupBy('name').order('-count').get(function (err, rows) {
-					should.equal(err, null);
+      it("should order items", function (done) {
+        Person.aggregate().count().groupBy('name').order('-count').get(function (err, rows) {
+          should.equal(err, null);
 
-					rows.should.be.a.Object();
-					rows.should.have.property("length", 2);
+          rows.should.be.a.Object();
+          rows.should.have.property("length", 2);
 
-					rows[0].count.should.equal(2);
-					rows[1].count.should.equal(1);
+          rows[0].count.should.equal(2);
+          rows[1].count.should.equal(1);
 
-					return done();
-				});
-			});
-		});
-	});
+          return done();
+        });
+      });
+    });
+  });
 
-	describe("using as()", function () {
-		before(setup());
+  describe("using as()", function () {
+    before(setup());
 
-		it("should use as an alias", function (done) {
-			Person.aggregate().count().as('total').groupBy('name').get(function (err, people) {
-				should.equal(err, null);
+    it("should use as an alias", function (done) {
+      Person.aggregate().count().as('total').groupBy('name').get(function (err, people) {
+        should.equal(err, null);
 
-				should(Array.isArray(people));
-				people.length.should.be.above(0);
+        should(Array.isArray(people));
+        people.length.should.be.above(0);
 
-				people[0].should.be.a.Object();
-				people[0].should.have.property("total");
+        people[0].should.be.a.Object();
+        people[0].should.have.property("total");
 
-				return done();
-			});
-		});
+        return done();
+      });
+    });
 
-		it("should throw if no aggregates defined", function (done) {
-			(function () {
-				Person.aggregate().as('total');
-			}).should.throw();
+    it("should throw if no aggregates defined", function (done) {
+      (function () {
+        Person.aggregate().as('total');
+      }).should.throw();
 
-			return done();
-		});
-	});
+      return done();
+    });
+  });
 });

--- a/test/integration/model-clear.js
+++ b/test/integration/model-clear.js
@@ -3,68 +3,68 @@ var helper   = require('../support/spec_helper');
 var ORM      = require('../../');
 
 describe("Model.clear()", function() {
-	var db = null;
-	var Person = null;
+  var db = null;
+  var Person = null;
 
-	var setup = function () {
-		return function (done) {
-			Person = db.define("person", {
-				name   : String
-			});
+  var setup = function () {
+    return function (done) {
+      Person = db.define("person", {
+        name   : String
+      });
 
-			ORM.singleton.clear();
+      ORM.singleton.clear();
 
-			return helper.dropSync(Person, function () {
-				Person.create([{
-					name: "John Doe"
-				}, {
-					name: "Jane Doe"
-				}], done);
-			});
-		};
-	};
+      return helper.dropSync(Person, function () {
+        Person.create([{
+          name: "John Doe"
+        }, {
+          name: "Jane Doe"
+        }], done);
+      });
+    };
+  };
 
-	before(function (done) {
-		helper.connect(function (connection) {
-			db = connection;
+  before(function (done) {
+    helper.connect(function (connection) {
+      db = connection;
 
-			return done();
-		});
-	});
+      return done();
+    });
+  });
 
-	after(function () {
-		return db.close();
-	});
+  after(function () {
+    return db.close();
+  });
 
-	describe("with callback", function () {
-		before(setup());
+  describe("with callback", function () {
+    before(setup());
 
-		it("should call when done", function (done) {
-			Person.clear(function (err) {
-				should.equal(err, null);
+    it("should call when done", function (done) {
+      Person.clear(function (err) {
+        should.equal(err, null);
 
-				Person.find().count(function (err, count) {
-					count.should.equal(0);
+        Person.find().count(function (err, count) {
+          count.should.equal(0);
 
-					return done();
-				});
-			});
-		});
-	});
+          return done();
+        });
+      });
+    });
+  });
 
-	describe("without callback", function () {
-		before(setup());
+  describe("without callback", function () {
+    before(setup());
 
-		it("should still remove", function (done) {
-			Person.clear();
+    it("should still remove", function (done) {
+      Person.clear();
 
-			setTimeout(function () {
-				Person.find().count(function (err, count) {
-					count.should.equal(0);
+      setTimeout(function () {
+        Person.find().count(function (err, count) {
+          count.should.equal(0);
 
-					return done();
-				});
-			}, 200);
-		});
-	});
+          return done();
+        });
+      }, 200);
+    });
+  });
 });

--- a/test/integration/model-count.js
+++ b/test/integration/model-count.js
@@ -3,77 +3,77 @@ var helper   = require('../support/spec_helper');
 var ORM      = require('../../');
 
 describe("Model.count()", function() {
-	var db = null;
-	var Person = null;
+  var db = null;
+  var Person = null;
 
-	var setup = function () {
-		return function (done) {
-			Person = db.define("person", {
-				name   : String
-			});
+  var setup = function () {
+    return function (done) {
+      Person = db.define("person", {
+        name   : String
+      });
 
-			return helper.dropSync(Person, function () {
-				Person.create([{
-					id  : 1,
-					name: "John Doe"
-				}, {
-					id  : 2,
-					name: "Jane Doe"
-				}, {
-					id  : 3,
-					name: "John Doe"
-				}], done);
-			});
-		};
-	};
+      return helper.dropSync(Person, function () {
+        Person.create([{
+          id  : 1,
+          name: "John Doe"
+        }, {
+          id  : 2,
+          name: "Jane Doe"
+        }, {
+          id  : 3,
+          name: "John Doe"
+        }], done);
+      });
+    };
+  };
 
-	before(function (done) {
-		helper.connect(function (connection) {
-			db = connection;
+  before(function (done) {
+    helper.connect(function (connection) {
+      db = connection;
 
-			return done();
-		});
-	});
+      return done();
+    });
+  });
 
-	after(function () {
-		return db.close();
-	});
+  after(function () {
+    return db.close();
+  });
 
-	describe("without callback", function () {
-		before(setup());
+  describe("without callback", function () {
+    before(setup());
 
-		it("should throw", function (done) {
-			Person.count.should.throw();
+    it("should throw", function (done) {
+      Person.count.should.throw();
 
-			return done();
-		});
-	});
+      return done();
+    });
+  });
 
-	describe("without conditions", function () {
-		before(setup());
+  describe("without conditions", function () {
+    before(setup());
 
-		it("should return all items in model", function (done) {
-			Person.count(function (err, count) {
-				should.equal(err, null);
+    it("should return all items in model", function (done) {
+      Person.count(function (err, count) {
+        should.equal(err, null);
 
-				count.should.equal(3);
+        count.should.equal(3);
 
-				return done();
-			});
-		});
-	});
+        return done();
+      });
+    });
+  });
 
-	describe("with conditions", function () {
-		before(setup());
+  describe("with conditions", function () {
+    before(setup());
 
-		it("should return only matching items", function (done) {
-			Person.count({ name: "John Doe" }, function (err, count) {
-				should.equal(err, null);
+    it("should return only matching items", function (done) {
+      Person.count({ name: "John Doe" }, function (err, count) {
+        should.equal(err, null);
 
-				count.should.equal(2);
+        count.should.equal(2);
 
-				return done();
-			});
-		});
-	});
+        return done();
+      });
+    });
+  });
 });

--- a/test/integration/model-create.js
+++ b/test/integration/model-create.js
@@ -3,125 +3,125 @@ var helper   = require('../support/spec_helper');
 var ORM      = require('../../');
 
 describe("Model.create()", function() {
-	var db = null;
-	var Pet = null;
-	var Person = null;
+  var db = null;
+  var Pet = null;
+  var Person = null;
 
-	var setup = function () {
-		return function (done) {
-			Person = db.define("person", {
-				name   : String
-			});
-			Pet = db.define("pet", {
-				name   : { type: "text", defaultValue: "Mutt" }
-			});
-			Person.hasMany("pets", Pet);
+  var setup = function () {
+    return function (done) {
+      Person = db.define("person", {
+        name   : String
+      });
+      Pet = db.define("pet", {
+        name   : { type: "text", defaultValue: "Mutt" }
+      });
+      Person.hasMany("pets", Pet);
 
-			return helper.dropSync([ Person, Pet ], done);
-		};
-	};
+      return helper.dropSync([ Person, Pet ], done);
+    };
+  };
 
-	before(function (done) {
-		helper.connect(function (connection) {
-			db = connection;
+  before(function (done) {
+    helper.connect(function (connection) {
+      db = connection;
 
-			return done();
-		});
-	});
+      return done();
+    });
+  });
 
-	after(function () {
-		return db.close();
-	});
+  after(function () {
+    return db.close();
+  });
 
-	describe("if passing an object", function () {
-		before(setup());
+  describe("if passing an object", function () {
+    before(setup());
 
-		it("should accept it as the only item to create", function (done) {
-			Person.create({
-				name : "John Doe"
-			}, function (err, John) {
-				should.equal(err, null);
-				John.should.have.property("name", "John Doe");
+    it("should accept it as the only item to create", function (done) {
+      Person.create({
+        name : "John Doe"
+      }, function (err, John) {
+        should.equal(err, null);
+        John.should.have.property("name", "John Doe");
 
-				return done();
-			});
-		});
-	});
+        return done();
+      });
+    });
+  });
 
-	describe("if passing an array", function () {
-		before(setup());
+  describe("if passing an array", function () {
+    before(setup());
 
-		it("should accept it as a list of items to create", function (done) {
-			Person.create([{
-				name : "John Doe"
-			}, {
-				name : "Jane Doe"
-			}], function (err, people) {
-				should.equal(err, null);
-				should(Array.isArray(people));
+    it("should accept it as a list of items to create", function (done) {
+      Person.create([{
+        name : "John Doe"
+      }, {
+        name : "Jane Doe"
+      }], function (err, people) {
+        should.equal(err, null);
+        should(Array.isArray(people));
 
-				people.should.have.property("length", 2);
-				people[0].should.have.property("name", "John Doe");
-				people[1].should.have.property("name", "Jane Doe");
+        people.should.have.property("length", 2);
+        people[0].should.have.property("name", "John Doe");
+        people[1].should.have.property("name", "Jane Doe");
 
-				return done();
-			});
-		});
-	});
+        return done();
+      });
+    });
+  });
 
-	describe("if element has an association", function () {
-		before(setup());
+  describe("if element has an association", function () {
+    before(setup());
 
-		it("should also create it or save it", function (done) {
-			Person.create({
-				name : "John Doe",
-				pets : [ new Pet({ name: "Deco" }) ]
-			}, function (err, John) {
-				should.equal(err, null);
+    it("should also create it or save it", function (done) {
+      Person.create({
+        name : "John Doe",
+        pets : [ new Pet({ name: "Deco" }) ]
+      }, function (err, John) {
+        should.equal(err, null);
 
-				John.should.have.property("name", "John Doe");
+        John.should.have.property("name", "John Doe");
 
-				should(Array.isArray(John.pets));
+        should(Array.isArray(John.pets));
 
-				John.pets[0].should.have.property("name", "Deco");
-				John.pets[0].should.have.property(Pet.id);
-				John.pets[0].saved().should.be.true;
+        John.pets[0].should.have.property("name", "Deco");
+        John.pets[0].should.have.property(Pet.id);
+        John.pets[0].saved().should.be.true;
 
-				return done();
-			});
-		});
+        return done();
+      });
+    });
 
-		it("should also create it or save it even if it's an object and not an instance", function (done) {
-			Person.create({
-				name : "John Doe",
-				pets : [ { name: "Deco" } ]
-			}, function (err, John) {
-				should.equal(err, null);
+    it("should also create it or save it even if it's an object and not an instance", function (done) {
+      Person.create({
+        name : "John Doe",
+        pets : [ { name: "Deco" } ]
+      }, function (err, John) {
+        should.equal(err, null);
 
-				John.should.have.property("name", "John Doe");
+        John.should.have.property("name", "John Doe");
 
-				should(Array.isArray(John.pets));
+        should(Array.isArray(John.pets));
 
-				John.pets[0].should.have.property("name", "Deco");
-				John.pets[0].should.have.property(Pet.id);
-				John.pets[0].saved().should.be.true;
+        John.pets[0].should.have.property("name", "Deco");
+        John.pets[0].should.have.property(Pet.id);
+        John.pets[0].saved().should.be.true;
 
-				return done();
-			});
-		});
-	});
+        return done();
+      });
+    });
+  });
 
-	describe("when not passing a property", function () {
-		before(setup());
+  describe("when not passing a property", function () {
+    before(setup());
 
-		it("should use defaultValue if defined", function (done) {
-			Pet.create({}, function (err, Mutt) {
-				should.equal(err, null);
+    it("should use defaultValue if defined", function (done) {
+      Pet.create({}, function (err, Mutt) {
+        should.equal(err, null);
 
-				Mutt.should.have.property("name", "Mutt");
+        Mutt.should.have.property("name", "Mutt");
 
-				return done();
-			});
-		});
-	});
+        return done();
+      });
+    });
+  });
 });

--- a/test/integration/model-exists.js
+++ b/test/integration/model-exists.js
@@ -3,131 +3,131 @@ var helper   = require('../support/spec_helper');
 var ORM      = require('../../');
 
 describe("Model.exists()", function() {
-	var db     = null;
-	var Person = null;
-	var good_id, bad_id;
+  var db     = null;
+  var Person = null;
+  var good_id, bad_id;
 
-	var setup = function () {
-		return function (done) {
-			Person = db.define("person", {
-				name   : String
-			});
+  var setup = function () {
+    return function (done) {
+      Person = db.define("person", {
+        name   : String
+      });
 
-			return helper.dropSync(Person, function () {
-				Person.create([{
-					name: "Jeremy Doe"
-				}, {
-					name: "John Doe"
-				}, {
-					name: "Jane Doe"
-				}], function (err, people) {
-					good_id = people[0][Person.id];
+      return helper.dropSync(Person, function () {
+        Person.create([{
+          name: "Jeremy Doe"
+        }, {
+          name: "John Doe"
+        }, {
+          name: "Jane Doe"
+        }], function (err, people) {
+          good_id = people[0][Person.id];
 
-					if (typeof good_id == "number") {
-						// numeric ID
-						bad_id = good_id * 100;
-					} else {
-						// string ID, keep same length..
-						bad_id = good_id.split('').reverse().join('');
-					}
+          if (typeof good_id == "number") {
+            // numeric ID
+            bad_id = good_id * 100;
+          } else {
+            // string ID, keep same length..
+            bad_id = good_id.split('').reverse().join('');
+          }
 
-					return done();
-				});
-			});
-		};
-	};
+          return done();
+        });
+      });
+    };
+  };
 
-	before(function (done) {
-		helper.connect(function (connection) {
-			db = connection;
+  before(function (done) {
+    helper.connect(function (connection) {
+      db = connection;
 
-			return done();
-		});
-	});
+      return done();
+    });
+  });
 
-	after(function () {
-		return db.close();
-	});
+  after(function () {
+    return db.close();
+  });
 
-	describe("without callback", function () {
-		before(setup());
+  describe("without callback", function () {
+    before(setup());
 
-		it("should throw", function (done) {
-			Person.exists.should.throw();
+    it("should throw", function (done) {
+      Person.exists.should.throw();
 
-			return done();
-		});
-	});
+      return done();
+    });
+  });
 
-	describe("with an id", function () {
-		before(setup());
+  describe("with an id", function () {
+    before(setup());
 
-		it("should return true if found", function (done) {
-			Person.exists(good_id, function (err, exists) {
-				should.equal(err, null);
+    it("should return true if found", function (done) {
+      Person.exists(good_id, function (err, exists) {
+        should.equal(err, null);
 
-				exists.should.be.true;
+        exists.should.be.true;
 
-				return done();
-			});
-		});
+        return done();
+      });
+    });
 
-		it("should return false if not found", function (done) {
-			Person.exists(bad_id, function (err, exists) {
-				should.equal(err, null);
+    it("should return false if not found", function (done) {
+      Person.exists(bad_id, function (err, exists) {
+        should.equal(err, null);
 
-				exists.should.be.false;
+        exists.should.be.false;
 
-				return done();
-			});
-		});
-	});
+        return done();
+      });
+    });
+  });
 
-	describe("with a list of ids", function () {
-		before(setup());
+  describe("with a list of ids", function () {
+    before(setup());
 
-		it("should return true if found", function (done) {
-			Person.exists([ good_id ], function (err, exists) {
-				should.equal(err, null);
+    it("should return true if found", function (done) {
+      Person.exists([ good_id ], function (err, exists) {
+        should.equal(err, null);
 
-				exists.should.be.true;
+        exists.should.be.true;
 
-				return done();
-			});
-		});
+        return done();
+      });
+    });
 
-		it("should return false if not found", function (done) {
-			Person.exists([ bad_id ], function (err, exists) {
-				should.equal(err, null);
+    it("should return false if not found", function (done) {
+      Person.exists([ bad_id ], function (err, exists) {
+        should.equal(err, null);
 
-				exists.should.be.false;
+        exists.should.be.false;
 
-				return done();
-			});
-		});
-	});
+        return done();
+      });
+    });
+  });
 
-	describe("with a conditions object", function () {
-		before(setup());
+  describe("with a conditions object", function () {
+    before(setup());
 
-		it("should return true if found", function (done) {
-			Person.exists({ name: "John Doe" }, function (err, exists) {
-				should.equal(err, null);
+    it("should return true if found", function (done) {
+      Person.exists({ name: "John Doe" }, function (err, exists) {
+        should.equal(err, null);
 
-				exists.should.be.true;
+        exists.should.be.true;
 
-				return done();
-			});
-		});
+        return done();
+      });
+    });
 
-		it("should return false if not found", function (done) {
-			Person.exists({ name: "Jack Doe" }, function (err, exists) {
-				should.equal(err, null);
+    it("should return false if not found", function (done) {
+      Person.exists({ name: "Jack Doe" }, function (err, exists) {
+        should.equal(err, null);
 
-				exists.should.be.false;
+        exists.should.be.false;
 
-				return done();
-			});
-		});
-	});
+        return done();
+      });
+    });
+  });
 });

--- a/test/integration/model-find-chain.js
+++ b/test/integration/model-find-chain.js
@@ -5,705 +5,705 @@ var ORM      = require('../../');
 var common   = require('../common');
 
 describe("Model.find() chaining", function() {
-	var db = null;
-	var Person = null;
-	var Dog = null;
-
-	var setup = function (extraOpts) {
-		if (!extraOpts) extraOpts = {};
-
-		return function (done) {
-			Person = db.define("person", {
-				name    : String,
-				surname : String,
-				age     : Number
-			}, extraOpts);
-			Person.hasMany("parents");
-			Person.hasOne("friend");
-
-			ORM.singleton.clear(); // clear identityCache cache
-
-			return helper.dropSync(Person, function () {
-				Person.create([{
-					name      : "John",
-					surname   : "Doe",
-					age       : 18,
-					friend_id : 1
-				}, {
-					name      : "Jane",
-					surname   : "Doe",
-					age       : 20,
-					friend_id : 1
-				}, {
-					name      : "Jane",
-					surname   : "Dean",
-					age       : 18,
-					friend_id : 1
-				}], done);
-			});
-		};
-	};
-
-	var setup2 = function () {
-		return function (done) {
-			Dog = db.define("dog", {
-				name: String,
-			});
-			Dog.hasMany("friends");
-			Dog.hasMany("family");
-
-			ORM.singleton.clear(); // clear identityCache cache
-
-			return helper.dropSync(Dog, function () {
-				Dog.create([{
-					name    : "Fido",
-					friends : [{ name: "Gunner" }, { name: "Chainsaw" }],
-					family  : [{ name: "Chester" }]
-				}, {
-					name    : "Thumper",
-					friends : [{ name: "Bambi" }],
-					family  : [{ name: "Princess" }, { name: "Butch" }]
-				}], done);
-			});
-		};
-	};
-
-	before(function (done) {
-		helper.connect(function (connection) {
-			db = connection;
-
-			return done();
-		});
-	});
-
-	after(function () {
-		return db.close();
-	});
-
-	describe(".limit(N)", function () {
-		before(setup());
-
-		it("should limit results to N items", function (done) {
-			Person.find().limit(2).run(function (err, instances) {
-				should.equal(err, null);
-				instances.should.have.property("length", 2);
-
-				return done();
-			});
-		});
-	});
-
-	describe(".skip(N)", function () {
-		before(setup());
-
-		it("should skip the first N results", function (done) {
-			Person.find().skip(2).order("age").run(function (err, instances) {
-				should.equal(err, null);
-				instances.should.have.property("length", 1);
-				instances[0].age.should.equal(20);
-
-				return done();
-			});
-		});
-	});
-
-	describe(".offset(N)", function () {
-		before(setup());
-
-		it("should skip the first N results", function (done) {
-			Person.find().offset(2).order("age").run(function (err, instances) {
-				should.equal(err, null);
-				instances.should.have.property("length", 1);
-				instances[0].age.should.equal(20);
-
-				return done();
-			});
-		});
-	});
-
-	describe("order", function () {
-		before(setup());
-
-		it("('property') should order by that property ascending", function (done) {
-			Person.find().order("age").run(function (err, instances) {
-				should.equal(err, null);
-				instances.should.have.property("length", 3);
-				instances[0].age.should.equal(18);
-				instances[2].age.should.equal(20);
-
-				return done();
-			});
-		});
-
-		it("('-property') should order by that property descending", function (done) {
-			Person.find().order("-age").run(function (err, instances) {
-				should.equal(err, null);
-				instances.should.have.property("length", 3);
-				instances[0].age.should.equal(20);
-				instances[2].age.should.equal(18);
-
-				return done();
-			});
-		});
-
-		it("('property', 'Z') should order by that property descending", function (done) {
-			Person.find().order("age", "Z").run(function (err, instances) {
-				should.equal(err, null);
-				instances.should.have.property("length", 3);
-				instances[0].age.should.equal(20);
-				instances[2].age.should.equal(18);
-
-				return done();
-			});
-		});
-	});
-
-	describe("orderRaw", function () {
-		if (common.protocol() == 'mongodb') return;
-
-		before(setup());
-
-		it("should allow ordering by SQL", function (done) {
-			Person.find().orderRaw("age DESC").run(function (err, instances) {
-				should.equal(err, null);
-				instances.should.have.property("length", 3);
-				instances[0].age.should.equal(20);
-				instances[2].age.should.equal(18);
-
-				return done();
-			});
-		});
-
-		it("should allow ordering by SQL with escaping", function (done) {
-			Person.find().orderRaw("?? DESC", ['age']).run(function (err, instances) {
-				should.equal(err, null);
-				instances.should.have.property("length", 3);
-				instances[0].age.should.equal(20);
-				instances[2].age.should.equal(18);
-
-				return done();
-			});
-		});
-	});
-
-	describe("only", function () {
-		before(setup());
-
-		it("('property', ...) should return only those properties, others null", function (done) {
-			Person.find().only("age", "surname").order("-age").run(function (err, instances) {
-				should.equal(err, null);
-				instances.should.have.property("length", 3);
-				instances[0].should.have.property("age");
-				instances[0].should.have.property("surname", "Doe");
-				instances[0].should.have.property("name", null);
-
-				return done();
-			});
-		});
-
-		// This works if cache is disabled. I suspect a cache bug.
-		xit("(['property', ...]) should return only those properties, others null", function (done) {
-			Person.find().only([ "age", "surname" ]).order("-age").run(function (err, instances) {
-				should.equal(err, null);
-				instances.should.have.property("length", 3);
-				instances[0].should.have.property("age");
-				instances[0].should.have.property("surname", "Doe");
-				instances[0].should.have.property("name", null);
-
-				return done();
-			});
-		});
-	});
-
-	describe("omit", function () {
-		before(setup());
-
-		it("('property', ...) should not get these properties", function (done) {
-			Person.find().omit("age", "surname").order("-age").run(function (err, instances) {
-				should.equal(err, null);
-				instances.should.have.property("length", 3);
-				if (common.protocol() != "mongodb") {
-					should.exist(instances[0].id);
-				}
-				should.exist(instances[0].friend_id);
-				instances[0].should.have.property("age", null);
-				instances[0].should.have.property("surname", null);
-				instances[0].should.have.property("name", "Jane");
-
-				return done();
-			});
-		});
-
-		it("(['property', ...]) should not get these properties", function (done) {
-			Person.find().omit(["age", "surname"]).order("-age").run(function (err, instances) {
-				should.equal(err, null);
-				instances.should.have.property("length", 3);
-				instances[0].should.have.property("age", null);
-				instances[0].should.have.property("surname", null);
-				instances[0].should.have.property("name", "Jane");
-
-				return done();
-			});
-		});
-	});
-
-	describe(".count()", function () {
-		before(setup());
-
-		it("should return only the total number of results", function (done) {
-			Person.find().count(function (err, count) {
-				should.equal(err, null);
-				count.should.equal(3);
-
-				return done();
-			});
-		});
-	});
-
-	describe(".first()", function () {
-		before(setup());
-
-		it("should return only the first element", function (done) {
-			Person.find().order("-age").first(function (err, JaneDoe) {
-				should.equal(err, null);
-
-				JaneDoe.name.should.equal("Jane");
-				JaneDoe.surname.should.equal("Doe");
-				JaneDoe.age.should.equal(20);
-
-				return done();
-			});
-		});
-
-		it("should return null if not found", function (done) {
-			Person.find({ name: "Jack" }).first(function (err, Jack) {
-				should.equal(err, null);
-				should.equal(Jack, null);
-
-				return done();
-			});
-		});
-	});
-
-	describe(".last()", function () {
-		before(setup());
-
-		it("should return only the last element", function (done) {
-			Person.find().order("age").last(function (err, JaneDoe) {
-				should.equal(err, null);
-
-				JaneDoe.name.should.equal("Jane");
-				JaneDoe.surname.should.equal("Doe");
-				JaneDoe.age.should.equal(20);
-
-				return done();
-			});
-		});
-
-		it("should return null if not found", function (done) {
-			Person.find({ name: "Jack" }).last(function (err, Jack) {
-				should.equal(err, null);
-				should.equal(Jack, null);
-
-				return done();
-			});
-		});
-	});
-
-	describe(".find()", function () {
-		before(setup());
-
-		it("should not change find if no arguments", function (done) {
-			Person.find().find().count(function (err, count) {
-				should.equal(err, null);
-				count.should.equal(3);
-
-				return done();
-			});
-		});
-
-		it("should restrict conditions if passed", function (done) {
-			Person.find().find({ age: 18 }).count(function (err, count) {
-				should.equal(err, null);
-				count.should.equal(2);
-
-				return done();
-			});
-		});
-
-		it("should restrict conditions if passed and also be chainable", function (done) {
-			Person.find().find({ age: 18 }).find({ name: "Jane" }).count(function (err, count) {
-				should.equal(err, null);
-				count.should.equal(1);
-
-				return done();
-			});
-		});
-
-		it("should return results if passed a callback as second argument", function (done) {
-			Person.find().find({ age: 18 }, function (err, instances) {
-				should.equal(err, null);
-				instances.should.have.property("length", 2);
-
-				return done();
-			});
-		});
-
-		if (common.protocol() == "mongodb") return;
-
-		it("should allow sql where conditions", function (done) {
-			Person.find({ age: 18 }).where("LOWER(surname) LIKE 'dea%'").all(function (err, items) {
-				should.equal(err, null);
-				items.length.should.equal(1);
-
-				return done();
-			});
-		});
-
-		it("should allow sql where conditions with auto escaping", function (done) {
-			Person.find({ age: 18 }).where("LOWER(surname) LIKE ?", ['dea%']).all(function (err, items) {
-				should.equal(err, null);
-				items.length.should.equal(1);
-
-				return done();
-			});
-		});
-
-		it("should append sql where conditions", function (done) {
-			Person.find().where("LOWER(surname) LIKE ?", ['do%']).all(function (err, items) {
-				should.equal(err, null);
-				items.length.should.equal(2);
-
-				Person.find().where("LOWER(name) LIKE ?", ['jane']).all(function (err, items) {
-					should.equal(err, null);
-					items.length.should.equal(2);
-
-					Person.find().where("LOWER(surname) LIKE ?", ['do%']).where("LOWER(name) LIKE ?", ['jane']).all(function (err, items) {
-						should.equal(err, null);
-						items.length.should.equal(1);
-
-						return done();
-					});
-				});
-			});
-		});
-	});
-
-	describe("finders should be chainable & interchangeable including", function () {
-		before(setup());
-
-		before(function (done) {
-			Person.create([
-					{ name: "Mel", surname: "Gabbs", age: 12 },
-					{ name: "Mel", surname: "Gibbs", age: 22 },
-					{ name: "Mel", surname: "Gobbs", age: 32 }
-				], function (err, items) {
-					should.not.exist(err);
-					done()
-				}
-			);
-		});
-
-		['find', 'where', 'all'].forEach(function (func) {
-			it("." + func + "()", function (done) {
-				Person[func]({ name: "Mel" })[func]({ age: ORM.gt(20) })[func](function (err, items) {
-					should.not.exist(err);
-					should.equal(items.length, 2);
-
-					should.equal(items[0].surname, "Gibbs");
-					should.equal(items[1].surname, "Gobbs");
-					done();
-				});
-			});
-		});
-
-		it("a mix", function (done) {
-			Person.all({ name: "Mel" }).where({ age: ORM.gt(20) }).find(function (err, items) {
-				should.not.exist(err);
-				should.equal(items.length, 2);
-
-				should.equal(items[0].surname, "Gibbs");
-				should.equal(items[1].surname, "Gobbs");
-				done();
-			});
-		});
-	});
-
-	describe(".each()", function () {
-		before(setup());
-
-		it("should return a ChainInstance", function (done) {
-			var chain = Person.find().each();
-
-			chain.filter.should.be.a.Function();
-			chain.sort.should.be.a.Function();
-			chain.count.should.be.a.Function();
-
-			return done();
-		});
-	});
-
-	describe(".remove()", function () {
-		var hookFired = false;
-
-		before(setup({
-			hooks: {
-				beforeRemove: function () {
-					hookFired = true;
-				}
-			}
-		}));
-
-		it("should have no problems if no results found", function (done) {
-			Person.find({ age: 22 }).remove(function (err) {
-				should.equal(err, null);
-
-				Person.find().count(function (err, count) {
-					should.equal(err, null);
-
-					count.should.equal(3);
-
-					return done();
-				});
-			});
-		});
-
-		it("should remove results without calling hooks", function (done) {
-			Person.find({ age: 20 }).remove(function (err) {
-				should.equal(err, null);
-				should.equal(hookFired, false);
-
-				Person.find().count(function (err, count) {
-					should.equal(err, null);
-
-					count.should.equal(2);
-
-					return done();
-				});
-			});
-		});
-
-	});
-
-	describe(".each()", function () {
-		var hookFired = false;
-
-		before(setup({
-			hooks: {
-				beforeRemove: function () {
-					hookFired = true;
-				}
-			}
-		}));
-
-		it("should return a ChainFind", function (done) {
-			var chain = Person.find({ age: 22 }).each();
-
-			chain.should.be.a.Object();
-			chain.filter.should.be.a.Function();
-			chain.sort.should.be.a.Function();
-			chain.count.should.be.a.Function();
-			chain.get.should.be.a.Function();
-			chain.save.should.be.a.Function();
-
-			return done();
-		});
-
-		describe(".count()", function () {
-			it("should return the total filtered items", function (done) {
-				Person.find().each().filter(function (person) {
-					return (person.age > 18);
-				}).count(function (count) {
-					count.should.equal(1);
-
-					return done();
-				});
-			});
-		});
-
-		describe(".sort()", function () {
-			it("should return the items sorted using the sorted function", function (done) {
-				Person.find().each().sort(function (first, second) {
-					return (first.age < second.age);
-				}).get(function (people) {
-					should(Array.isArray(people));
-
-					people.length.should.equal(3);
-					people[0].age.should.equal(20);
-					people[2].age.should.equal(18);
-
-					return done();
-				});
-			});
-		});
-
-		describe(".save()", function () {
-			it("should save items after changes", function (done) {
-				Person.find({ surname: "Dean" }).each(function (person) {
-					person.age.should.not.equal(45);
-					person.age = 45;
-				}).save(function () {
-					Person.find({ surname: "Dean" }, function (err, people) {
-						should(Array.isArray(people));
-
-						people.length.should.equal(1);
-						people[0].age.should.equal(45);
-
-						return done();
-					});
-				});
-			});
-		});
-
-		describe("if passing a callback", function () {
-			it("should use it to .forEach()", function (done) {
-				Person.find({ surname: "Dean" }).each(function (person) {
-					person.fullName = person.name + " " + person.surname;
-				}).get(function (people) {
-					should(Array.isArray(people));
-
-					people.length.should.equal(1);
-					people[0].fullName = "Jane Dean";
-
-					return done();
-				});
-			});
-		});
-
-		// TODO: Implement
-		xit(".remove() should call hooks", function () {
-			Person.find().each().remove(function (err) {
-				should.not.exist(err);
-				should.equal(hookFired, true);
-			});
-		});
-
-		if (common.protocol() == "mongodb") return;
-
-		describe(".hasAccessor() for hasOne associations", function () {
-		    it("should be chainable", function (done) {
-				Person.find({ name: "John" }, function (err, John) {
-					should.equal(err, null);
-
-					var Justin = new Person({
-						name : "Justin",
-						age  : 45
-					});
-
-					John[0].setParents([ Justin ], function (err) {
-						should.equal(err, null);
-
-						Person.find().hasParents(Justin).all(function (err, people) {
-						    should.equal(err, null);
-
-							should(Array.isArray(people));
-
-							people.length.should.equal(1);
-							people[0].name.should.equal("John");
-
-							return done();
-						});
-					});
-				});
-			});
-		});
-	});
-
-	describe(".eager()", function () {
-		before(setup2());
-
-		// TODO: Remove this code once the Mongo eager loading is implemented
-		var isMongo = function () {
-			if (db.driver.config.protocol == "mongodb:") {
-				(function () {
-					Dog.find().eager("friends").all(function () {
-						// Should not ever run.
-					});
-				}).should.throw();
-
-				return true;
-			}
-			return false;
-		};
-
-		it("should fetch all listed associations in a single query", function (done) {
-			if (isMongo()) { return done(); };
-
-			Dog.find({ name: ["Fido", "Thumper"] }).eager("friends").all(function (err, dogs) {
-				should.equal(err, null);
-
-				should(Array.isArray(dogs));
-
-				dogs.length.should.equal(2);
-
-				dogs[0].friends.length.should.equal(2);
-				dogs[1].friends.length.should.equal(1);
-				done();
-			});
-		});
-
-		it("should be able to handle multiple associations", function (done) {
-			if (isMongo()) { return done(); };
-
-			Dog.find({ name: ["Fido", "Thumper"] }).eager("friends", "family").all(function (err, dogs) {
-				should.equal(err, null);
-
-				should(Array.isArray(dogs));
-
-				dogs.length.should.equal(2);
-
-				dogs[0].friends.length.should.equal(2);
-				dogs[0].family.length.should.equal(1);
-				dogs[1].friends.length.should.equal(1);
-				dogs[1].family.length.should.equal(2);
-				done();
-			});
-		});
-
-		it("should work with array parameters too", function (done) {
-			if (isMongo()) { return done(); };
-
-			Dog.find({ name: ["Fido", "Thumper"] }).eager(["friends", "family"]).all(function (err, dogs) {
-				should.equal(err, null);
-
-				should(Array.isArray(dogs));
-
-				dogs.length.should.equal(2);
-
-				dogs[0].friends.length.should.equal(2);
-				dogs[0].family.length.should.equal(1);
-				dogs[1].friends.length.should.equal(1);
-				dogs[1].family.length.should.equal(2);
-				done();
-			});
-		});
-	});
-
-	describe(".success()", function () {
-		before(setup());
-
-		it("should return a Promise with .fail() method", function (done) {
-			Person.find().success(function (people) {
-				should(Array.isArray(people));
-
-				return done();
-			}).fail(function (err) {
-				// never called..
-			});
-		});
-	});
-
-	describe(".fail()", function () {
-		before(setup());
-
-		it("should return a Promise with .success() method", function (done) {
-			Person.find().fail(function (err) {
-				// never called..
-			}).success(function (people) {
-				should(Array.isArray(people));
-
-				return done();
-			});
-		});
-	});
+  var db = null;
+  var Person = null;
+  var Dog = null;
+
+  var setup = function (extraOpts) {
+    if (!extraOpts) extraOpts = {};
+
+    return function (done) {
+      Person = db.define("person", {
+        name    : String,
+        surname : String,
+        age     : Number
+      }, extraOpts);
+      Person.hasMany("parents");
+      Person.hasOne("friend");
+
+      ORM.singleton.clear(); // clear identityCache cache
+
+      return helper.dropSync(Person, function () {
+        Person.create([{
+          name      : "John",
+          surname   : "Doe",
+          age       : 18,
+          friend_id : 1
+        }, {
+          name      : "Jane",
+          surname   : "Doe",
+          age       : 20,
+          friend_id : 1
+        }, {
+          name      : "Jane",
+          surname   : "Dean",
+          age       : 18,
+          friend_id : 1
+        }], done);
+      });
+    };
+  };
+
+  var setup2 = function () {
+    return function (done) {
+      Dog = db.define("dog", {
+        name: String,
+      });
+      Dog.hasMany("friends");
+      Dog.hasMany("family");
+
+      ORM.singleton.clear(); // clear identityCache cache
+
+      return helper.dropSync(Dog, function () {
+        Dog.create([{
+          name    : "Fido",
+          friends : [{ name: "Gunner" }, { name: "Chainsaw" }],
+          family  : [{ name: "Chester" }]
+        }, {
+          name    : "Thumper",
+          friends : [{ name: "Bambi" }],
+          family  : [{ name: "Princess" }, { name: "Butch" }]
+        }], done);
+      });
+    };
+  };
+
+  before(function (done) {
+    helper.connect(function (connection) {
+      db = connection;
+
+      return done();
+    });
+  });
+
+  after(function () {
+    return db.close();
+  });
+
+  describe(".limit(N)", function () {
+    before(setup());
+
+    it("should limit results to N items", function (done) {
+      Person.find().limit(2).run(function (err, instances) {
+        should.equal(err, null);
+        instances.should.have.property("length", 2);
+
+        return done();
+      });
+    });
+  });
+
+  describe(".skip(N)", function () {
+    before(setup());
+
+    it("should skip the first N results", function (done) {
+      Person.find().skip(2).order("age").run(function (err, instances) {
+        should.equal(err, null);
+        instances.should.have.property("length", 1);
+        instances[0].age.should.equal(20);
+
+        return done();
+      });
+    });
+  });
+
+  describe(".offset(N)", function () {
+    before(setup());
+
+    it("should skip the first N results", function (done) {
+      Person.find().offset(2).order("age").run(function (err, instances) {
+        should.equal(err, null);
+        instances.should.have.property("length", 1);
+        instances[0].age.should.equal(20);
+
+        return done();
+      });
+    });
+  });
+
+  describe("order", function () {
+    before(setup());
+
+    it("('property') should order by that property ascending", function (done) {
+      Person.find().order("age").run(function (err, instances) {
+        should.equal(err, null);
+        instances.should.have.property("length", 3);
+        instances[0].age.should.equal(18);
+        instances[2].age.should.equal(20);
+
+        return done();
+      });
+    });
+
+    it("('-property') should order by that property descending", function (done) {
+      Person.find().order("-age").run(function (err, instances) {
+        should.equal(err, null);
+        instances.should.have.property("length", 3);
+        instances[0].age.should.equal(20);
+        instances[2].age.should.equal(18);
+
+        return done();
+      });
+    });
+
+    it("('property', 'Z') should order by that property descending", function (done) {
+      Person.find().order("age", "Z").run(function (err, instances) {
+        should.equal(err, null);
+        instances.should.have.property("length", 3);
+        instances[0].age.should.equal(20);
+        instances[2].age.should.equal(18);
+
+        return done();
+      });
+    });
+  });
+
+  describe("orderRaw", function () {
+    if (common.protocol() == 'mongodb') return;
+
+    before(setup());
+
+    it("should allow ordering by SQL", function (done) {
+      Person.find().orderRaw("age DESC").run(function (err, instances) {
+        should.equal(err, null);
+        instances.should.have.property("length", 3);
+        instances[0].age.should.equal(20);
+        instances[2].age.should.equal(18);
+
+        return done();
+      });
+    });
+
+    it("should allow ordering by SQL with escaping", function (done) {
+      Person.find().orderRaw("?? DESC", ['age']).run(function (err, instances) {
+        should.equal(err, null);
+        instances.should.have.property("length", 3);
+        instances[0].age.should.equal(20);
+        instances[2].age.should.equal(18);
+
+        return done();
+      });
+    });
+  });
+
+  describe("only", function () {
+    before(setup());
+
+    it("('property', ...) should return only those properties, others null", function (done) {
+      Person.find().only("age", "surname").order("-age").run(function (err, instances) {
+        should.equal(err, null);
+        instances.should.have.property("length", 3);
+        instances[0].should.have.property("age");
+        instances[0].should.have.property("surname", "Doe");
+        instances[0].should.have.property("name", null);
+
+        return done();
+      });
+    });
+
+    // This works if cache is disabled. I suspect a cache bug.
+    xit("(['property', ...]) should return only those properties, others null", function (done) {
+      Person.find().only([ "age", "surname" ]).order("-age").run(function (err, instances) {
+        should.equal(err, null);
+        instances.should.have.property("length", 3);
+        instances[0].should.have.property("age");
+        instances[0].should.have.property("surname", "Doe");
+        instances[0].should.have.property("name", null);
+
+        return done();
+      });
+    });
+  });
+
+  describe("omit", function () {
+    before(setup());
+
+    it("('property', ...) should not get these properties", function (done) {
+      Person.find().omit("age", "surname").order("-age").run(function (err, instances) {
+        should.equal(err, null);
+        instances.should.have.property("length", 3);
+        if (common.protocol() != "mongodb") {
+          should.exist(instances[0].id);
+        }
+        should.exist(instances[0].friend_id);
+        instances[0].should.have.property("age", null);
+        instances[0].should.have.property("surname", null);
+        instances[0].should.have.property("name", "Jane");
+
+        return done();
+      });
+    });
+
+    it("(['property', ...]) should not get these properties", function (done) {
+      Person.find().omit(["age", "surname"]).order("-age").run(function (err, instances) {
+        should.equal(err, null);
+        instances.should.have.property("length", 3);
+        instances[0].should.have.property("age", null);
+        instances[0].should.have.property("surname", null);
+        instances[0].should.have.property("name", "Jane");
+
+        return done();
+      });
+    });
+  });
+
+  describe(".count()", function () {
+    before(setup());
+
+    it("should return only the total number of results", function (done) {
+      Person.find().count(function (err, count) {
+        should.equal(err, null);
+        count.should.equal(3);
+
+        return done();
+      });
+    });
+  });
+
+  describe(".first()", function () {
+    before(setup());
+
+    it("should return only the first element", function (done) {
+      Person.find().order("-age").first(function (err, JaneDoe) {
+        should.equal(err, null);
+
+        JaneDoe.name.should.equal("Jane");
+        JaneDoe.surname.should.equal("Doe");
+        JaneDoe.age.should.equal(20);
+
+        return done();
+      });
+    });
+
+    it("should return null if not found", function (done) {
+      Person.find({ name: "Jack" }).first(function (err, Jack) {
+        should.equal(err, null);
+        should.equal(Jack, null);
+
+        return done();
+      });
+    });
+  });
+
+  describe(".last()", function () {
+    before(setup());
+
+    it("should return only the last element", function (done) {
+      Person.find().order("age").last(function (err, JaneDoe) {
+        should.equal(err, null);
+
+        JaneDoe.name.should.equal("Jane");
+        JaneDoe.surname.should.equal("Doe");
+        JaneDoe.age.should.equal(20);
+
+        return done();
+      });
+    });
+
+    it("should return null if not found", function (done) {
+      Person.find({ name: "Jack" }).last(function (err, Jack) {
+        should.equal(err, null);
+        should.equal(Jack, null);
+
+        return done();
+      });
+    });
+  });
+
+  describe(".find()", function () {
+    before(setup());
+
+    it("should not change find if no arguments", function (done) {
+      Person.find().find().count(function (err, count) {
+        should.equal(err, null);
+        count.should.equal(3);
+
+        return done();
+      });
+    });
+
+    it("should restrict conditions if passed", function (done) {
+      Person.find().find({ age: 18 }).count(function (err, count) {
+        should.equal(err, null);
+        count.should.equal(2);
+
+        return done();
+      });
+    });
+
+    it("should restrict conditions if passed and also be chainable", function (done) {
+      Person.find().find({ age: 18 }).find({ name: "Jane" }).count(function (err, count) {
+        should.equal(err, null);
+        count.should.equal(1);
+
+        return done();
+      });
+    });
+
+    it("should return results if passed a callback as second argument", function (done) {
+      Person.find().find({ age: 18 }, function (err, instances) {
+        should.equal(err, null);
+        instances.should.have.property("length", 2);
+
+        return done();
+      });
+    });
+
+    if (common.protocol() == "mongodb") return;
+
+    it("should allow sql where conditions", function (done) {
+      Person.find({ age: 18 }).where("LOWER(surname) LIKE 'dea%'").all(function (err, items) {
+        should.equal(err, null);
+        items.length.should.equal(1);
+
+        return done();
+      });
+    });
+
+    it("should allow sql where conditions with auto escaping", function (done) {
+      Person.find({ age: 18 }).where("LOWER(surname) LIKE ?", ['dea%']).all(function (err, items) {
+        should.equal(err, null);
+        items.length.should.equal(1);
+
+        return done();
+      });
+    });
+
+    it("should append sql where conditions", function (done) {
+      Person.find().where("LOWER(surname) LIKE ?", ['do%']).all(function (err, items) {
+        should.equal(err, null);
+        items.length.should.equal(2);
+
+        Person.find().where("LOWER(name) LIKE ?", ['jane']).all(function (err, items) {
+          should.equal(err, null);
+          items.length.should.equal(2);
+
+          Person.find().where("LOWER(surname) LIKE ?", ['do%']).where("LOWER(name) LIKE ?", ['jane']).all(function (err, items) {
+            should.equal(err, null);
+            items.length.should.equal(1);
+
+            return done();
+          });
+        });
+      });
+    });
+  });
+
+  describe("finders should be chainable & interchangeable including", function () {
+    before(setup());
+
+    before(function (done) {
+      Person.create([
+          { name: "Mel", surname: "Gabbs", age: 12 },
+          { name: "Mel", surname: "Gibbs", age: 22 },
+          { name: "Mel", surname: "Gobbs", age: 32 }
+        ], function (err, items) {
+          should.not.exist(err);
+          done()
+        }
+      );
+    });
+
+    ['find', 'where', 'all'].forEach(function (func) {
+      it("." + func + "()", function (done) {
+        Person[func]({ name: "Mel" })[func]({ age: ORM.gt(20) })[func](function (err, items) {
+          should.not.exist(err);
+          should.equal(items.length, 2);
+
+          should.equal(items[0].surname, "Gibbs");
+          should.equal(items[1].surname, "Gobbs");
+          done();
+        });
+      });
+    });
+
+    it("a mix", function (done) {
+      Person.all({ name: "Mel" }).where({ age: ORM.gt(20) }).find(function (err, items) {
+        should.not.exist(err);
+        should.equal(items.length, 2);
+
+        should.equal(items[0].surname, "Gibbs");
+        should.equal(items[1].surname, "Gobbs");
+        done();
+      });
+    });
+  });
+
+  describe(".each()", function () {
+    before(setup());
+
+    it("should return a ChainInstance", function (done) {
+      var chain = Person.find().each();
+
+      chain.filter.should.be.a.Function();
+      chain.sort.should.be.a.Function();
+      chain.count.should.be.a.Function();
+
+      return done();
+    });
+  });
+
+  describe(".remove()", function () {
+    var hookFired = false;
+
+    before(setup({
+      hooks: {
+        beforeRemove: function () {
+          hookFired = true;
+        }
+      }
+    }));
+
+    it("should have no problems if no results found", function (done) {
+      Person.find({ age: 22 }).remove(function (err) {
+        should.equal(err, null);
+
+        Person.find().count(function (err, count) {
+          should.equal(err, null);
+
+          count.should.equal(3);
+
+          return done();
+        });
+      });
+    });
+
+    it("should remove results without calling hooks", function (done) {
+      Person.find({ age: 20 }).remove(function (err) {
+        should.equal(err, null);
+        should.equal(hookFired, false);
+
+        Person.find().count(function (err, count) {
+          should.equal(err, null);
+
+          count.should.equal(2);
+
+          return done();
+        });
+      });
+    });
+
+  });
+
+  describe(".each()", function () {
+    var hookFired = false;
+
+    before(setup({
+      hooks: {
+        beforeRemove: function () {
+          hookFired = true;
+        }
+      }
+    }));
+
+    it("should return a ChainFind", function (done) {
+      var chain = Person.find({ age: 22 }).each();
+
+      chain.should.be.a.Object();
+      chain.filter.should.be.a.Function();
+      chain.sort.should.be.a.Function();
+      chain.count.should.be.a.Function();
+      chain.get.should.be.a.Function();
+      chain.save.should.be.a.Function();
+
+      return done();
+    });
+
+    describe(".count()", function () {
+      it("should return the total filtered items", function (done) {
+        Person.find().each().filter(function (person) {
+          return (person.age > 18);
+        }).count(function (count) {
+          count.should.equal(1);
+
+          return done();
+        });
+      });
+    });
+
+    describe(".sort()", function () {
+      it("should return the items sorted using the sorted function", function (done) {
+        Person.find().each().sort(function (first, second) {
+          return (first.age < second.age);
+        }).get(function (people) {
+          should(Array.isArray(people));
+
+          people.length.should.equal(3);
+          people[0].age.should.equal(20);
+          people[2].age.should.equal(18);
+
+          return done();
+        });
+      });
+    });
+
+    describe(".save()", function () {
+      it("should save items after changes", function (done) {
+        Person.find({ surname: "Dean" }).each(function (person) {
+          person.age.should.not.equal(45);
+          person.age = 45;
+        }).save(function () {
+          Person.find({ surname: "Dean" }, function (err, people) {
+            should(Array.isArray(people));
+
+            people.length.should.equal(1);
+            people[0].age.should.equal(45);
+
+            return done();
+          });
+        });
+      });
+    });
+
+    describe("if passing a callback", function () {
+      it("should use it to .forEach()", function (done) {
+        Person.find({ surname: "Dean" }).each(function (person) {
+          person.fullName = person.name + " " + person.surname;
+        }).get(function (people) {
+          should(Array.isArray(people));
+
+          people.length.should.equal(1);
+          people[0].fullName = "Jane Dean";
+
+          return done();
+        });
+      });
+    });
+
+    // TODO: Implement
+    xit(".remove() should call hooks", function () {
+      Person.find().each().remove(function (err) {
+        should.not.exist(err);
+        should.equal(hookFired, true);
+      });
+    });
+
+    if (common.protocol() == "mongodb") return;
+
+    describe(".hasAccessor() for hasOne associations", function () {
+        it("should be chainable", function (done) {
+        Person.find({ name: "John" }, function (err, John) {
+          should.equal(err, null);
+
+          var Justin = new Person({
+            name : "Justin",
+            age  : 45
+          });
+
+          John[0].setParents([ Justin ], function (err) {
+            should.equal(err, null);
+
+            Person.find().hasParents(Justin).all(function (err, people) {
+                should.equal(err, null);
+
+              should(Array.isArray(people));
+
+              people.length.should.equal(1);
+              people[0].name.should.equal("John");
+
+              return done();
+            });
+          });
+        });
+      });
+    });
+  });
+
+  describe(".eager()", function () {
+    before(setup2());
+
+    // TODO: Remove this code once the Mongo eager loading is implemented
+    var isMongo = function () {
+      if (db.driver.config.protocol == "mongodb:") {
+        (function () {
+          Dog.find().eager("friends").all(function () {
+            // Should not ever run.
+          });
+        }).should.throw();
+
+        return true;
+      }
+      return false;
+    };
+
+    it("should fetch all listed associations in a single query", function (done) {
+      if (isMongo()) { return done(); };
+
+      Dog.find({ name: ["Fido", "Thumper"] }).eager("friends").all(function (err, dogs) {
+        should.equal(err, null);
+
+        should(Array.isArray(dogs));
+
+        dogs.length.should.equal(2);
+
+        dogs[0].friends.length.should.equal(2);
+        dogs[1].friends.length.should.equal(1);
+        done();
+      });
+    });
+
+    it("should be able to handle multiple associations", function (done) {
+      if (isMongo()) { return done(); };
+
+      Dog.find({ name: ["Fido", "Thumper"] }).eager("friends", "family").all(function (err, dogs) {
+        should.equal(err, null);
+
+        should(Array.isArray(dogs));
+
+        dogs.length.should.equal(2);
+
+        dogs[0].friends.length.should.equal(2);
+        dogs[0].family.length.should.equal(1);
+        dogs[1].friends.length.should.equal(1);
+        dogs[1].family.length.should.equal(2);
+        done();
+      });
+    });
+
+    it("should work with array parameters too", function (done) {
+      if (isMongo()) { return done(); };
+
+      Dog.find({ name: ["Fido", "Thumper"] }).eager(["friends", "family"]).all(function (err, dogs) {
+        should.equal(err, null);
+
+        should(Array.isArray(dogs));
+
+        dogs.length.should.equal(2);
+
+        dogs[0].friends.length.should.equal(2);
+        dogs[0].family.length.should.equal(1);
+        dogs[1].friends.length.should.equal(1);
+        dogs[1].family.length.should.equal(2);
+        done();
+      });
+    });
+  });
+
+  describe(".success()", function () {
+    before(setup());
+
+    it("should return a Promise with .fail() method", function (done) {
+      Person.find().success(function (people) {
+        should(Array.isArray(people));
+
+        return done();
+      }).fail(function (err) {
+        // never called..
+      });
+    });
+  });
+
+  describe(".fail()", function () {
+    before(setup());
+
+    it("should return a Promise with .success() method", function (done) {
+      Person.find().fail(function (err) {
+        // never called..
+      }).success(function (people) {
+        should(Array.isArray(people));
+
+        return done();
+      });
+    });
+  });
 });

--- a/test/integration/model-find-mapsto.js
+++ b/test/integration/model-find-mapsto.js
@@ -3,96 +3,96 @@ var helper   = require('../support/spec_helper');
 var ORM      = require('../../');
 
 describe("Model.pkMapTo.find()", function() {
-	var db = null;
-	var Person = null;
+  var db = null;
+  var Person = null;
 
-	var setup = function () {
-		return function (done) {
+  var setup = function () {
+    return function (done) {
 
-			// The fact that we've applied mapsTo to the key
-			// property of the model - will break the cache.
+      // The fact that we've applied mapsTo to the key
+      // property of the model - will break the cache.
 
-			// Without Stuart's little bugfix, 2nd (and subsequent) calls to find()
-			// will return the repeats of the first obect retrieved and placed in the cache.
-			Person = db.define("person", {
-				personId : {type : "integer", key: true,   mapsTo: "id"},
-				name     : String,
-				surname  : String,
-				age      : Number,
-				male     : Boolean
-			});
+      // Without Stuart's little bugfix, 2nd (and subsequent) calls to find()
+      // will return the repeats of the first obect retrieved and placed in the cache.
+      Person = db.define("person", {
+        personId : {type : "integer", key: true,   mapsTo: "id"},
+        name     : String,
+        surname  : String,
+        age      : Number,
+        male     : Boolean
+      });
 
-			return helper.dropSync(Person, function () {
-				Person.create([{
-					personId: 1001,
-					name    : "John",
-					surname : "Doe",
-					age     : 18,
-					male    : true
-				}, {
-					personId: 1002,
-					name    : "Jane",
-					surname : "Doe",
-					age     : 16,
-					male    : false
-				}, {
-					personId: 1003,
-					name    : "Jeremy",
-					surname : "Dean",
-					age     : 18,
-					male    : true
-				}, {
-					personId: 1004,
-					name    : "Jack",
-					surname : "Dean",
-					age     : 20,
-					male    : true
-				}, {
-					personId: 1005,
-					name    : "Jasmine",
-					surname : "Doe",
-					age     : 20,
-					male    : false
-				}], done);
-			});
-		};
-	};
+      return helper.dropSync(Person, function () {
+        Person.create([{
+          personId: 1001,
+          name    : "John",
+          surname : "Doe",
+          age     : 18,
+          male    : true
+        }, {
+          personId: 1002,
+          name    : "Jane",
+          surname : "Doe",
+          age     : 16,
+          male    : false
+        }, {
+          personId: 1003,
+          name    : "Jeremy",
+          surname : "Dean",
+          age     : 18,
+          male    : true
+        }, {
+          personId: 1004,
+          name    : "Jack",
+          surname : "Dean",
+          age     : 20,
+          male    : true
+        }, {
+          personId: 1005,
+          name    : "Jasmine",
+          surname : "Doe",
+          age     : 20,
+          male    : false
+        }], done);
+      });
+    };
+  };
 
-	before(function (done) {
-		helper.connect(function (connection) {
-			db = connection;
+  before(function (done) {
+    helper.connect(function (connection) {
+      db = connection;
 
-			return done();
-		});
-	});
+      return done();
+    });
+  });
 
-	after(function () {
-		return db.close();
-	});
+  after(function () {
+    return db.close();
+  });
 
 
-	describe("Cache should work with mapped key field", function () {
-		before(setup());
+  describe("Cache should work with mapped key field", function () {
+    before(setup());
 
-		it("1st find should work", function (done) {
-			Person.find({ surname: "Dean" }, function (err, people) {
-				should.not.exist(err);
-				people.should.be.a.Object();
-				people.should.have.property("length", 2);
-				people[0].surname.should.equal("Dean");
+    it("1st find should work", function (done) {
+      Person.find({ surname: "Dean" }, function (err, people) {
+        should.not.exist(err);
+        people.should.be.a.Object();
+        people.should.have.property("length", 2);
+        people[0].surname.should.equal("Dean");
 
-				return done();
-			});
-		});
-		it("2nd find should should also work", function (done) {
-			Person.find({ surname: "Doe" }, function (err, people) {
-				should.not.exist(err);
-				people.should.be.a.Object();
-				people.should.have.property("length", 3);
-				people[0].surname.should.equal("Doe");
+        return done();
+      });
+    });
+    it("2nd find should should also work", function (done) {
+      Person.find({ surname: "Doe" }, function (err, people) {
+        should.not.exist(err);
+        people.should.be.a.Object();
+        people.should.have.property("length", 3);
+        people[0].surname.should.equal("Doe");
 
-				return done();
-			});
-		});
-	});
+        return done();
+      });
+    });
+  });
 });

--- a/test/integration/model-find.js
+++ b/test/integration/model-find.js
@@ -3,351 +3,351 @@ var helper   = require('../support/spec_helper');
 var ORM      = require('../../');
 
 describe("Model.find()", function() {
-	var db = null;
-	var Person = null;
+  var db = null;
+  var Person = null;
 
-	var setup = function () {
-		return function (done) {
-			Person = db.define("person", {
-				name    : String,
-				surname : String,
-				age     : Number,
-				male    : Boolean
-			});
+  var setup = function () {
+    return function (done) {
+      Person = db.define("person", {
+        name    : String,
+        surname : String,
+        age     : Number,
+        male    : Boolean
+      });
 
-			return helper.dropSync(Person, function () {
-				Person.create([{
-					name    : "John",
-					surname : "Doe",
-					age     : 18,
-					male    : true
-				}, {
-					name    : "Jane",
-					surname : "Doe",
-					age     : 16,
-					male    : false
-				}, {
-					name    : "Jeremy",
-					surname : "Dean",
-					age     : 18,
-					male    : true
-				}, {
-					name    : "Jack",
-					surname : "Dean",
-					age     : 20,
-					male    : true
-				}, {
-					name    : "Jasmine",
-					surname : "Doe",
-					age     : 20,
-					male    : false
-				}], done);
-			});
-		};
-	};
+      return helper.dropSync(Person, function () {
+        Person.create([{
+          name    : "John",
+          surname : "Doe",
+          age     : 18,
+          male    : true
+        }, {
+          name    : "Jane",
+          surname : "Doe",
+          age     : 16,
+          male    : false
+        }, {
+          name    : "Jeremy",
+          surname : "Dean",
+          age     : 18,
+          male    : true
+        }, {
+          name    : "Jack",
+          surname : "Dean",
+          age     : 20,
+          male    : true
+        }, {
+          name    : "Jasmine",
+          surname : "Doe",
+          age     : 20,
+          male    : false
+        }], done);
+      });
+    };
+  };
 
-	before(function (done) {
-		helper.connect(function (connection) {
-			db = connection;
+  before(function (done) {
+    helper.connect(function (connection) {
+      db = connection;
 
-			return done();
-		});
-	});
+      return done();
+    });
+  });
 
-	after(function () {
-		return db.close();
-	});
+  after(function () {
+    return db.close();
+  });
 
-	describe("without arguments", function () {
-		before(setup());
+  describe("without arguments", function () {
+    before(setup());
 
-		it("should return all items", function (done) {
-			Person.find(function (err, people) {
-				should.not.exist(err);
-				people.should.be.a.Object();
-				people.should.have.property("length", 5);
+    it("should return all items", function (done) {
+      Person.find(function (err, people) {
+        should.not.exist(err);
+        people.should.be.a.Object();
+        people.should.have.property("length", 5);
 
-				return done();
-			});
-		});
-	});
+        return done();
+      });
+    });
+  });
 
-	describe("with a number as argument", function () {
-		before(setup());
+  describe("with a number as argument", function () {
+    before(setup());
 
-		it("should use it as limit", function (done) {
-			Person.find(2, function (err, people) {
-				should.not.exist(err);
-				people.should.be.a.Object();
-				people.should.have.property("length", 2);
+    it("should use it as limit", function (done) {
+      Person.find(2, function (err, people) {
+        should.not.exist(err);
+        people.should.be.a.Object();
+        people.should.have.property("length", 2);
 
-				return done();
-			});
-		});
-	});
+        return done();
+      });
+    });
+  });
 
-	describe("with a string argument", function () {
-		before(setup());
+  describe("with a string argument", function () {
+    before(setup());
 
-		it("should use it as property ascending order", function (done) {
-			Person.find("age", function (err, people) {
-				should.not.exist(err);
-				people.should.be.a.Object();
-				people.should.have.property("length", 5);
-				people[0].age.should.equal(16);
-				people[4].age.should.equal(20);
+    it("should use it as property ascending order", function (done) {
+      Person.find("age", function (err, people) {
+        should.not.exist(err);
+        people.should.be.a.Object();
+        people.should.have.property("length", 5);
+        people[0].age.should.equal(16);
+        people[4].age.should.equal(20);
 
-				return done();
-			});
-		});
+        return done();
+      });
+    });
 
-		it("should use it as property descending order if starting with '-'", function (done) {
-			Person.find("-age", function (err, people) {
-				should.not.exist(err);
-				people.should.be.a.Object();
-				people.should.have.property("length", 5);
-				people[0].age.should.equal(20);
-				people[4].age.should.equal(16);
+    it("should use it as property descending order if starting with '-'", function (done) {
+      Person.find("-age", function (err, people) {
+        should.not.exist(err);
+        people.should.be.a.Object();
+        people.should.have.property("length", 5);
+        people[0].age.should.equal(20);
+        people[4].age.should.equal(16);
 
-				return done();
-			});
-		});
-	});
+        return done();
+      });
+    });
+  });
 
-	describe("with an Array as argument", function () {
-		before(setup());
+  describe("with an Array as argument", function () {
+    before(setup());
 
-		it("should use it as property ascending order", function (done) {
-			Person.find([ "age" ], function (err, people) {
-				should.not.exist(err);
-				people.should.be.a.Object();
-				people.should.have.property("length", 5);
-				people[0].age.should.equal(16);
-				people[4].age.should.equal(20);
+    it("should use it as property ascending order", function (done) {
+      Person.find([ "age" ], function (err, people) {
+        should.not.exist(err);
+        people.should.be.a.Object();
+        people.should.have.property("length", 5);
+        people[0].age.should.equal(16);
+        people[4].age.should.equal(20);
 
-				return done();
-			});
-		});
+        return done();
+      });
+    });
 
-		it("should use it as property descending order if starting with '-'", function (done) {
-			Person.find([ "-age" ], function (err, people) {
-				should.not.exist(err);
-				people.should.be.a.Object();
-				people.should.have.property("length", 5);
-				people[0].age.should.equal(20);
-				people[4].age.should.equal(16);
+    it("should use it as property descending order if starting with '-'", function (done) {
+      Person.find([ "-age" ], function (err, people) {
+        should.not.exist(err);
+        people.should.be.a.Object();
+        people.should.have.property("length", 5);
+        people[0].age.should.equal(20);
+        people[4].age.should.equal(16);
 
-				return done();
-			});
-		});
+        return done();
+      });
+    });
 
-		it("should use it as property descending order if element is 'Z'", function (done) {
-			Person.find([ "age", "Z" ], function (err, people) {
-				should.not.exist(err);
-				people.should.be.a.Object();
-				people.should.have.property("length", 5);
-				people[0].age.should.equal(20);
-				people[4].age.should.equal(16);
+    it("should use it as property descending order if element is 'Z'", function (done) {
+      Person.find([ "age", "Z" ], function (err, people) {
+        should.not.exist(err);
+        people.should.be.a.Object();
+        people.should.have.property("length", 5);
+        people[0].age.should.equal(20);
+        people[4].age.should.equal(16);
 
-				return done();
-			});
-		});
+        return done();
+      });
+    });
 
-		it("should accept multiple ordering", function (done) {
-			Person.find([ "age", "name", "Z" ], function (err, people) {
-				should.not.exist(err);
-				people.should.be.a.Object();
-				people.should.have.property("length", 5);
-				people[0].age.should.equal(16);
-				people[4].age.should.equal(20);
+    it("should accept multiple ordering", function (done) {
+      Person.find([ "age", "name", "Z" ], function (err, people) {
+        should.not.exist(err);
+        people.should.be.a.Object();
+        people.should.have.property("length", 5);
+        people[0].age.should.equal(16);
+        people[4].age.should.equal(20);
 
-				return done();
-			});
-		});
+        return done();
+      });
+    });
 
-		it("should accept multiple ordering using '-' instead of 'Z'", function (done) {
-			Person.find([ "age", "-name" ], function (err, people) {
-				should.not.exist(err);
-				people.should.be.a.Object();
-				people.should.have.property("length", 5);
-				people[0].age.should.equal(16);
-				people[4].age.should.equal(20);
+    it("should accept multiple ordering using '-' instead of 'Z'", function (done) {
+      Person.find([ "age", "-name" ], function (err, people) {
+        should.not.exist(err);
+        people.should.be.a.Object();
+        people.should.have.property("length", 5);
+        people[0].age.should.equal(16);
+        people[4].age.should.equal(20);
 
-				return done();
-			});
-		});
-	});
+        return done();
+      });
+    });
+  });
 
-	describe("with an Object as argument", function () {
-		before(setup());
+  describe("with an Object as argument", function () {
+    before(setup());
 
-		it("should use it as conditions", function (done) {
-			Person.find({ age: 16 }, function (err, people) {
-				should.not.exist(err);
-				people.should.be.a.Object();
-				people.should.have.property("length", 1);
-				people[0].age.should.equal(16);
+    it("should use it as conditions", function (done) {
+      Person.find({ age: 16 }, function (err, people) {
+        should.not.exist(err);
+        people.should.be.a.Object();
+        people.should.have.property("length", 1);
+        people[0].age.should.equal(16);
 
-				return done();
-			});
-		});
+        return done();
+      });
+    });
 
-		it("should accept comparison objects", function (done) {
-			Person.find({ age: ORM.gt(18) }, function (err, people) {
-				should.not.exist(err);
-				people.should.be.a.Object();
-				people.should.have.property("length", 2);
-				people[0].age.should.equal(20);
-				people[1].age.should.equal(20);
+    it("should accept comparison objects", function (done) {
+      Person.find({ age: ORM.gt(18) }, function (err, people) {
+        should.not.exist(err);
+        people.should.be.a.Object();
+        people.should.have.property("length", 2);
+        people[0].age.should.equal(20);
+        people[1].age.should.equal(20);
 
-				return done();
-			});
-		});
+        return done();
+      });
+    });
 
-		describe("with another Object as argument", function () {
-			before(setup());
+    describe("with another Object as argument", function () {
+      before(setup());
 
-			it("should use it as options", function (done) {
-				Person.find({ age: 18 }, 1, { cache: false }, function (err, people) {
-					should.not.exist(err);
-					people.should.be.a.Object();
-					people.should.have.property("length", 1);
-					people[0].age.should.equal(18);
+      it("should use it as options", function (done) {
+        Person.find({ age: 18 }, 1, { cache: false }, function (err, people) {
+          should.not.exist(err);
+          people.should.be.a.Object();
+          people.should.have.property("length", 1);
+          people[0].age.should.equal(18);
 
-					return done();
-				});
-			});
+          return done();
+        });
+      });
 
-			describe("if a limit is passed", function () {
-				before(setup());
+      describe("if a limit is passed", function () {
+        before(setup());
 
-				it("should use it", function (done) {
-					Person.find({ age: 18 }, { limit: 1 }, function (err, people) {
-						should.not.exist(err);
-						people.should.be.a.Object();
-						people.should.have.property("length", 1);
-						people[0].age.should.equal(18);
+        it("should use it", function (done) {
+          Person.find({ age: 18 }, { limit: 1 }, function (err, people) {
+            should.not.exist(err);
+            people.should.be.a.Object();
+            people.should.have.property("length", 1);
+            people[0].age.should.equal(18);
 
-						return done();
-					});
-				});
-			});
+            return done();
+          });
+        });
+      });
 
-			describe("if an offset is passed", function () {
-				before(setup());
+      describe("if an offset is passed", function () {
+        before(setup());
 
-				it("should use it", function (done) {
-					Person.find({}, { offset: 1 }, "age", function (err, people) {
-						should.not.exist(err);
-						people.should.be.a.Object();
-						people.should.have.property("length", 4);
-						people[0].age.should.equal(18);
+        it("should use it", function (done) {
+          Person.find({}, { offset: 1 }, "age", function (err, people) {
+            should.not.exist(err);
+            people.should.be.a.Object();
+            people.should.have.property("length", 4);
+            people[0].age.should.equal(18);
 
-						return done();
-					});
-				});
-			});
+            return done();
+          });
+        });
+      });
 
-			describe("if an order is passed", function () {
-				before(setup());
+      describe("if an order is passed", function () {
+        before(setup());
 
-				it("should use it", function (done) {
-					Person.find({ surname: "Doe" }, { order: "age" }, function (err, people) {
-						should.not.exist(err);
-						people.should.be.a.Object();
-						people.should.have.property("length", 3);
-						people[0].age.should.equal(16);
+        it("should use it", function (done) {
+          Person.find({ surname: "Doe" }, { order: "age" }, function (err, people) {
+            should.not.exist(err);
+            people.should.be.a.Object();
+            people.should.have.property("length", 3);
+            people[0].age.should.equal(16);
 
-						return done();
-					});
-				});
+            return done();
+          });
+        });
 
-				it("should use it and ignore previously defined order", function (done) {
-					Person.find({ surname: "Doe" }, "-age", { order: "age" }, function (err, people) {
-						should.not.exist(err);
-						people.should.be.a.Object();
-						people.should.have.property("length", 3);
-						people[0].age.should.equal(16);
+        it("should use it and ignore previously defined order", function (done) {
+          Person.find({ surname: "Doe" }, "-age", { order: "age" }, function (err, people) {
+            should.not.exist(err);
+            people.should.be.a.Object();
+            people.should.have.property("length", 3);
+            people[0].age.should.equal(16);
 
-						return done();
-					});
-				});
-			});
-		});
-	});
+            return done();
+          });
+        });
+      });
+    });
+  });
 
-	describe("if defined static methods", function () {
-		before(setup());
+  describe("if defined static methods", function () {
+    before(setup());
 
-		it("should be rechainable", function (done) {
-			Person.over18 = function () {
-				return this.find({ age: ORM.gt(18) });
-			};
-			Person.family = function (family) {
-				return this.find({ surname: family });
-			};
+    it("should be rechainable", function (done) {
+      Person.over18 = function () {
+        return this.find({ age: ORM.gt(18) });
+      };
+      Person.family = function (family) {
+        return this.find({ surname: family });
+      };
 
-			Person.over18().family("Doe").run(function (err, people) {
-				should.not.exist(err);
-				people.should.be.a.Object();
-				people.should.have.property("length", 1);
-				people[0].name.should.equal("Jasmine");
-				people[0].surname.should.equal("Doe");
+      Person.over18().family("Doe").run(function (err, people) {
+        should.not.exist(err);
+        people.should.be.a.Object();
+        people.should.have.property("length", 1);
+        people[0].name.should.equal("Jasmine");
+        people[0].surname.should.equal("Doe");
 
-				return done();
-			});
-		});
-	});
+        return done();
+      });
+    });
+  });
 
-	describe("with identityCache disabled", function () {
-		it("should not return singletons", function (done) {
-			Person.find({ name: "Jasmine" }, { identityCache: false }, function (err, people) {
-				should.not.exist(err);
-				people.should.be.a.Object();
-				people.should.have.property("length", 1);
-				people[0].name.should.equal("Jasmine");
-				people[0].surname.should.equal("Doe");
+  describe("with identityCache disabled", function () {
+    it("should not return singletons", function (done) {
+      Person.find({ name: "Jasmine" }, { identityCache: false }, function (err, people) {
+        should.not.exist(err);
+        people.should.be.a.Object();
+        people.should.have.property("length", 1);
+        people[0].name.should.equal("Jasmine");
+        people[0].surname.should.equal("Doe");
 
-				people[0].surname = "Dux";
+        people[0].surname = "Dux";
 
-				Person.find({ name: "Jasmine" }, { identityCache: false }, function (err, people) {
-					should.not.exist(err);
-					people.should.be.a.Object();
-					people.should.have.property("length", 1);
-					people[0].name.should.equal("Jasmine");
-					people[0].surname.should.equal("Doe");
+        Person.find({ name: "Jasmine" }, { identityCache: false }, function (err, people) {
+          should.not.exist(err);
+          people.should.be.a.Object();
+          people.should.have.property("length", 1);
+          people[0].name.should.equal("Jasmine");
+          people[0].surname.should.equal("Doe");
 
-					return done();
-				});
-			});
-		});
-	});
+          return done();
+        });
+      });
+    });
+  });
 
-	describe("when using Model.all()", function () {
-		it("should work exactly the same", function (done) {
-			Person.all({ surname: "Doe" }, "-age", 1, function (err, people) {
-				should.not.exist(err);
-				people.should.be.a.Object();
-				people.should.have.property("length", 1);
-				people[0].name.should.equal("Jasmine");
-				people[0].surname.should.equal("Doe");
+  describe("when using Model.all()", function () {
+    it("should work exactly the same", function (done) {
+      Person.all({ surname: "Doe" }, "-age", 1, function (err, people) {
+        should.not.exist(err);
+        people.should.be.a.Object();
+        people.should.have.property("length", 1);
+        people[0].name.should.equal("Jasmine");
+        people[0].surname.should.equal("Doe");
 
-				return done();
-			});
-		});
-	});
+        return done();
+      });
+    });
+  });
 
-	describe("when using Model.where()", function () {
-		it("should work exactly the same", function (done) {
-			Person.where({ surname: "Doe" }, "-age", 1, function (err, people) {
-				should.not.exist(err);
-				people.should.be.a.Object();
-				people.should.have.property("length", 1);
-				people[0].name.should.equal("Jasmine");
-				people[0].surname.should.equal("Doe");
+  describe("when using Model.where()", function () {
+    it("should work exactly the same", function (done) {
+      Person.where({ surname: "Doe" }, "-age", 1, function (err, people) {
+        should.not.exist(err);
+        people.should.be.a.Object();
+        people.should.have.property("length", 1);
+        people[0].name.should.equal("Jasmine");
+        people[0].surname.should.equal("Doe");
 
-				return done();
-			});
-		});
-	});
+        return done();
+      });
+    });
+  });
 });

--- a/test/integration/model-get.js
+++ b/test/integration/model-get.js
@@ -6,337 +6,337 @@ var ORM      = require('../../');
 var protocol = common.protocol();
 
 describe("Model.get()", function() {
-	var db     = null;
-	var Person = null;
-	var John;
-
-	var setup = function (identityCache) {
-		return function (done) {
-			Person = db.define("person", {
-				name     : { type: 'text', mapsTo: 'fullname' }
-			}, {
-				identityCache : identityCache,
-				methods  : {
-					UID: function () {
-						return this[Person.id];
-					}
-				}
-			});
-
-			ORM.singleton.clear(); // clear identityCache cache
-
-			return helper.dropSync(Person, function () {
-				Person.create([{
-					name: "John Doe"
-				}, {
-					name: "Jane Doe"
-				}], function (err, people) {
-					John = people[0];
-
-					return done();
-				});
-			});
-		};
-	};
-
-	before(function (done) {
-		helper.connect(function (connection) {
-			db = connection;
-
-			return done();
-		});
-	});
-
-	after(function () {
-		return db.close();
-	});
-
-	describe("mapsTo", function () {
-		if (protocol == 'mongodb') return;
-
-		before(setup(true));
-
-		it("should create the table with a different column name than property name", function (done) {
-			var sql;
-
-			if (protocol == 'sqlite') {
-				sql = "PRAGMA table_info(?)";
-			} else {
-				sql = "SELECT column_name FROM information_schema.columns WHERE table_name = ?";
-			}
-
-			db.driver.execQuery(sql, [Person.table], function (err, data) {
-				should.not.exist(err);
-
-				var names = _.map(data, protocol == 'sqlite' ? 'name' : 'column_name')
-
-				should.equal(typeof Person.properties.name, 'object');
-				should.notEqual(names.indexOf('fullname'), -1);
-
-				done();
-			});
-		});
-	});
-
-	describe("with identityCache cache", function () {
-		before(setup(true));
-
-		it("should return item with id 1", function (done) {
-			Person.get(John[Person.id], function (err, John) {
-				should.equal(err, null);
-
-				John.should.be.a.Object();
-				John.should.have.property(Person.id, John[Person.id]);
-				John.should.have.property("name", "John Doe");
-
-				return done();
-			});
-		});
-
-		it("should have an UID method", function (done) {
-			Person.get(John[Person.id], function (err, John) {
-				should.equal(err, null);
-
-				John.UID.should.be.a.Function();
-				John.UID().should.equal(John[Person.id]);
-
-				return done();
-			});
-		});
-
-		describe("changing name and getting id 1 again", function () {
-			it("should return the original object with unchanged name", function (done) {
-				Person.get(John[Person.id], function (err, John1) {
-					should.equal(err, null);
-
-					John1.name = "James";
-
-					Person.get(John[Person.id], function (err, John2) {
-						should.equal(err, null);
-
-						John1[Person.id].should.equal(John2[Person.id]);
-						John2.name.should.equal("John Doe");
-
-						return done();
-					});
-				});
-			});
-		});
-
-		describe("changing instance.identityCacheSaveCheck = false", function () {
-			before(function (done) {
-				Person.settings.set("instance.identityCacheSaveCheck", false);
-
-				it("should return the same object with the changed name", function (done) {
-					Person.get(John[Person.id], function (err, John1) {
-						should.equal(err, null);
-
-						John1.name = "James";
-
-						Person.get(John[Person.id], function (err, John2) {
-							should.equal(err, null);
-
-							John1[Person.id].should.equal(John2[Person.id]);
-							John2.name.should.equal("James");
-
-							return done();
-						});
-					});
-				});
-			});
-		});
-	});
-
-	describe("with no identityCache cache", function () {
-		before(setup(false));
-
-		describe("fetching several times", function () {
-			it("should return different objects", function (done) {
-				Person.get(John[Person.id], function (err, John1) {
-					should.equal(err, null);
-					Person.get(John[Person.id], function (err, John2) {
-						should.equal(err, null);
-
-						John1[Person.id].should.equal(John2[Person.id]);
-						John1.should.not.equal(John2);
-
-						return done();
-					});
-				});
-			});
-		});
-	});
-
-	describe("with identityCache cache = 0.5 secs", function () {
-		before(setup(0.5));
-
-		describe("fetching again after 0.2 secs", function () {
-			it("should return same objects", function (done) {
-				Person.get(John[Person.id], function (err, John1) {
-					should.equal(err, null);
-
-					setTimeout(function () {
-						Person.get(John[Person.id], function (err, John2) {
-							should.equal(err, null);
-
-							John1[Person.id].should.equal(John2[Person.id]);
-							John1.should.equal(John2);
-
-							return done();
-						});
-					}, 200);
-				});
-			});
-		});
-
-		describe("fetching again after 0.7 secs", function () {
-			it("should return different objects", function (done) {
-				Person.get(John[Person.id], function (err, John1) {
-					should.equal(err, null);
-
-					setTimeout(function () {
-						Person.get(John[Person.id], function (err, John2) {
-							should.equal(err, null);
-
-							John1.should.not.equal(John2);
-
-							return done();
-						});
-					}, 700);
-				});
-			});
-		});
-	});
-
-	describe("with empty object as options", function () {
-		before(setup());
-
-		it("should return item with id 1 like previously", function (done) {
-			Person.get(John[Person.id], {}, function (err, John) {
-				should.equal(err, null);
-
-				John.should.be.a.Object();
-				John.should.have.property(Person.id, John[Person.id]);
-				John.should.have.property("name", "John Doe");
-
-				return done();
-			});
-		});
-	});
-
-	describe("without callback", function () {
-		before(setup(true));
-
-		it("should throw", function (done) {
-			(function () {
-				Person.get(John[Person.id]);
-			}).should.throw();
-
-			return done();
-		});
-	});
-
-	describe("when not found", function () {
-		before(setup(true));
-
-		it("should return an error", function (done) {
-			Person.get(999, function (err) {
-				err.should.be.a.Object();
-				err.message.should.equal("Not found");
-
-				return done();
-			});
-		});
-	});
-
-	describe("if passed an Array with ids", function () {
-		before(setup(true));
-
-		it("should accept and try to fetch", function (done) {
-			Person.get([ John[Person.id] ], function (err, John) {
-				should.equal(err, null);
-
-				John.should.be.a.Object();
-				John.should.have.property(Person.id, John[Person.id]);
-				John.should.have.property("name", "John Doe");
-
-				return done();
-			});
-		});
-	});
-
-	describe("if passed a wrong number of ids", function () {
-		before(setup(true));
-
-		it("should throw", function (done) {
-			(function () {
-				Person.get(1, 2, function () {});
-			}).should.throw();
-
-			return done();
-		});
-	});
-
-	describe("if primary key name is changed", function () {
-		before(function (done) {
-			Person = db.define("person", {
-				name : String
-			});
-
-			ORM.singleton.clear();
-
-			return helper.dropSync(Person, function () {
-				Person.create([{
-					name : "John Doe"
-				}, {
-					name : "Jane Doe"
-				}], done);
-			});
-		});
-
-		it("should search by key name and not 'id'", function (done) {
-			db.settings.set('properties.primary_key', 'name');
-
-			var OtherPerson = db.define("person", {
-				id : Number
-			});
-
-			OtherPerson.get("Jane Doe", function (err, person) {
-				should.equal(err, null);
-
-				person.name.should.equal("Jane Doe");
-
-				return done();
-			});
-		});
-	});
-
-	describe("with a point property type", function() {
-		if (common.protocol() == 'sqlite' || common.protocol() == 'mongodb') return;
-
-		it("should deserialize the point to an array", function (done) {
-			db.settings.set('properties.primary_key', 'id');
-
-			Person = db.define("person", {
-				name     : String,
-				location : { type: "point" }
-			});
-
-			ORM.singleton.clear();
-
-			return helper.dropSync(Person, function () {
-				Person.create({
-					name     : "John Doe",
-					location : { x : 51.5177, y : -0.0968 }
-				}, function (err, person) {
-					should.equal(err, null);
-
-					person.location.should.be.an.instanceOf(Object);
-					person.location.should.have.property('x', 51.5177);
-					person.location.should.have.property('y', -0.0968);
-					return done();
-				});
-			});
-		});
-	});
+  var db     = null;
+  var Person = null;
+  var John;
+
+  var setup = function (identityCache) {
+    return function (done) {
+      Person = db.define("person", {
+        name     : { type: 'text', mapsTo: 'fullname' }
+      }, {
+        identityCache : identityCache,
+        methods  : {
+          UID: function () {
+            return this[Person.id];
+          }
+        }
+      });
+
+      ORM.singleton.clear(); // clear identityCache cache
+
+      return helper.dropSync(Person, function () {
+        Person.create([{
+          name: "John Doe"
+        }, {
+          name: "Jane Doe"
+        }], function (err, people) {
+          John = people[0];
+
+          return done();
+        });
+      });
+    };
+  };
+
+  before(function (done) {
+    helper.connect(function (connection) {
+      db = connection;
+
+      return done();
+    });
+  });
+
+  after(function () {
+    return db.close();
+  });
+
+  describe("mapsTo", function () {
+    if (protocol == 'mongodb') return;
+
+    before(setup(true));
+
+    it("should create the table with a different column name than property name", function (done) {
+      var sql;
+
+      if (protocol == 'sqlite') {
+        sql = "PRAGMA table_info(?)";
+      } else {
+        sql = "SELECT column_name FROM information_schema.columns WHERE table_name = ?";
+      }
+
+      db.driver.execQuery(sql, [Person.table], function (err, data) {
+        should.not.exist(err);
+
+        var names = _.map(data, protocol == 'sqlite' ? 'name' : 'column_name')
+
+        should.equal(typeof Person.properties.name, 'object');
+        should.notEqual(names.indexOf('fullname'), -1);
+
+        done();
+      });
+    });
+  });
+
+  describe("with identityCache cache", function () {
+    before(setup(true));
+
+    it("should return item with id 1", function (done) {
+      Person.get(John[Person.id], function (err, John) {
+        should.equal(err, null);
+
+        John.should.be.a.Object();
+        John.should.have.property(Person.id, John[Person.id]);
+        John.should.have.property("name", "John Doe");
+
+        return done();
+      });
+    });
+
+    it("should have an UID method", function (done) {
+      Person.get(John[Person.id], function (err, John) {
+        should.equal(err, null);
+
+        John.UID.should.be.a.Function();
+        John.UID().should.equal(John[Person.id]);
+
+        return done();
+      });
+    });
+
+    describe("changing name and getting id 1 again", function () {
+      it("should return the original object with unchanged name", function (done) {
+        Person.get(John[Person.id], function (err, John1) {
+          should.equal(err, null);
+
+          John1.name = "James";
+
+          Person.get(John[Person.id], function (err, John2) {
+            should.equal(err, null);
+
+            John1[Person.id].should.equal(John2[Person.id]);
+            John2.name.should.equal("John Doe");
+
+            return done();
+          });
+        });
+      });
+    });
+
+    describe("changing instance.identityCacheSaveCheck = false", function () {
+      before(function (done) {
+        Person.settings.set("instance.identityCacheSaveCheck", false);
+
+        it("should return the same object with the changed name", function (done) {
+          Person.get(John[Person.id], function (err, John1) {
+            should.equal(err, null);
+
+            John1.name = "James";
+
+            Person.get(John[Person.id], function (err, John2) {
+              should.equal(err, null);
+
+              John1[Person.id].should.equal(John2[Person.id]);
+              John2.name.should.equal("James");
+
+              return done();
+            });
+          });
+        });
+      });
+    });
+  });
+
+  describe("with no identityCache cache", function () {
+    before(setup(false));
+
+    describe("fetching several times", function () {
+      it("should return different objects", function (done) {
+        Person.get(John[Person.id], function (err, John1) {
+          should.equal(err, null);
+          Person.get(John[Person.id], function (err, John2) {
+            should.equal(err, null);
+
+            John1[Person.id].should.equal(John2[Person.id]);
+            John1.should.not.equal(John2);
+
+            return done();
+          });
+        });
+      });
+    });
+  });
+
+  describe("with identityCache cache = 0.5 secs", function () {
+    before(setup(0.5));
+
+    describe("fetching again after 0.2 secs", function () {
+      it("should return same objects", function (done) {
+        Person.get(John[Person.id], function (err, John1) {
+          should.equal(err, null);
+
+          setTimeout(function () {
+            Person.get(John[Person.id], function (err, John2) {
+              should.equal(err, null);
+
+              John1[Person.id].should.equal(John2[Person.id]);
+              John1.should.equal(John2);
+
+              return done();
+            });
+          }, 200);
+        });
+      });
+    });
+
+    describe("fetching again after 0.7 secs", function () {
+      it("should return different objects", function (done) {
+        Person.get(John[Person.id], function (err, John1) {
+          should.equal(err, null);
+
+          setTimeout(function () {
+            Person.get(John[Person.id], function (err, John2) {
+              should.equal(err, null);
+
+              John1.should.not.equal(John2);
+
+              return done();
+            });
+          }, 700);
+        });
+      });
+    });
+  });
+
+  describe("with empty object as options", function () {
+    before(setup());
+
+    it("should return item with id 1 like previously", function (done) {
+      Person.get(John[Person.id], {}, function (err, John) {
+        should.equal(err, null);
+
+        John.should.be.a.Object();
+        John.should.have.property(Person.id, John[Person.id]);
+        John.should.have.property("name", "John Doe");
+
+        return done();
+      });
+    });
+  });
+
+  describe("without callback", function () {
+    before(setup(true));
+
+    it("should throw", function (done) {
+      (function () {
+        Person.get(John[Person.id]);
+      }).should.throw();
+
+      return done();
+    });
+  });
+
+  describe("when not found", function () {
+    before(setup(true));
+
+    it("should return an error", function (done) {
+      Person.get(999, function (err) {
+        err.should.be.a.Object();
+        err.message.should.equal("Not found");
+
+        return done();
+      });
+    });
+  });
+
+  describe("if passed an Array with ids", function () {
+    before(setup(true));
+
+    it("should accept and try to fetch", function (done) {
+      Person.get([ John[Person.id] ], function (err, John) {
+        should.equal(err, null);
+
+        John.should.be.a.Object();
+        John.should.have.property(Person.id, John[Person.id]);
+        John.should.have.property("name", "John Doe");
+
+        return done();
+      });
+    });
+  });
+
+  describe("if passed a wrong number of ids", function () {
+    before(setup(true));
+
+    it("should throw", function (done) {
+      (function () {
+        Person.get(1, 2, function () {});
+      }).should.throw();
+
+      return done();
+    });
+  });
+
+  describe("if primary key name is changed", function () {
+    before(function (done) {
+      Person = db.define("person", {
+        name : String
+      });
+
+      ORM.singleton.clear();
+
+      return helper.dropSync(Person, function () {
+        Person.create([{
+          name : "John Doe"
+        }, {
+          name : "Jane Doe"
+        }], done);
+      });
+    });
+
+    it("should search by key name and not 'id'", function (done) {
+      db.settings.set('properties.primary_key', 'name');
+
+      var OtherPerson = db.define("person", {
+        id : Number
+      });
+
+      OtherPerson.get("Jane Doe", function (err, person) {
+        should.equal(err, null);
+
+        person.name.should.equal("Jane Doe");
+
+        return done();
+      });
+    });
+  });
+
+  describe("with a point property type", function() {
+    if (common.protocol() == 'sqlite' || common.protocol() == 'mongodb') return;
+
+    it("should deserialize the point to an array", function (done) {
+      db.settings.set('properties.primary_key', 'id');
+
+      Person = db.define("person", {
+        name     : String,
+        location : { type: "point" }
+      });
+
+      ORM.singleton.clear();
+
+      return helper.dropSync(Person, function () {
+        Person.create({
+          name     : "John Doe",
+          location : { x : 51.5177, y : -0.0968 }
+        }, function (err, person) {
+          should.equal(err, null);
+
+          person.location.should.be.an.instanceOf(Object);
+          person.location.should.have.property('x', 51.5177);
+          person.location.should.have.property('y', -0.0968);
+          return done();
+        });
+      });
+    });
+  });
 });

--- a/test/integration/model-keys.js
+++ b/test/integration/model-keys.js
@@ -3,109 +3,109 @@ var helper   = require('../support/spec_helper');
 var ORM      = require('../../');
 
 describe("Model keys option", function() {
-	var db = null;
+  var db = null;
 
-	before(function (done) {
-		this.timeout(4000);
+  before(function (done) {
+    this.timeout(4000);
 
-		helper.connect(function (connection) {
-			db = connection;
+    helper.connect(function (connection) {
+      db = connection;
 
-			return done();
-		});
-	});
+      return done();
+    });
+  });
 
-	after(function () {
-		return db.close();
-	});
+  after(function () {
+    return db.close();
+  });
 
-	describe("if model id is a property", function () {
-		var Person = null;
+  describe("if model id is a property", function () {
+    var Person = null;
 
-		before(function (done) {
-			Person = db.define("person", {
-				uid     : String,
-				name    : String,
-				surname : String
-			}, {
-				id      : "uid"
-			});
+    before(function (done) {
+      Person = db.define("person", {
+        uid     : String,
+        name    : String,
+        surname : String
+      }, {
+        id      : "uid"
+      });
 
-			return helper.dropSync(Person, done);
-		});
+      return helper.dropSync(Person, done);
+    });
 
-		it("should not auto increment IDs", function (done) {
-			Person.create({
-				uid     : "john-doe",
-				name    : "John",
-				surname : "Doe"
-			}, function (err, JohnDoe) {
-				should.equal(err, null);
+    it("should not auto increment IDs", function (done) {
+      Person.create({
+        uid     : "john-doe",
+        name    : "John",
+        surname : "Doe"
+      }, function (err, JohnDoe) {
+        should.equal(err, null);
 
-				JohnDoe.uid.should.equal("john-doe");
-				JohnDoe.should.not.have.property("id");
+        JohnDoe.uid.should.equal("john-doe");
+        JohnDoe.should.not.have.property("id");
 
-				return done();
-			});
-		});
-	});
+        return done();
+      });
+    });
+  });
 
-	describe("if model defines several keys", function () {
-		var DoorAccessHistory = null;
+  describe("if model defines several keys", function () {
+    var DoorAccessHistory = null;
 
-		before(function (done) {
-			DoorAccessHistory = db.define("door_access_history", {
-				year   : { type: 'integer' },
-				month  : { type: 'integer' },
-				day    : { type: 'integer' },
-				user   : String,
-				action : [ "in", "out" ]
-			}, {
-				id   : [ "year", "month", "day" ]
-			});
+    before(function (done) {
+      DoorAccessHistory = db.define("door_access_history", {
+        year   : { type: 'integer' },
+        month  : { type: 'integer' },
+        day    : { type: 'integer' },
+        user   : String,
+        action : [ "in", "out" ]
+      }, {
+        id   : [ "year", "month", "day" ]
+      });
 
-			return helper.dropSync(DoorAccessHistory, function () {
-				DoorAccessHistory.create([
-					{ year: 2013, month: 7, day : 11, user : "dresende", action : "in" },
-					{ year: 2013, month: 7, day : 12, user : "dresende", action : "out" }
-				], done);
-			});
-		});
+      return helper.dropSync(DoorAccessHistory, function () {
+        DoorAccessHistory.create([
+          { year: 2013, month: 7, day : 11, user : "dresende", action : "in" },
+          { year: 2013, month: 7, day : 12, user : "dresende", action : "out" }
+        ], done);
+      });
+    });
 
-		it("should make possible to get instances based on all keys", function (done) {
-			DoorAccessHistory.get(2013, 7, 11, function (err, HistoryItem) {
-				should.equal(err, null);
+    it("should make possible to get instances based on all keys", function (done) {
+      DoorAccessHistory.get(2013, 7, 11, function (err, HistoryItem) {
+        should.equal(err, null);
 
-				HistoryItem.year.should.equal(2013);
-				HistoryItem.month.should.equal(7);
-				HistoryItem.day.should.equal(11);
-				HistoryItem.user.should.equal("dresende");
-				HistoryItem.action.should.equal("in");
+        HistoryItem.year.should.equal(2013);
+        HistoryItem.month.should.equal(7);
+        HistoryItem.day.should.equal(11);
+        HistoryItem.user.should.equal("dresende");
+        HistoryItem.action.should.equal("in");
 
-				return done();
-			})
-		});
+        return done();
+      })
+    });
 
-		it("should make possible to remove instances based on all keys", function (done) {
-			DoorAccessHistory.get(2013, 7, 12, function (err, HistoryItem) {
-				should.equal(err, null);
+    it("should make possible to remove instances based on all keys", function (done) {
+      DoorAccessHistory.get(2013, 7, 12, function (err, HistoryItem) {
+        should.equal(err, null);
 
-				HistoryItem.remove(function (err) {
-					should.equal(err, null);
+        HistoryItem.remove(function (err) {
+          should.equal(err, null);
 
-					DoorAccessHistory.get(2013, 7, 12, function (err) {
-						err.should.have.property("code", ORM.ErrorCodes.NOT_FOUND);
+          DoorAccessHistory.get(2013, 7, 12, function (err) {
+            err.should.have.property("code", ORM.ErrorCodes.NOT_FOUND);
 
-						DoorAccessHistory.exists(2013, 7, 12, function (err, exists) {
-							should.equal(err, null);
+            DoorAccessHistory.exists(2013, 7, 12, function (err, exists) {
+              should.equal(err, null);
 
-							exists.should.be.false;
+              exists.should.be.false;
 
-							return done();
-						});
-					});
-				});
-			})
-		});
-	});
+              return done();
+            });
+          });
+        });
+      })
+    });
+  });
 });

--- a/test/integration/model-keys.js
+++ b/test/integration/model-keys.js
@@ -6,8 +6,6 @@ describe("Model keys option", function() {
   var db = null;
 
   before(function (done) {
-    this.timeout(4000);
-
     helper.connect(function (connection) {
       db = connection;
 

--- a/test/integration/model-one.js
+++ b/test/integration/model-one.js
@@ -3,104 +3,104 @@ var helper   = require('../support/spec_helper');
 var ORM      = require('../../');
 
 describe("Model.one()", function() {
-	var db = null;
-	var Person = null;
+  var db = null;
+  var Person = null;
 
-	var setup = function () {
-		return function (done) {
-			Person = db.define("person", {
-				name   : String
-			});
+  var setup = function () {
+    return function (done) {
+      Person = db.define("person", {
+        name   : String
+      });
 
-			return helper.dropSync(Person, function () {
-				Person.create([{
-					id  : 1,
-					name: "Jeremy Doe"
-				}, {
-					id  : 2,
-					name: "John Doe"
-				}, {
-					id  : 3,
-					name: "Jane Doe"
-				}], done);
-			});
-		};
-	};
+      return helper.dropSync(Person, function () {
+        Person.create([{
+          id  : 1,
+          name: "Jeremy Doe"
+        }, {
+          id  : 2,
+          name: "John Doe"
+        }, {
+          id  : 3,
+          name: "Jane Doe"
+        }], done);
+      });
+    };
+  };
 
-	before(function (done) {
-		helper.connect(function (connection) {
-			db = connection;
+  before(function (done) {
+    helper.connect(function (connection) {
+      db = connection;
 
-			return done();
-		});
-	});
+      return done();
+    });
+  });
 
-	after(function () {
-		return db.close();
-	});
+  after(function () {
+    return db.close();
+  });
 
-	describe("without arguments", function () {
-		before(setup());
+  describe("without arguments", function () {
+    before(setup());
 
-		it("should return first item in model", function (done) {
-			Person.one(function (err, person) {
-				should.equal(err, null);
+    it("should return first item in model", function (done) {
+      Person.one(function (err, person) {
+        should.equal(err, null);
 
-				person.name.should.equal("Jeremy Doe");
+        person.name.should.equal("Jeremy Doe");
 
-				return done();
-			});
-		});
-	});
+        return done();
+      });
+    });
+  });
 
-	describe("without callback", function () {
-		before(setup());
+  describe("without callback", function () {
+    before(setup());
 
-		it("should throw", function (done) {
-			Person.one.should.throw();
+    it("should throw", function (done) {
+      Person.one.should.throw();
 
-			return done();
-		});
-	});
+      return done();
+    });
+  });
 
-	describe("with order", function () {
-		before(setup());
+  describe("with order", function () {
+    before(setup());
 
-		it("should return first item in model based on order", function (done) {
-			Person.one("-name", function (err, person) {
-				should.equal(err, null);
+    it("should return first item in model based on order", function (done) {
+      Person.one("-name", function (err, person) {
+        should.equal(err, null);
 
-				person.name.should.equal("John Doe");
+        person.name.should.equal("John Doe");
 
-				return done();
-			});
-		});
-	});
+        return done();
+      });
+    });
+  });
 
-	describe("with conditions", function () {
-		before(setup());
+  describe("with conditions", function () {
+    before(setup());
 
-		it("should return first item in model based on conditions", function (done) {
-			Person.one({ name: "Jane Doe" }, function (err, person) {
-				should.equal(err, null);
+    it("should return first item in model based on conditions", function (done) {
+      Person.one({ name: "Jane Doe" }, function (err, person) {
+        should.equal(err, null);
 
-				person.name.should.equal("Jane Doe");
+        person.name.should.equal("Jane Doe");
 
-				return done();
-			});
-		});
+        return done();
+      });
+    });
 
-		describe("if no match", function () {
-			before(setup());
+    describe("if no match", function () {
+      before(setup());
 
-			it("should return null", function (done) {
-				Person.one({ name: "Jack Doe" }, function (err, person) {
-					should.equal(err, null);
-					should.equal(person, null);
+      it("should return null", function (done) {
+        Person.one({ name: "Jack Doe" }, function (err, person) {
+          should.equal(err, null);
+          should.equal(person, null);
 
-					return done();
-				});
-			});
-		});
-	});
+          return done();
+        });
+      });
+    });
+  });
 });

--- a/test/integration/model-save.js
+++ b/test/integration/model-save.js
@@ -4,477 +4,477 @@ var common   = require('../common');
 var ORM      = require('../../');
 
 describe("Model.save()", function() {
-	var db = null;
-	var Person = null;
-
-	var setup = function (nameDefinition, opts) {
-		opts = opts || {};
-
-		return function (done) {
-			Person = db.define("person", {
-				name   : nameDefinition || String
-			}, opts || {});
-
-			Person.hasOne("parent", Person, opts.hasOneOpts);
-			if ('saveAssociationsByDefault' in opts) {
-				Person.settings.set(
-					'instance.saveAssociationsByDefault', opts.saveAssociationsByDefault
-				);
-			}
-
-			return helper.dropSync(Person, done);
-		};
-	};
-
-	before(function (done) {
-		helper.connect(function (connection) {
-			db = connection;
-
-			return done();
-		});
-	});
-
-	after(function () {
-		return db.close();
-	});
-
-	describe("if properties have default values", function () {
-		before(setup({ type: "text", defaultValue: "John" }));
-
-		it("should use it if not defined", function (done) {
-			var John = new Person();
-
-			John.save(function (err) {
-				should.equal(err, null);
-				John.name.should.equal("John");
-
-				return done();
-			});
-		});
-	});
-
-	describe("with callback", function () {
-		before(setup());
-
-		it("should save item and return id", function (done) {
-			var John = new Person({
-				name: "John"
-			});
-			John.save(function (err) {
-				should.equal(err, null);
-				should.exist(John[Person.id]);
-
-				Person.get(John[Person.id], function (err, JohnCopy) {
-					should.equal(err, null);
-
-					JohnCopy[Person.id].should.equal(John[Person.id]);
-					JohnCopy.name.should.equal(John.name);
-
-					return done();
-				});
-			});
-		});
-	});
-
-	describe("without callback", function () {
-		before(setup());
-
-		it("should still save item and return id", function (done) {
-			var John = new Person({
-				name: "John"
-			});
-			John.save();
-			John.on("save", function (err) {
-				should.equal(err, null);
-				should.exist(John[Person.id]);
-
-				Person.get(John[Person.id], function (err, JohnCopy) {
-					should.equal(err, null);
-
-					JohnCopy[Person.id].should.equal(John[Person.id]);
-					JohnCopy.name.should.equal(John.name);
-
-					return done();
-				});
-			});
-		});
-	});
-
-	describe("with properties object", function () {
-		before(setup());
-
-		it("should update properties, save item and return id", function (done) {
-			var John = new Person({
-				name: "Jane"
-			});
-			John.save({ name: "John" }, function (err) {
-				should.equal(err, null);
-				should.exist(John[Person.id]);
-				John.name.should.equal("John");
-
-				Person.get(John[Person.id], function (err, JohnCopy) {
-					should.equal(err, null);
-
-					JohnCopy[Person.id].should.equal(John[Person.id]);
-					JohnCopy.name.should.equal(John.name);
-
-					return done();
-				});
-			});
-		});
-	});
-
-	describe("with unknown argument type", function () {
-		before(setup());
-
-		it("should should throw", function (done) {
-			var John = new Person({
-				name: "Jane"
-			});
-			(function () {
-				John.save("will-fail");
-			}).should.throw();
-
-			return done();
-		});
-	});
-
-	describe("if passed an association instance", function () {
-		before(setup());
-
-		it("should save association first and then save item and return id", function (done) {
-			var Jane = new Person({
-				name  : "Jane"
-			});
-			var John = new Person({
-				name  : "John",
-				parent: Jane
-			});
-			John.save(function (err) {
-				should.equal(err, null);
-				John.saved().should.be.true;
-				Jane.saved().should.be.true;
-
-				should.exist(John[Person.id]);
-				should.exist(Jane[Person.id]);
-
-				return done();
-			});
-		});
-	});
-
-	describe("if passed an association object", function () {
-		before(setup());
-
-		it("should save association first and then save item and return id", function (done) {
-			var John = new Person({
-				name  : "John",
-				parent: {
-					name  : "Jane"
-				}
-			});
-			John.save(function (err) {
-				should.equal(err, null);
-				John.saved().should.be.true;
-				John.parent.saved().should.be.true;
-
-				should.exist(John[Person.id]);
-				should.exist(John.parent[Person.id]);
-				should.equal(John.parent.name, "Jane");
-
-				return done();
-			});
-		});
-	});
-
-	describe("if autoSave is on", function () {
-		before(setup(null, { autoSave: true }));
-
-		it("should save the instance as soon as a property is changed", function (done) {
-			var John = new Person({
-				name : "Jhon"
-			});
-			John.save(function (err) {
-				should.equal(err, null);
-
-				John.on("save", function () {
-					return done();
-				});
-
-				John.name = "John";
-			});
-		});
-	});
-
-	describe("with saveAssociations", function () {
-		var afterSaveCalled = false;
-
-		if (common.protocol() == 'mongodb') return;
-
-		describe("default on in settings", function () {
-			beforeEach(function (done) {
-				function afterSave () {
-					afterSaveCalled = true;
-				}
-				var hooks = { afterSave: afterSave };
-
-				setup(null, { hooks: hooks, cache: false, hasOneOpts: { autoFetch: true } })(function (err) {
-					should.not.exist(err);
-
-					Person.create({ name: 'Olga' }, function (err, olga) {
-						should.not.exist(err);
-
-						should.exist(olga);
-						Person.create({ name: 'Hagar', parent_id: olga.id }, function (err, hagar) {
-							should.not.exist(err);
-							should.exist(hagar);
-							afterSaveCalled = false;
-							done();
-						});
-					});
-				});
-			});
-
-			it("should be on", function () {
-				should.equal(Person.settings.get('instance.saveAssociationsByDefault'), true);
-			});
-
-			it("off should not save associations but save itself", function (done) {
-				Person.one({ name: 'Hagar' }, function (err, hagar) {
-					should.not.exist(err);
-					should.exist(hagar.parent);
-
-					hagar.parent.name = 'Olga2';
-					hagar.save({name: 'Hagar2'}, { saveAssociations: false }, function (err) {
-						should.not.exist(err);
-						should.equal(afterSaveCalled, true);
-
-						Person.get(hagar.parent.id, function (err, olga) {
-							should.not.exist(err);
-							should.equal(olga.name, 'Olga');
-							done();
-						});
-					});
-				});
-			});
-
-			it("off should not save associations or itself if there are no changes", function (done) {
-				Person.one({ name: 'Hagar' }, function (err, hagar) {
-					should.not.exist(err);
-
-					hagar.save({}, { saveAssociations: false }, function (err) {
-						should.not.exist(err);
-						should.equal(afterSaveCalled, false);
-
-						Person.get(hagar.parent.id, function (err, olga) {
-							should.not.exist(err);
-							should.equal(olga.name, 'Olga');
-							done();
-						});
-					});
-				});
-			});
-
-			it("unspecified should save associations and itself", function (done) {
-				Person.one({ name: 'Hagar' }, function (err, hagar) {
-					should.not.exist(err);
-					should.exist(hagar.parent);
-
-					hagar.parent.name = 'Olga2';
-					hagar.save({name: 'Hagar2'}, function (err) {
-						should.not.exist(err);
-
-						Person.get(hagar.parent.id, function (err, olga) {
-							should.not.exist(err);
-							should.equal(olga.name, 'Olga2');
-
-							Person.get(hagar.id, function (err, person) {
-								should.not.exist(err);
-								should.equal(person.name, 'Hagar2');
-
-								done();
-							});
-						});
-					});
-				});
-			});
-
-			it("on should save associations and itself", function (done) {
-				Person.one({ name: 'Hagar' }, function (err, hagar) {
-					should.not.exist(err);
-					should.exist(hagar.parent);
-
-					hagar.parent.name = 'Olga2';
-					hagar.save({name: 'Hagar2'}, { saveAssociations: true }, function (err) {
-						should.not.exist(err);
-
-						Person.get(hagar.parent.id, function (err, olga) {
-							should.not.exist(err);
-							should.equal(olga.name, 'Olga2');
-
-							Person.get(hagar.id, function (err, person) {
-								should.not.exist(err);
-								should.equal(person.name, 'Hagar2');
-
-								done();
-							});
-						});
-					});
-				});
-			});
-		});
-
-		describe("turned off in settings", function () {
-			beforeEach(function (done) {
-				function afterSave () {
-					afterSaveCalled = true;
-				}
-				var hooks = { afterSave: afterSave };
-
-				setup(null, {
-					hooks: hooks, cache: false, hasOneOpts: { autoFetch: true },
-					saveAssociationsByDefault: false
-				})(function (err) {
-					should.not.exist(err);
-
-					Person.create({ name: 'Olga' }, function (err, olga) {
-						should.not.exist(err);
-
-						should.exist(olga);
-						Person.create({ name: 'Hagar', parent_id: olga.id }, function (err, hagar) {
-							should.not.exist(err);
-							should.exist(hagar);
-							afterSaveCalled = false;
-							done();
-						});
-					});
-				});
-			});
-
-			it("should be off", function () {
-				should.equal(Person.settings.get('instance.saveAssociationsByDefault'), false);
-			});
-
-			it("unspecified should not save associations but save itself", function (done) {
-				Person.one({ name: 'Hagar' }, function (err, hagar) {
-					should.not.exist(err);
-					should.exist(hagar.parent);
-
-					hagar.parent.name = 'Olga2';
-					hagar.save({ name: 'Hagar2' }, function (err) {
-						should.not.exist(err);
-
-						Person.get(hagar.parent.id, function (err, olga) {
-							should.not.exist(err);
-							should.equal(olga.name, 'Olga');
-
-							Person.get(hagar.id, function (err, person) {
-								should.not.exist(err);
-								should.equal(person.name, 'Hagar2');
-
-								done();
-							});
-						});
-					});
-				});
-			});
-
-			it("off should not save associations but save itself", function (done) {
-				Person.one({ name: 'Hagar' }, function (err, hagar) {
-					should.not.exist(err);
-					should.exist(hagar.parent);
-
-					hagar.parent.name = 'Olga2';
-					hagar.save({ name: 'Hagar2' }, { saveAssociations: false }, function (err) {
-						should.not.exist(err);
-						should.equal(afterSaveCalled, true);
-
-						Person.get(hagar.parent.id, function (err, olga) {
-							should.not.exist(err);
-							should.equal(olga.name, 'Olga');
-							done();
-						});
-					});
-				});
-			});
-
-			it("on should save associations and itself", function (done) {
-				Person.one({ name: 'Hagar' }, function (err, hagar) {
-					should.not.exist(err);
-					should.exist(hagar.parent);
-
-					hagar.parent.name = 'Olga2';
-					hagar.save({ name: 'Hagar2' }, { saveAssociations: true }, function (err) {
-						should.not.exist(err);
-
-						Person.get(hagar.parent.id, function (err, olga) {
-							should.not.exist(err);
-							should.equal(olga.name, 'Olga2');
-
-							Person.get(hagar.id, function (err, person) {
-								should.not.exist(err);
-								should.equal(person.name, 'Hagar2');
-
-								done();
-							});
-						});
-					});
-				});
-			});
-		});
-	});
-
-	describe("with a point property", function () {
-		if (common.protocol() == 'sqlite' || common.protocol() == 'mongodb') return;
-
-		it("should save the instance as a geospatial point", function (done) {
-			setup({ type: "point" }, null)(function () {
-				var John = new Person({
-					name: { x: 51.5177, y: -0.0968 }
-				});
-				John.save(function (err) {
-					should.equal(err, null);
-
-					John.name.should.be.an.instanceOf(Object);
-					John.name.should.have.property('x', 51.5177);
-					John.name.should.have.property('y', -0.0968);
-					return done();
-				});
-			});
-		});
-	});
-
-	describe("mockable", function() {
-		before(setup());
-
-		it("save should be writable", function(done) {
-			var John = new Person({
-				name: "John"
-			});
-			var saveCalled = false;
-			John.save = function(cb) {
-				saveCalled = true;
-				cb(null);
-			};
-			John.save(function(err) {
-				should.equal(saveCalled,true);
-				return done();
-			});
-		});
-
-		it("saved should be writable", function(done) {
-			var John = new Person({
-				name: "John"
-			});
-			var savedCalled = false;
-			John.saved = function() {
-				savedCalled = true;
-				return true;
-			};
-
-			John.saved()
-			savedCalled.should.be.true;
-			done();
-		})
-	});
+  var db = null;
+  var Person = null;
+
+  var setup = function (nameDefinition, opts) {
+    opts = opts || {};
+
+    return function (done) {
+      Person = db.define("person", {
+        name   : nameDefinition || String
+      }, opts || {});
+
+      Person.hasOne("parent", Person, opts.hasOneOpts);
+      if ('saveAssociationsByDefault' in opts) {
+        Person.settings.set(
+          'instance.saveAssociationsByDefault', opts.saveAssociationsByDefault
+        );
+      }
+
+      return helper.dropSync(Person, done);
+    };
+  };
+
+  before(function (done) {
+    helper.connect(function (connection) {
+      db = connection;
+
+      return done();
+    });
+  });
+
+  after(function () {
+    return db.close();
+  });
+
+  describe("if properties have default values", function () {
+    before(setup({ type: "text", defaultValue: "John" }));
+
+    it("should use it if not defined", function (done) {
+      var John = new Person();
+
+      John.save(function (err) {
+        should.equal(err, null);
+        John.name.should.equal("John");
+
+        return done();
+      });
+    });
+  });
+
+  describe("with callback", function () {
+    before(setup());
+
+    it("should save item and return id", function (done) {
+      var John = new Person({
+        name: "John"
+      });
+      John.save(function (err) {
+        should.equal(err, null);
+        should.exist(John[Person.id]);
+
+        Person.get(John[Person.id], function (err, JohnCopy) {
+          should.equal(err, null);
+
+          JohnCopy[Person.id].should.equal(John[Person.id]);
+          JohnCopy.name.should.equal(John.name);
+
+          return done();
+        });
+      });
+    });
+  });
+
+  describe("without callback", function () {
+    before(setup());
+
+    it("should still save item and return id", function (done) {
+      var John = new Person({
+        name: "John"
+      });
+      John.save();
+      John.on("save", function (err) {
+        should.equal(err, null);
+        should.exist(John[Person.id]);
+
+        Person.get(John[Person.id], function (err, JohnCopy) {
+          should.equal(err, null);
+
+          JohnCopy[Person.id].should.equal(John[Person.id]);
+          JohnCopy.name.should.equal(John.name);
+
+          return done();
+        });
+      });
+    });
+  });
+
+  describe("with properties object", function () {
+    before(setup());
+
+    it("should update properties, save item and return id", function (done) {
+      var John = new Person({
+        name: "Jane"
+      });
+      John.save({ name: "John" }, function (err) {
+        should.equal(err, null);
+        should.exist(John[Person.id]);
+        John.name.should.equal("John");
+
+        Person.get(John[Person.id], function (err, JohnCopy) {
+          should.equal(err, null);
+
+          JohnCopy[Person.id].should.equal(John[Person.id]);
+          JohnCopy.name.should.equal(John.name);
+
+          return done();
+        });
+      });
+    });
+  });
+
+  describe("with unknown argument type", function () {
+    before(setup());
+
+    it("should should throw", function (done) {
+      var John = new Person({
+        name: "Jane"
+      });
+      (function () {
+        John.save("will-fail");
+      }).should.throw();
+
+      return done();
+    });
+  });
+
+  describe("if passed an association instance", function () {
+    before(setup());
+
+    it("should save association first and then save item and return id", function (done) {
+      var Jane = new Person({
+        name  : "Jane"
+      });
+      var John = new Person({
+        name  : "John",
+        parent: Jane
+      });
+      John.save(function (err) {
+        should.equal(err, null);
+        John.saved().should.be.true;
+        Jane.saved().should.be.true;
+
+        should.exist(John[Person.id]);
+        should.exist(Jane[Person.id]);
+
+        return done();
+      });
+    });
+  });
+
+  describe("if passed an association object", function () {
+    before(setup());
+
+    it("should save association first and then save item and return id", function (done) {
+      var John = new Person({
+        name  : "John",
+        parent: {
+          name  : "Jane"
+        }
+      });
+      John.save(function (err) {
+        should.equal(err, null);
+        John.saved().should.be.true;
+        John.parent.saved().should.be.true;
+
+        should.exist(John[Person.id]);
+        should.exist(John.parent[Person.id]);
+        should.equal(John.parent.name, "Jane");
+
+        return done();
+      });
+    });
+  });
+
+  describe("if autoSave is on", function () {
+    before(setup(null, { autoSave: true }));
+
+    it("should save the instance as soon as a property is changed", function (done) {
+      var John = new Person({
+        name : "Jhon"
+      });
+      John.save(function (err) {
+        should.equal(err, null);
+
+        John.on("save", function () {
+          return done();
+        });
+
+        John.name = "John";
+      });
+    });
+  });
+
+  describe("with saveAssociations", function () {
+    var afterSaveCalled = false;
+
+    if (common.protocol() == 'mongodb') return;
+
+    describe("default on in settings", function () {
+      beforeEach(function (done) {
+        function afterSave () {
+          afterSaveCalled = true;
+        }
+        var hooks = { afterSave: afterSave };
+
+        setup(null, { hooks: hooks, cache: false, hasOneOpts: { autoFetch: true } })(function (err) {
+          should.not.exist(err);
+
+          Person.create({ name: 'Olga' }, function (err, olga) {
+            should.not.exist(err);
+
+            should.exist(olga);
+            Person.create({ name: 'Hagar', parent_id: olga.id }, function (err, hagar) {
+              should.not.exist(err);
+              should.exist(hagar);
+              afterSaveCalled = false;
+              done();
+            });
+          });
+        });
+      });
+
+      it("should be on", function () {
+        should.equal(Person.settings.get('instance.saveAssociationsByDefault'), true);
+      });
+
+      it("off should not save associations but save itself", function (done) {
+        Person.one({ name: 'Hagar' }, function (err, hagar) {
+          should.not.exist(err);
+          should.exist(hagar.parent);
+
+          hagar.parent.name = 'Olga2';
+          hagar.save({name: 'Hagar2'}, { saveAssociations: false }, function (err) {
+            should.not.exist(err);
+            should.equal(afterSaveCalled, true);
+
+            Person.get(hagar.parent.id, function (err, olga) {
+              should.not.exist(err);
+              should.equal(olga.name, 'Olga');
+              done();
+            });
+          });
+        });
+      });
+
+      it("off should not save associations or itself if there are no changes", function (done) {
+        Person.one({ name: 'Hagar' }, function (err, hagar) {
+          should.not.exist(err);
+
+          hagar.save({}, { saveAssociations: false }, function (err) {
+            should.not.exist(err);
+            should.equal(afterSaveCalled, false);
+
+            Person.get(hagar.parent.id, function (err, olga) {
+              should.not.exist(err);
+              should.equal(olga.name, 'Olga');
+              done();
+            });
+          });
+        });
+      });
+
+      it("unspecified should save associations and itself", function (done) {
+        Person.one({ name: 'Hagar' }, function (err, hagar) {
+          should.not.exist(err);
+          should.exist(hagar.parent);
+
+          hagar.parent.name = 'Olga2';
+          hagar.save({name: 'Hagar2'}, function (err) {
+            should.not.exist(err);
+
+            Person.get(hagar.parent.id, function (err, olga) {
+              should.not.exist(err);
+              should.equal(olga.name, 'Olga2');
+
+              Person.get(hagar.id, function (err, person) {
+                should.not.exist(err);
+                should.equal(person.name, 'Hagar2');
+
+                done();
+              });
+            });
+          });
+        });
+      });
+
+      it("on should save associations and itself", function (done) {
+        Person.one({ name: 'Hagar' }, function (err, hagar) {
+          should.not.exist(err);
+          should.exist(hagar.parent);
+
+          hagar.parent.name = 'Olga2';
+          hagar.save({name: 'Hagar2'}, { saveAssociations: true }, function (err) {
+            should.not.exist(err);
+
+            Person.get(hagar.parent.id, function (err, olga) {
+              should.not.exist(err);
+              should.equal(olga.name, 'Olga2');
+
+              Person.get(hagar.id, function (err, person) {
+                should.not.exist(err);
+                should.equal(person.name, 'Hagar2');
+
+                done();
+              });
+            });
+          });
+        });
+      });
+    });
+
+    describe("turned off in settings", function () {
+      beforeEach(function (done) {
+        function afterSave () {
+          afterSaveCalled = true;
+        }
+        var hooks = { afterSave: afterSave };
+
+        setup(null, {
+          hooks: hooks, cache: false, hasOneOpts: { autoFetch: true },
+          saveAssociationsByDefault: false
+        })(function (err) {
+          should.not.exist(err);
+
+          Person.create({ name: 'Olga' }, function (err, olga) {
+            should.not.exist(err);
+
+            should.exist(olga);
+            Person.create({ name: 'Hagar', parent_id: olga.id }, function (err, hagar) {
+              should.not.exist(err);
+              should.exist(hagar);
+              afterSaveCalled = false;
+              done();
+            });
+          });
+        });
+      });
+
+      it("should be off", function () {
+        should.equal(Person.settings.get('instance.saveAssociationsByDefault'), false);
+      });
+
+      it("unspecified should not save associations but save itself", function (done) {
+        Person.one({ name: 'Hagar' }, function (err, hagar) {
+          should.not.exist(err);
+          should.exist(hagar.parent);
+
+          hagar.parent.name = 'Olga2';
+          hagar.save({ name: 'Hagar2' }, function (err) {
+            should.not.exist(err);
+
+            Person.get(hagar.parent.id, function (err, olga) {
+              should.not.exist(err);
+              should.equal(olga.name, 'Olga');
+
+              Person.get(hagar.id, function (err, person) {
+                should.not.exist(err);
+                should.equal(person.name, 'Hagar2');
+
+                done();
+              });
+            });
+          });
+        });
+      });
+
+      it("off should not save associations but save itself", function (done) {
+        Person.one({ name: 'Hagar' }, function (err, hagar) {
+          should.not.exist(err);
+          should.exist(hagar.parent);
+
+          hagar.parent.name = 'Olga2';
+          hagar.save({ name: 'Hagar2' }, { saveAssociations: false }, function (err) {
+            should.not.exist(err);
+            should.equal(afterSaveCalled, true);
+
+            Person.get(hagar.parent.id, function (err, olga) {
+              should.not.exist(err);
+              should.equal(olga.name, 'Olga');
+              done();
+            });
+          });
+        });
+      });
+
+      it("on should save associations and itself", function (done) {
+        Person.one({ name: 'Hagar' }, function (err, hagar) {
+          should.not.exist(err);
+          should.exist(hagar.parent);
+
+          hagar.parent.name = 'Olga2';
+          hagar.save({ name: 'Hagar2' }, { saveAssociations: true }, function (err) {
+            should.not.exist(err);
+
+            Person.get(hagar.parent.id, function (err, olga) {
+              should.not.exist(err);
+              should.equal(olga.name, 'Olga2');
+
+              Person.get(hagar.id, function (err, person) {
+                should.not.exist(err);
+                should.equal(person.name, 'Hagar2');
+
+                done();
+              });
+            });
+          });
+        });
+      });
+    });
+  });
+
+  describe("with a point property", function () {
+    if (common.protocol() == 'sqlite' || common.protocol() == 'mongodb') return;
+
+    it("should save the instance as a geospatial point", function (done) {
+      setup({ type: "point" }, null)(function () {
+        var John = new Person({
+          name: { x: 51.5177, y: -0.0968 }
+        });
+        John.save(function (err) {
+          should.equal(err, null);
+
+          John.name.should.be.an.instanceOf(Object);
+          John.name.should.have.property('x', 51.5177);
+          John.name.should.have.property('y', -0.0968);
+          return done();
+        });
+      });
+    });
+  });
+
+  describe("mockable", function() {
+    before(setup());
+
+    it("save should be writable", function(done) {
+      var John = new Person({
+        name: "John"
+      });
+      var saveCalled = false;
+      John.save = function(cb) {
+        saveCalled = true;
+        cb(null);
+      };
+      John.save(function(err) {
+        should.equal(saveCalled,true);
+        return done();
+      });
+    });
+
+    it("saved should be writable", function(done) {
+      var John = new Person({
+        name: "John"
+      });
+      var savedCalled = false;
+      John.saved = function() {
+        savedCalled = true;
+        return true;
+      };
+
+      John.saved()
+      savedCalled.should.be.true;
+      done();
+    })
+  });
 });

--- a/test/integration/orm-exports.js
+++ b/test/integration/orm-exports.js
@@ -8,342 +8,342 @@ var common   = require('../common');
 var protocol = common.protocol();
 
 describe("ORM", function() {
-	describe("when loaded", function () {
-		it("should expose .express(), .use() and .connect()", function (done) {
-			ORM.express.should.be.a.Function();
-			ORM.use.should.be.a.Function();
-			ORM.connect.should.be.a.Function();
+  describe("when loaded", function () {
+    it("should expose .express(), .use() and .connect()", function (done) {
+      ORM.express.should.be.a.Function();
+      ORM.use.should.be.a.Function();
+      ORM.connect.should.be.a.Function();
 
-			return done();
-		});
+      return done();
+    });
 
-		it("should expose default settings container", function (done) {
-			ORM.settings.should.be.a.Object();
-			ORM.settings.get.should.be.a.Function();
-			ORM.settings.set.should.be.a.Function();
-			ORM.settings.unset.should.be.a.Function();
+    it("should expose default settings container", function (done) {
+      ORM.settings.should.be.a.Object();
+      ORM.settings.get.should.be.a.Function();
+      ORM.settings.set.should.be.a.Function();
+      ORM.settings.unset.should.be.a.Function();
 
-			return done();
-		});
+      return done();
+    });
 
-		it("should expose generic Settings constructor", function (done) {
-			ORM.Settings.should.be.a.Object();
-			ORM.Settings.Container.should.be.a.Function();
+    it("should expose generic Settings constructor", function (done) {
+      ORM.Settings.should.be.a.Object();
+      ORM.Settings.Container.should.be.a.Function();
 
-			return done();
-		});
+      return done();
+    });
 
-		it("should expose singleton manager", function (done) {
-			ORM.singleton.should.be.a.Object();
-			ORM.singleton.clear.should.be.a.Function();
+    it("should expose singleton manager", function (done) {
+      ORM.singleton.should.be.a.Object();
+      ORM.singleton.clear.should.be.a.Function();
 
-			return done();
-		});
+      return done();
+    });
 
-		it("should expose predefined validators", function (done) {
-			ORM.validators.should.be.a.Object();
-			ORM.validators.rangeNumber.should.be.a.Function();
-			ORM.validators.rangeLength.should.be.a.Function();
+    it("should expose predefined validators", function (done) {
+      ORM.validators.should.be.a.Object();
+      ORM.validators.rangeNumber.should.be.a.Function();
+      ORM.validators.rangeLength.should.be.a.Function();
 
-			return done();
-		});
-	});
+      return done();
+    });
+  });
 });
 
 describe("ORM.connect()", function () {
-	it("should expose .use(), .define(), .sync() and .load()", function (done) {
-		var db = ORM.connect();
+  it("should expose .use(), .define(), .sync() and .load()", function (done) {
+    var db = ORM.connect();
 
-		db.use.should.be.a.Function();
-		db.define.should.be.a.Function();
-		db.sync.should.be.a.Function();
-		db.load.should.be.a.Function();
+    db.use.should.be.a.Function();
+    db.define.should.be.a.Function();
+    db.sync.should.be.a.Function();
+    db.load.should.be.a.Function();
 
-		return done();
-	});
+    return done();
+  });
 
-	it("should emit an error if no url is passed", function (done) {
-		var db = ORM.connect();
+  it("should emit an error if no url is passed", function (done) {
+    var db = ORM.connect();
 
-		db.on("connect", function (err) {
-			err.message.should.equal("CONNECTION_URL_EMPTY");
+    db.on("connect", function (err) {
+      err.message.should.equal("CONNECTION_URL_EMPTY");
 
-			return done();
-		});
-	});
+      return done();
+    });
+  });
 
-	it("should allow protocol alias", function (done) {
-		var db = ORM.connect("pg://127.0.0.2");
+  it("should allow protocol alias", function (done) {
+    var db = ORM.connect("pg://127.0.0.2");
 
-		db.once("connect", function (err) {
-			should.exist(err);
-			err.message.should.not.equal("CONNECTION_PROTOCOL_NOT_SUPPORTED");
+    db.once("connect", function (err) {
+      should.exist(err);
+      err.message.should.not.equal("CONNECTION_PROTOCOL_NOT_SUPPORTED");
 
-			return done();
-		});
-	});
+      return done();
+    });
+  });
 
-	it("should emit an error if empty url is passed", function (done) {
-		var db = ORM.connect("");
+  it("should emit an error if empty url is passed", function (done) {
+    var db = ORM.connect("");
 
-		db.on("connect", function (err) {
-			err.message.should.equal("CONNECTION_URL_EMPTY");
+    db.on("connect", function (err) {
+      err.message.should.equal("CONNECTION_URL_EMPTY");
 
-			return done();
-		});
-	});
+      return done();
+    });
+  });
 
-	it("should emit an error if empty url (with only spaces) is passed", function (done) {
-		var db = ORM.connect("   ");
+  it("should emit an error if empty url (with only spaces) is passed", function (done) {
+    var db = ORM.connect("   ");
 
-		db.on("connect", function (err) {
-			err.message.should.equal("CONNECTION_URL_EMPTY");
+    db.on("connect", function (err) {
+      err.message.should.equal("CONNECTION_URL_EMPTY");
 
-			return done();
-		});
-	});
+      return done();
+    });
+  });
 
-	it("should emit an error if no protocol is passed", function (done) {
-		var db = ORM.connect("user@db");
+  it("should emit an error if no protocol is passed", function (done) {
+    var db = ORM.connect("user@db");
 
-		db.on("connect", function (err) {
-			err.message.should.equal("CONNECTION_URL_NO_PROTOCOL");
+    db.on("connect", function (err) {
+      err.message.should.equal("CONNECTION_URL_NO_PROTOCOL");
 
-			return done();
-		});
-	});
+      return done();
+    });
+  });
 
-	it("should emit an error if unknown protocol is passed", function (done) {
-		var db = ORM.connect("unknown://db");
+  it("should emit an error if unknown protocol is passed", function (done) {
+    var db = ORM.connect("unknown://db");
 
-		db.on("connect", function (err) {
-			should.equal(err.literalCode, 'NO_SUPPORT');
-			should.equal(
-				err.message,
-				"Connection protocol not supported - have you installed the database driver for unknown?"
-			);
+    db.on("connect", function (err) {
+      should.equal(err.literalCode, 'NO_SUPPORT');
+      should.equal(
+        err.message,
+        "Connection protocol not supported - have you installed the database driver for unknown?"
+      );
 
-			return done();
-		});
-	});
+      return done();
+    });
+  });
 
-	it("should emit an error if cannot connect", function (done) {
-		var db = ORM.connect("mysql://fakeuser:nopassword@127.0.0.1/unknowndb");
+  it("should emit an error if cannot connect", function (done) {
+    var db = ORM.connect("mysql://fakeuser:nopassword@127.0.0.1/unknowndb");
 
-		db.on("connect", function (err) {
-			should.exist(err);
-			should.equal(err.message.indexOf("Connection protocol not supported"), -1);
-			err.message.should.not.equal("CONNECTION_URL_NO_PROTOCOL");
-			err.message.should.not.equal("CONNECTION_URL_EMPTY");
+    db.on("connect", function (err) {
+      should.exist(err);
+      should.equal(err.message.indexOf("Connection protocol not supported"), -1);
+      err.message.should.not.equal("CONNECTION_URL_NO_PROTOCOL");
+      err.message.should.not.equal("CONNECTION_URL_EMPTY");
 
-			return done();
-		});
-	});
+      return done();
+    });
+  });
 
-	it("should emit valid error if exception being thrown during connection try", function (done) {
-		var testConfig = {
-			protocol : 'mongodb',
-			href     : 'unknownhost',
-			database : 'unknowndb',
-			user     : '',
-			password : ''
-		},
-		db = ORM.connect(testConfig);
+  it("should emit valid error if exception being thrown during connection try", function (done) {
+    var testConfig = {
+      protocol : 'mongodb',
+      href     : 'unknownhost',
+      database : 'unknowndb',
+      user     : '',
+      password : ''
+    },
+    db = ORM.connect(testConfig);
 
-		db.on("connect", function (err) {
-			should.exist(err);
-			should.equal(err.message.indexOf("Connection protocol not supported"), -1);
-			err.message.should.not.equal("CONNECTION_URL_NO_PROTOCOL");
-			err.message.should.not.equal("CONNECTION_URL_EMPTY");
+    db.on("connect", function (err) {
+      should.exist(err);
+      should.equal(err.message.indexOf("Connection protocol not supported"), -1);
+      err.message.should.not.equal("CONNECTION_URL_NO_PROTOCOL");
+      err.message.should.not.equal("CONNECTION_URL_EMPTY");
 
-			return done();
-		});
-	});
+      return done();
+    });
+  });
 
-	it("should not modify connection opts", function (done) {
-		var opts = {
-			protocol : 'mysql',
-			user     : 'notauser',
-			password : "wrong password",
-			query    : { pool: true, debug: true }
-		};
+  it("should not modify connection opts", function (done) {
+    var opts = {
+      protocol : 'mysql',
+      user     : 'notauser',
+      password : "wrong password",
+      query    : { pool: true, debug: true }
+    };
 
-		var expected = JSON.stringify(opts);
+    var expected = JSON.stringify(opts);
 
-		ORM.connect(opts, function (err, db) {
-			should.equal(
-				JSON.stringify(opts),
-				expected
-			);
-			done();
-		});
-	});
+    ORM.connect(opts, function (err, db) {
+      should.equal(
+        JSON.stringify(opts),
+        expected
+      );
+      done();
+    });
+  });
 
-	it("should emit no error if ok", function (done) {
-		var db = ORM.connect(common.getConnectionString());
+  it("should emit no error if ok", function (done) {
+    var db = ORM.connect(common.getConnectionString());
 
-		db.on("connect", function (err) {
-			should.not.exist(err);
+    db.on("connect", function (err) {
+      should.not.exist(err);
 
-			return done();
-		});
-	});
+      return done();
+    });
+  });
 
-	describe("if no connection error", function () {
-		var db = null;
+  describe("if no connection error", function () {
+    var db = null;
 
-		before(function (done) {
-			helper.connect(function (connection) {
-				db = connection;
+    before(function (done) {
+      helper.connect(function (connection) {
+        db = connection;
 
-				return done();
-			});
-		});
+        return done();
+      });
+    });
 
-		after(function () {
-			return db.close();
-		});
+    after(function () {
+      return db.close();
+    });
 
-		it("should be able to ping the server", function (done) {
-			db.ping(function () {
-				return done();
-			});
-		});
-	});
+    it("should be able to ping the server", function (done) {
+      db.ping(function () {
+        return done();
+      });
+    });
+  });
 
-	describe("if callback is passed", function (done) {
-		it("should return an error if empty url is passed", function (done) {
-			ORM.connect("", function (err) {
-				err.message.should.equal("CONNECTION_URL_EMPTY");
+  describe("if callback is passed", function (done) {
+    it("should return an error if empty url is passed", function (done) {
+      ORM.connect("", function (err) {
+        err.message.should.equal("CONNECTION_URL_EMPTY");
 
-				return done();
-			});
-		});
+        return done();
+      });
+    });
 
-		it("should return an error if no protocol is passed", function (done) {
-			ORM.connect("user@db", function (err) {
-				err.message.should.equal("CONNECTION_URL_NO_PROTOCOL");
+    it("should return an error if no protocol is passed", function (done) {
+      ORM.connect("user@db", function (err) {
+        err.message.should.equal("CONNECTION_URL_NO_PROTOCOL");
 
-				return done();
-			});
-		});
+        return done();
+      });
+    });
 
-		it("should return an error if unknown protocol is passed", function (done) {
-			ORM.connect("unknown://db", function (err) {
-				should.equal(err.literalCode, 'NO_SUPPORT');
-				should.equal(
-					err.message,
-					"Connection protocol not supported - have you installed the database driver for unknown?"
-				);
+    it("should return an error if unknown protocol is passed", function (done) {
+      ORM.connect("unknown://db", function (err) {
+        should.equal(err.literalCode, 'NO_SUPPORT');
+        should.equal(
+          err.message,
+          "Connection protocol not supported - have you installed the database driver for unknown?"
+        );
 
-				return done();
-			});
-		});
-	});
+        return done();
+      });
+    });
+  });
 
-	if (protocol != 'mongodb') {
-		describe("query options", function () {
-			it("should understand pool `'false'` from query string", function (done) {
-				var connString = common.getConnectionString() + "debug=false&pool=false";
-				ORM.connect(connString, function (err, db) {
-					should.not.exist(err);
-					should.strictEqual(db.driver.opts.pool,  false);
-					should.strictEqual(db.driver.opts.debug, false);
-					done();
-				});
-			});
+  if (protocol != 'mongodb') {
+    describe("query options", function () {
+      it("should understand pool `'false'` from query string", function (done) {
+        var connString = common.getConnectionString() + "debug=false&pool=false";
+        ORM.connect(connString, function (err, db) {
+          should.not.exist(err);
+          should.strictEqual(db.driver.opts.pool,  false);
+          should.strictEqual(db.driver.opts.debug, false);
+          done();
+        });
+      });
 
-			it("should understand pool `'0'` from query string", function (done) {
-				var connString = common.getConnectionString() + "debug=0&pool=0";
-				ORM.connect(connString, function (err, db) {
-					should.not.exist(err);
-					should.strictEqual(db.driver.opts.pool,  false);
-					should.strictEqual(db.driver.opts.debug, false);
-					done();
-				});
-			});
+      it("should understand pool `'0'` from query string", function (done) {
+        var connString = common.getConnectionString() + "debug=0&pool=0";
+        ORM.connect(connString, function (err, db) {
+          should.not.exist(err);
+          should.strictEqual(db.driver.opts.pool,  false);
+          should.strictEqual(db.driver.opts.debug, false);
+          done();
+        });
+      });
 
-			it("should understand pool `'true'` from query string", function (done) {
-				var connString = common.getConnectionString() + "debug=true&pool=true";
-				ORM.connect(connString, function (err, db) {
-					should.not.exist(err);
-					should.strictEqual(db.driver.opts.pool,  true);
-					should.strictEqual(db.driver.opts.debug, true);
-					done();
-				});
-			});
+      it("should understand pool `'true'` from query string", function (done) {
+        var connString = common.getConnectionString() + "debug=true&pool=true";
+        ORM.connect(connString, function (err, db) {
+          should.not.exist(err);
+          should.strictEqual(db.driver.opts.pool,  true);
+          should.strictEqual(db.driver.opts.debug, true);
+          done();
+        });
+      });
 
-			it("should understand pool `'1'` from query string", function (done) {
-				var connString = common.getConnectionString() + "debug=1&pool=1";
-				ORM.connect(connString, function (err, db) {
-					should.not.exist(err);
-					should.strictEqual(db.driver.opts.pool,  true);
-					should.strictEqual(db.driver.opts.debug, true);
-					done();
-				});
-			});
+      it("should understand pool `'1'` from query string", function (done) {
+        var connString = common.getConnectionString() + "debug=1&pool=1";
+        ORM.connect(connString, function (err, db) {
+          should.not.exist(err);
+          should.strictEqual(db.driver.opts.pool,  true);
+          should.strictEqual(db.driver.opts.debug, true);
+          done();
+        });
+      });
 
-			it("should understand pool `true` from query options", function (done) {
-				var connOpts = _.extend(common.getConfig(), {
-					protocol: common.protocol(),
-					query: {
-					  pool: true, debug: true
-					}
-				});
-				ORM.connect(connOpts, function (err, db) {
-					should.not.exist(err);
-					should.strictEqual(db.driver.opts.pool,  true);
-					should.strictEqual(db.driver.opts.debug, true);
-					done();
-				});
-			});
+      it("should understand pool `true` from query options", function (done) {
+        var connOpts = _.extend(common.getConfig(), {
+          protocol: common.protocol(),
+          query: {
+            pool: true, debug: true
+          }
+        });
+        ORM.connect(connOpts, function (err, db) {
+          should.not.exist(err);
+          should.strictEqual(db.driver.opts.pool,  true);
+          should.strictEqual(db.driver.opts.debug, true);
+          done();
+        });
+      });
 
-			it("should understand pool `false` from query options", function (done) {
-				var connOpts = _.extend(common.getConfig(), {
-					protocol: common.protocol(),
-					query: {
-					  pool: false, debug: false
-					}
-				});
-				ORM.connect(connOpts, function (err, db) {
-					should.not.exist(err);
-					should.strictEqual(db.driver.opts.pool,  false);
-					should.strictEqual(db.driver.opts.debug, false);
-					done();
-				});
-			});
-		});
-	}
+      it("should understand pool `false` from query options", function (done) {
+        var connOpts = _.extend(common.getConfig(), {
+          protocol: common.protocol(),
+          query: {
+            pool: false, debug: false
+          }
+        });
+        ORM.connect(connOpts, function (err, db) {
+          should.not.exist(err);
+          should.strictEqual(db.driver.opts.pool,  false);
+          should.strictEqual(db.driver.opts.debug, false);
+          done();
+        });
+      });
+    });
+  }
 });
 
 describe("ORM.use()", function () {
-	it("should be able to use an established connection", function (done) {
-		var db = new sqlite.Database(':memory:');
+  it("should be able to use an established connection", function (done) {
+    var db = new sqlite.Database(':memory:');
 
-		ORM.use(db, "sqlite", function (err) {
-			should.not.exist(err);
+    ORM.use(db, "sqlite", function (err) {
+      should.not.exist(err);
 
-			return done();
-		});
-	});
+      return done();
+    });
+  });
 
-	it("should be accept protocol alias", function (done) {
-		var db = new pg.Client();
+  it("should be accept protocol alias", function (done) {
+    var db = new pg.Client();
 
-		ORM.use(db, "pg", function (err) {
-			should.equal(err, null);
+    ORM.use(db, "pg", function (err) {
+      should.equal(err, null);
 
-			return done();
-		});
-	});
+      return done();
+    });
+  });
 
-	it("should return an error in callback if protocol not supported", function (done) {
-		var db = new pg.Client();
+  it("should return an error in callback if protocol not supported", function (done) {
+    var db = new pg.Client();
 
-		ORM.use(db, "unknowndriver", function (err) {
-			should.exist(err);
+    ORM.use(db, "unknowndriver", function (err) {
+      should.exist(err);
 
-			return done();
-		});
-	});
+      return done();
+    });
+  });
 });

--- a/test/integration/predefined-validators.js
+++ b/test/integration/predefined-validators.js
@@ -6,108 +6,108 @@ var protocol = common.protocol().toLowerCase();
 var undef      = undefined;
 
 function checkValidation(done, expected) {
-	return function (returned) {
-		should.equal(returned, expected);
+  return function (returned) {
+    should.equal(returned, expected);
 
-		return done();
-	};
+    return done();
+  };
 }
 
 describe("Predefined Validators", function () {
 
-	describe("equalToProperty('name')", function () {
-		it("should pass if equal", function (done) {
-			validators.equalToProperty('name').call({ name: "John Doe" }, 'John Doe', checkValidation(done));
-		});
-		it("should not pass if not equal", function (done) {
-			validators.equalToProperty('name').call({ name: "John" }, 'John Doe', checkValidation(done, 'not-equal-to-property'));
-		});
-		it("should not pass even if equal to other property", function (done) {
-			validators.equalToProperty('name').call({ surname: "John Doe" }, 'John Doe', checkValidation(done, 'not-equal-to-property'));
-		});
-	});
+  describe("equalToProperty('name')", function () {
+    it("should pass if equal", function (done) {
+      validators.equalToProperty('name').call({ name: "John Doe" }, 'John Doe', checkValidation(done));
+    });
+    it("should not pass if not equal", function (done) {
+      validators.equalToProperty('name').call({ name: "John" }, 'John Doe', checkValidation(done, 'not-equal-to-property'));
+    });
+    it("should not pass even if equal to other property", function (done) {
+      validators.equalToProperty('name').call({ surname: "John Doe" }, 'John Doe', checkValidation(done, 'not-equal-to-property'));
+    });
+  });
 
-	describe("unique()", function () {
-	    if (protocol === "mongodb") return;
+  describe("unique()", function () {
+      if (protocol === "mongodb") return;
 
-		var db = null;
-		var Person = null;
+    var db = null;
+    var Person = null;
 
-		var setup = function () {
-			return function (done) {
-				Person = db.define("person", {
-					name    : String,
-					surname : String
-				}, {
-					validations: {
-						surname: validators.unique()
-					}
-				});
+    var setup = function () {
+      return function (done) {
+        Person = db.define("person", {
+          name    : String,
+          surname : String
+        }, {
+          validations: {
+            surname: validators.unique()
+          }
+        });
 
-				Person.settings.set("instance.returnAllErrors", false);
+        Person.settings.set("instance.returnAllErrors", false);
 
-				return helper.dropSync(Person, function () {
-					Person.create([{
-						name    : "John",
-						surname : "Doe"
-					}], done);
-				});
-			};
-		};
+        return helper.dropSync(Person, function () {
+          Person.create([{
+            name    : "John",
+            surname : "Doe"
+          }], done);
+        });
+      };
+    };
 
-		before(function (done) {
-			helper.connect(function (connection) {
-				db = connection;
+    before(function (done) {
+      helper.connect(function (connection) {
+        db = connection;
 
-				return setup()(done);
-			});
-		});
+        return setup()(done);
+      });
+    });
 
-		after(function () {
-			return db.close();
-		});
+    after(function () {
+      return db.close();
+    });
 
-		it("should not pass if more elements with that property exist", function (done) {
-			var janeDoe = new Person({
-				name    : "Jane",
-				surname : "Doe" // <-- in table already!
-			});
-			janeDoe.save(function (err) {
-				err.should.be.a.Object();
-				err.should.have.property("property", "surname");
-				err.should.have.property("value",    "Doe");
-				err.should.have.property("msg",      "not-unique");
+    it("should not pass if more elements with that property exist", function (done) {
+      var janeDoe = new Person({
+        name    : "Jane",
+        surname : "Doe" // <-- in table already!
+      });
+      janeDoe.save(function (err) {
+        err.should.be.a.Object();
+        err.should.have.property("property", "surname");
+        err.should.have.property("value",    "Doe");
+        err.should.have.property("msg",      "not-unique");
 
-				return done();
-			});
-		});
+        return done();
+      });
+    });
 
-		it("should pass if no more elements with that property exist", function (done) {
-			var janeDean = new Person({
-				name    : "Jane",
-				surname : "Dean" // <-- not in table
-			});
-			janeDean.save(function (err) {
-				should.equal(err, null);
+    it("should pass if no more elements with that property exist", function (done) {
+      var janeDean = new Person({
+        name    : "Jane",
+        surname : "Dean" // <-- not in table
+      });
+      janeDean.save(function (err) {
+        should.equal(err, null);
 
-				return done();
-			});
-		});
+        return done();
+      });
+    });
 
-		it("should pass if resaving the same instance", function (done) {
-			Person.find({ name: "John", surname: "Doe" }, function (err, Johns) {
-				should.equal(err, null);
-				Johns.should.have.property("length", 1);
+    it("should pass if resaving the same instance", function (done) {
+      Person.find({ name: "John", surname: "Doe" }, function (err, Johns) {
+        should.equal(err, null);
+        Johns.should.have.property("length", 1);
 
-				Johns[0].surname = "Doe"; // forcing resave
+        Johns[0].surname = "Doe"; // forcing resave
 
-				Johns[0].save(function (err) {
-					should.equal(err, null);
+        Johns[0].save(function (err) {
+          should.equal(err, null);
 
-					return done();
-				});
-			});
-		});
-	});
+          return done();
+        });
+      });
+    });
+  });
 
 });

--- a/test/integration/property-custom.js
+++ b/test/integration/property-custom.js
@@ -4,171 +4,171 @@ var common   = require('../common');
 var ORM      = require('../../');
 
 describe("custom types", function() {
-	if (common.protocol() == 'mongodb') return;
+  if (common.protocol() == 'mongodb') return;
 
-	var db = null;
+  var db = null;
 
-	before(function (done) {
-		helper.connect(function (connection) {
-			db = connection;
+  before(function (done) {
+    helper.connect(function (connection) {
+      db = connection;
 
-			done();
-		});
-	});
+      done();
+    });
+  });
 
-	after(function () {
-		db.close();
-	});
+  after(function () {
+    db.close();
+  });
 
-	describe("simple", function () {
-		var LottoTicket = null;
+  describe("simple", function () {
+    var LottoTicket = null;
 
-		before(function (done) {
-			db.defineType('numberArray', {
-				datastoreType: function(prop) {
-					return 'TEXT'
-				},
-				valueToProperty: function(value, prop) {
-					if (Array.isArray(value)) {
-						return value;
-					} else {
-						return value.split(',').map(function (v) {
-							return Number(v);
-						});
-					}
-				},
-				propertyToValue: function(value, prop) {
-					return value.join(',')
-				}
-			});
+    before(function (done) {
+      db.defineType('numberArray', {
+        datastoreType: function(prop) {
+          return 'TEXT'
+        },
+        valueToProperty: function(value, prop) {
+          if (Array.isArray(value)) {
+            return value;
+          } else {
+            return value.split(',').map(function (v) {
+              return Number(v);
+            });
+          }
+        },
+        propertyToValue: function(value, prop) {
+          return value.join(',')
+        }
+      });
 
-			LottoTicket = db.define('lotto_ticket', {
-				numbers: { type: 'numberArray' }
-			});
+      LottoTicket = db.define('lotto_ticket', {
+        numbers: { type: 'numberArray' }
+      });
 
-			return helper.dropSync(LottoTicket, done);
-		});
+      return helper.dropSync(LottoTicket, done);
+    });
 
-		it("should create the table", function () {
-			should(true);
-		});
+    it("should create the table", function () {
+      should(true);
+    });
 
-		it("should store data in the table", function (done) {
-			var ticket = new LottoTicket({ numbers: [4,23,6,45,9,12,3,29] });
+    it("should store data in the table", function (done) {
+      var ticket = new LottoTicket({ numbers: [4,23,6,45,9,12,3,29] });
 
-			ticket.save(function (err) {
-				should.not.exist(err);
+      ticket.save(function (err) {
+        should.not.exist(err);
 
-				LottoTicket.find().all(function (err, items) {
-					should.not.exist(err);
-					should.equal(items.length, 1);
-					should(Array.isArray(items[0].numbers));
+        LottoTicket.find().all(function (err, items) {
+          should.not.exist(err);
+          should.equal(items.length, 1);
+          should(Array.isArray(items[0].numbers));
 
-					[4,23,6,45,9,12,3,29].should.eql(items[0].numbers);
+          [4,23,6,45,9,12,3,29].should.eql(items[0].numbers);
 
-					done();
-				});
-			});
-		});
+          done();
+        });
+      });
+    });
 
-		describe("hasMany extra properties", function () {
-			it("should work", function (done) {
-				db.defineType('customDate', {
-			    datastoreType: function (prop) {
-			      return 'TEXT';
-			    }
-			  });
-				var Person = db.define('person', {
-					name    : String,
-					surname : String,
-					age     : Number
-				});
-				var Pet = db.define('pet', {
-					name    : String
-				});
-				Person.hasMany('pets', Pet, { date: { type: 'customDate' } }, { autoFetch: true });
+    describe("hasMany extra properties", function () {
+      it("should work", function (done) {
+        db.defineType('customDate', {
+          datastoreType: function (prop) {
+            return 'TEXT';
+          }
+        });
+        var Person = db.define('person', {
+          name    : String,
+          surname : String,
+          age     : Number
+        });
+        var Pet = db.define('pet', {
+          name    : String
+        });
+        Person.hasMany('pets', Pet, { date: { type: 'customDate' } }, { autoFetch: true });
 
-				return helper.dropSync([ Person, Pet ], function (err) {
-					should.not.exist(err);
+        return helper.dropSync([ Person, Pet ], function (err) {
+          should.not.exist(err);
 
-					Person.create({
-						name    : "John",
-						surname : "Doe",
-						age     : 20
-					}, function (err, person) {
-						should.not.exist(err);
+          Person.create({
+            name    : "John",
+            surname : "Doe",
+            age     : 20
+          }, function (err, person) {
+            should.not.exist(err);
 
-						Pet.create({ name: 'Fido' }, function (err, pet) {
-							should.not.exist(err);
+            Pet.create({ name: 'Fido' }, function (err, pet) {
+              should.not.exist(err);
 
-							person.addPets(pet, { date: '2014-05-20' }, function (err) {
-								should.not.exist(err);
+              person.addPets(pet, { date: '2014-05-20' }, function (err) {
+                should.not.exist(err);
 
-								Person.get(person.id, function (err, freshPerson) {
-									should.not.exist(err);
-									should.equal(freshPerson.pets.length, 1);
-									should.equal(freshPerson.pets[0].extra.date, '2014-05-20');
-									done();
-								});
-							});
-						});
-					});
-				});
-			});
-		});
-	});
+                Person.get(person.id, function (err, freshPerson) {
+                  should.not.exist(err);
+                  should.equal(freshPerson.pets.length, 1);
+                  should.equal(freshPerson.pets[0].extra.date, '2014-05-20');
+                  done();
+                });
+              });
+            });
+          });
+        });
+      });
+    });
+  });
 
-	describe("complex", function () {
-		var WonkyTotal = null;
+  describe("complex", function () {
+    var WonkyTotal = null;
 
-		before(function (done) {
-			db.defineType('wonkyNumber', {
-				datastoreType: function (prop) {
-					return 'INTEGER';
-				},
-				datastoreGet: function (prop, helper) {
-					return helper.escape('?? - 1', [prop.mapsTo]);
-				},
-				valueToProperty: function (value, prop) {
-					return value + 7;
-				},
-				propertyToValue: function (value, prop) {
-					if (value == null) {
-						return value;
-					} else {
-						return function (helper) {
-							return helper.escape('(? - 2)', [value]);
-						};
-					}
-				}
-			});
+    before(function (done) {
+      db.defineType('wonkyNumber', {
+        datastoreType: function (prop) {
+          return 'INTEGER';
+        },
+        datastoreGet: function (prop, helper) {
+          return helper.escape('?? - 1', [prop.mapsTo]);
+        },
+        valueToProperty: function (value, prop) {
+          return value + 7;
+        },
+        propertyToValue: function (value, prop) {
+          if (value == null) {
+            return value;
+          } else {
+            return function (helper) {
+              return helper.escape('(? - 2)', [value]);
+            };
+          }
+        }
+      });
 
-			WonkyTotal = db.define('wonky', {
-				name:  String,
-				total: { type: 'wonkyNumber', mapsTo: 'blah_total' }
-			});
+      WonkyTotal = db.define('wonky', {
+        name:  String,
+        total: { type: 'wonkyNumber', mapsTo: 'blah_total' }
+      });
 
-			return helper.dropSync(WonkyTotal, done);
-		});
+      return helper.dropSync(WonkyTotal, done);
+    });
 
-		it("should store wonky total in a differently named field", function (done) {
-			var item = new WonkyTotal();
+    it("should store wonky total in a differently named field", function (done) {
+      var item = new WonkyTotal();
 
-			item.name  = "cabbages";
-			item.total = 8;
+      item.name  = "cabbages";
+      item.total = 8;
 
-			item.save(function (err) {
-				should.not.exist(err);
-				should.equal(item.total, 15);
+      item.save(function (err) {
+        should.not.exist(err);
+        should.equal(item.total, 15);
 
-				WonkyTotal.get(item.id, function (err, item) {
-					should.not.exist(err);
-					should.equal(item.total, 19); // (15 - 2) - 1 + 7
+        WonkyTotal.get(item.id, function (err, item) {
+          should.not.exist(err);
+          should.equal(item.total, 19); // (15 - 2) - 1 + 7
 
-					done();
-				});
-			});
-		});
-	});
+          done();
+        });
+      });
+    });
+  });
 
 });

--- a/test/integration/property-lazyload.js
+++ b/test/integration/property-lazyload.js
@@ -3,133 +3,133 @@ var helper   = require('../support/spec_helper');
 var ORM      = require('../../');
 
 describe("LazyLoad properties", function() {
-	var db = null;
-	var Person = null;
-	var PersonPhoto = new Buffer(1024); // fake photo
-	var OtherPersonPhoto = new Buffer(1024); // other fake photo
+  var db = null;
+  var Person = null;
+  var PersonPhoto = new Buffer(1024); // fake photo
+  var OtherPersonPhoto = new Buffer(1024); // other fake photo
 
-	var setup = function () {
-		return function (done) {
-			Person = db.define("person", {
-				name   : String,
-				photo  : { type: "binary", lazyload: true }
-			});
+  var setup = function () {
+    return function (done) {
+      Person = db.define("person", {
+        name   : String,
+        photo  : { type: "binary", lazyload: true }
+      });
 
-			ORM.singleton.clear();
+      ORM.singleton.clear();
 
-			return helper.dropSync(Person, function () {
-				Person.create({
-					name  : "John Doe",
-					photo : PersonPhoto
-				}, done);
-			});
-		};
-	};
+      return helper.dropSync(Person, function () {
+        Person.create({
+          name  : "John Doe",
+          photo : PersonPhoto
+        }, done);
+      });
+    };
+  };
 
-	before(function (done) {
-		helper.connect(function (connection) {
-			db = connection;
+  before(function (done) {
+    helper.connect(function (connection) {
+      db = connection;
 
-			return done();
-		});
-	});
+      return done();
+    });
+  });
 
-	after(function () {
-		return db.close();
-	});
+  after(function () {
+    return db.close();
+  });
 
-	describe("when defined", function () {
-		before(setup());
+  describe("when defined", function () {
+    before(setup());
 
-		it("should not be available when fetching an instance", function (done) {
-			Person.find().first(function (err, John) {
-				should.equal(err, null);
+    it("should not be available when fetching an instance", function (done) {
+      Person.find().first(function (err, John) {
+        should.equal(err, null);
 
-				John.should.be.a.Object();
+        John.should.be.a.Object();
 
-				John.should.have.property("name", "John Doe");
-				John.should.have.property("photo", null);
+        John.should.have.property("name", "John Doe");
+        John.should.have.property("photo", null);
 
-				return done();
-			});
-		});
+        return done();
+      });
+    });
 
-		it("should have apropriate accessors", function (done) {
-			Person.find().first(function (err, John) {
-				should.equal(err, null);
+    it("should have apropriate accessors", function (done) {
+      Person.find().first(function (err, John) {
+        should.equal(err, null);
 
-				John.should.be.a.Object();
-				John.getPhoto.should.be.a.Function();
-				John.setPhoto.should.be.a.Function();
-				John.removePhoto.should.be.a.Function();
+        John.should.be.a.Object();
+        John.getPhoto.should.be.a.Function();
+        John.setPhoto.should.be.a.Function();
+        John.removePhoto.should.be.a.Function();
 
-				return done();
-			});
-		});
+        return done();
+      });
+    });
 
-		it("getAccessor should return property", function (done) {
-			Person.find().first(function (err, John) {
-				should.equal(err, null);
+    it("getAccessor should return property", function (done) {
+      Person.find().first(function (err, John) {
+        should.equal(err, null);
 
-				John.should.be.a.Object();
+        John.should.be.a.Object();
 
-				John.getPhoto(function (err, photo) {
-					should.equal(err, null);
-					photo.toString().should.equal(PersonPhoto.toString());
+        John.getPhoto(function (err, photo) {
+          should.equal(err, null);
+          photo.toString().should.equal(PersonPhoto.toString());
 
-					return done();
-				});
-			});
-		});
+          return done();
+        });
+      });
+    });
 
-		it("setAccessor should change property", function (done) {
-			Person.find().first(function (err, John) {
-				should.equal(err, null);
+    it("setAccessor should change property", function (done) {
+      Person.find().first(function (err, John) {
+        should.equal(err, null);
 
-				John.should.be.a.Object();
+        John.should.be.a.Object();
 
-				John.setPhoto(OtherPersonPhoto, function (err) {
-					should.equal(err, null);
+        John.setPhoto(OtherPersonPhoto, function (err) {
+          should.equal(err, null);
 
-					Person.find().first(function (err, John) {
-						should.equal(err, null);
+          Person.find().first(function (err, John) {
+            should.equal(err, null);
 
-						John.should.be.a.Object();
+            John.should.be.a.Object();
 
-						John.getPhoto(function (err, photo) {
-							should.equal(err, null);
-							photo.toString().should.equal(OtherPersonPhoto.toString());
+            John.getPhoto(function (err, photo) {
+              should.equal(err, null);
+              photo.toString().should.equal(OtherPersonPhoto.toString());
 
-							return done();
-						});
-					});
-				});
-			});
-		});
+              return done();
+            });
+          });
+        });
+      });
+    });
 
-		it("removeAccessor should change property", function (done) {
-			Person.find().first(function (err, John) {
-				should.equal(err, null);
+    it("removeAccessor should change property", function (done) {
+      Person.find().first(function (err, John) {
+        should.equal(err, null);
 
-				John.should.be.a.Object();
+        John.should.be.a.Object();
 
-				John.removePhoto(function (err) {
-					should.equal(err, null);
+        John.removePhoto(function (err) {
+          should.equal(err, null);
 
-					Person.get(John[Person.id], function (err, John) {
-						should.equal(err, null);
+          Person.get(John[Person.id], function (err, John) {
+            should.equal(err, null);
 
-						John.should.be.a.Object();
+            John.should.be.a.Object();
 
-						John.getPhoto(function (err, photo) {
-							should.equal(err, null);
-							should.equal(photo, null);
+            John.getPhoto(function (err, photo) {
+              should.equal(err, null);
+              should.equal(photo, null);
 
-							return done();
-						});
-					});
-				});
-			});
-		});
-	});
+              return done();
+            });
+          });
+        });
+      });
+    });
+  });
 });

--- a/test/integration/property-maps-to.js
+++ b/test/integration/property-maps-to.js
@@ -7,285 +7,285 @@ var ORM      = require('../../');
 if (common.protocol() == "mongodb") return;
 
 describe("Property.mapsTo", function() {
-	var db = null;
+  var db = null;
 
-	before(function (done) {
-		helper.connect(function (connection) {
-			db = connection;
-			db.settings.set('instance.identityCache', false);
+  before(function (done) {
+    helper.connect(function (connection) {
+      db = connection;
+      db.settings.set('instance.identityCache', false);
 
-			return done();
-		});
-	});
+      return done();
+    });
+  });
 
-	after(function () {
-		return db.close();
-	});
+  after(function () {
+    return db.close();
+  });
 
-	describe("normal", function () {
-		var Book = null;
-		var id1 = null, id2 = null;
+  describe("normal", function () {
+    var Book = null;
+    var id1 = null, id2 = null;
 
-		before(function (done) {
-			Book = db.define("book", {
-				title: { type: 'text', mapsTo: 'book_title', required: true },
-				pages: { type: 'integer', required: false }
-			});
-			return helper.dropSync(Book, done);
-		});
+    before(function (done) {
+      Book = db.define("book", {
+        title: { type: 'text', mapsTo: 'book_title', required: true },
+        pages: { type: 'integer', required: false }
+      });
+      return helper.dropSync(Book, done);
+    });
 
-		it("should create", function (done) {
-			Book.create({ title: "History of the wheel", pages: 297 }, function (err, book) {
-				should.not.exist(err);
-				should.exist(book);
-				should.equal(book.title, "History of the wheel");
-				id1 = book.id;
+    it("should create", function (done) {
+      Book.create({ title: "History of the wheel", pages: 297 }, function (err, book) {
+        should.not.exist(err);
+        should.exist(book);
+        should.equal(book.title, "History of the wheel");
+        id1 = book.id;
 
-				done()
-			});
-		});
+        done()
+      });
+    });
 
-		it("should save new", function (done) {
-			book = new Book({ title: "Stuff", pages: 33 })
-			book.save(function (err, book) {
-				should.not.exist(err);
-				should.exist(book);
-				should.equal(book.title, "Stuff");
-				id2 = book.id;
+    it("should save new", function (done) {
+      book = new Book({ title: "Stuff", pages: 33 })
+      book.save(function (err, book) {
+        should.not.exist(err);
+        should.exist(book);
+        should.equal(book.title, "Stuff");
+        id2 = book.id;
 
-				done()
-			});
-		});
+        done()
+      });
+    });
 
-		it("should get book1", function (done) {
-			Book.get(id1, function (err, book) {
-				should.not.exist(err);
-				should.exist(book);
-				should.equal(book.title, "History of the wheel");
-				done();
-			});
-		});
+    it("should get book1", function (done) {
+      Book.get(id1, function (err, book) {
+        should.not.exist(err);
+        should.exist(book);
+        should.equal(book.title, "History of the wheel");
+        done();
+      });
+    });
 
-		it("should get book2", function (done) {
-			Book.get(id2, function (err, book) {
-				should.not.exist(err);
-				should.exist(book);
-				should.equal(book.title, "Stuff");
-				done();
-			});
-		});
+    it("should get book2", function (done) {
+      Book.get(id2, function (err, book) {
+        should.not.exist(err);
+        should.exist(book);
+        should.equal(book.title, "Stuff");
+        done();
+      });
+    });
 
-		it("should find", function (done) {
-			Book.one({ title: "History of the wheel" }, function (err, book) {
-				should.not.exist(err);
-				should.exist(book);
-				should.equal(book.title, "History of the wheel");
-				done();
-			});
-		});
+    it("should find", function (done) {
+      Book.one({ title: "History of the wheel" }, function (err, book) {
+        should.not.exist(err);
+        should.exist(book);
+        should.equal(book.title, "History of the wheel");
+        done();
+      });
+    });
 
-		it("should update", function (done) {
-			Book.one(function (err, book) {
-				should.not.exist(err);
-				should.exist(book);
-				should.equal(book.title, "History of the wheel");
+    it("should update", function (done) {
+      Book.one(function (err, book) {
+        should.not.exist(err);
+        should.exist(book);
+        should.equal(book.title, "History of the wheel");
 
-				book.title = "Quantum theory";
-				book.pages = 5;
+        book.title = "Quantum theory";
+        book.pages = 5;
 
-				book.save(function (err) {
-					should.not.exist(err);
-					should.equal(book.title, "Quantum theory");
+        book.save(function (err) {
+          should.not.exist(err);
+          should.equal(book.title, "Quantum theory");
 
-					Book.get(book.id, function (err, freshBook) {
-						should.not.exist(err);
-						should.exist(freshBook);
-						should.equal(book.title, "Quantum theory");
-						done();
-					});
-				});
-			});
-		});
+          Book.get(book.id, function (err, freshBook) {
+            should.not.exist(err);
+            should.exist(freshBook);
+            should.equal(book.title, "Quantum theory");
+            done();
+          });
+        });
+      });
+    });
 
-		it("should order", function (done) {
-			Book.create({ title: "Zzz", pages: 2 }, function (err) {
-				should.not.exist(err);
+    it("should order", function (done) {
+      Book.create({ title: "Zzz", pages: 2 }, function (err) {
+        should.not.exist(err);
 
-				Book.create({ title: "Aaa", pages: 3 }, function (err) {
-					should.not.exist(err);
+        Book.create({ title: "Aaa", pages: 3 }, function (err) {
+          should.not.exist(err);
 
-					Book.find().order("-title").all(function (err, items) {
-						should.not.exist(err);
-						should.equal(
-							_.map(items, 'title').join(','),
-							"Zzz,Stuff,Quantum theory,Aaa"
-						)
-						Book.find().order("title").all(function (err, items) {
-							should.not.exist(err);
-							should.equal(
-								_.map(items, 'title').join(','),
-								"Aaa,Quantum theory,Stuff,Zzz"
-							)
-							done();
-						});
-					});
-				});
-			});
-		});
-	});
+          Book.find().order("-title").all(function (err, items) {
+            should.not.exist(err);
+            should.equal(
+              _.map(items, 'title').join(','),
+              "Zzz,Stuff,Quantum theory,Aaa"
+            )
+            Book.find().order("title").all(function (err, items) {
+              should.not.exist(err);
+              should.equal(
+                _.map(items, 'title').join(','),
+                "Aaa,Quantum theory,Stuff,Zzz"
+              )
+              done();
+            });
+          });
+        });
+      });
+    });
+  });
 
-	describe("keys", function () {
-		var Person = null;
-		var id1 = null, id2 = null;
+  describe("keys", function () {
+    var Person = null;
+    var id1 = null, id2 = null;
 
-		before(function (done) {
-			Person = db.define("person", {
-				firstName: { type: 'text', mapsTo: 'first_name', key: true },
-				lastName:  { type: 'text', mapsTo: 'last_name',  key: true },
-				age:       { type: 'integer' }
-			});
+    before(function (done) {
+      Person = db.define("person", {
+        firstName: { type: 'text', mapsTo: 'first_name', key: true },
+        lastName:  { type: 'text', mapsTo: 'last_name',  key: true },
+        age:       { type: 'integer' }
+      });
 
-			return helper.dropSync(Person, done);
-		});
+      return helper.dropSync(Person, done);
+    });
 
-		it("should throw an error if invalid keys are specified", function () {
-			(function () {
-				db.define("blah", {
-					name: { type: 'text' }
-				}, {
-					id: ['banana']
-				});
-			}).should.throw("Model defined without any keys");
-		});
+    it("should throw an error if invalid keys are specified", function () {
+      (function () {
+        db.define("blah", {
+          name: { type: 'text' }
+        }, {
+          id: ['banana']
+        });
+      }).should.throw("Model defined without any keys");
+    });
 
-		it("should create", function (done) {
-			Person.create({ firstName: 'John', lastName: 'Smith', age: 48 }, function (err, person) {
-				should.not.exist(err);
-				should.exist(person);
-				should.equal(person.firstName, 'John');
-				should.equal(person.lastName,  'Smith');
-				id1 = [person.firstName, person.lastName];
+    it("should create", function (done) {
+      Person.create({ firstName: 'John', lastName: 'Smith', age: 48 }, function (err, person) {
+        should.not.exist(err);
+        should.exist(person);
+        should.equal(person.firstName, 'John');
+        should.equal(person.lastName,  'Smith');
+        id1 = [person.firstName, person.lastName];
 
-				done()
-			});
-		});
+        done()
+      });
+    });
 
-		it("should save new", function (done) {
-			person = new Person({ firstName: 'Jane', lastName: 'Doe', age: 50 });
+    it("should save new", function (done) {
+      person = new Person({ firstName: 'Jane', lastName: 'Doe', age: 50 });
 
-			person.save(function (err) {
-				should.not.exist(err);
-				should.exist(person);
-				should.equal(person.firstName, 'Jane');
-				should.equal(person.lastName,  'Doe');
-				id2 = [person.firstName, person.lastName];
+      person.save(function (err) {
+        should.not.exist(err);
+        should.exist(person);
+        should.equal(person.firstName, 'Jane');
+        should.equal(person.lastName,  'Doe');
+        id2 = [person.firstName, person.lastName];
 
-				done()
-			});
-		});
+        done()
+      });
+    });
 
-		it("should get person1", function (done) {
-			Person.get(id1[0], id1[1], function (err, person) {
-				should.not.exist(err);
-				should.exist(person);
-				should.equal(person.firstName, 'John');
-				should.equal(person.lastName,  'Smith');
-				done();
-			});
-		});
+    it("should get person1", function (done) {
+      Person.get(id1[0], id1[1], function (err, person) {
+        should.not.exist(err);
+        should.exist(person);
+        should.equal(person.firstName, 'John');
+        should.equal(person.lastName,  'Smith');
+        done();
+      });
+    });
 
-		it("should get person2", function (done) {
-			Person.get(id2[0], id2[1], function (err, person) {
-				should.not.exist(err);
-				should.exist(person);
-				should.equal(person.firstName, 'Jane');
-				should.equal(person.lastName,  'Doe');
-				done();
-			});
-		});
+    it("should get person2", function (done) {
+      Person.get(id2[0], id2[1], function (err, person) {
+        should.not.exist(err);
+        should.exist(person);
+        should.equal(person.firstName, 'Jane');
+        should.equal(person.lastName,  'Doe');
+        done();
+      });
+    });
 
-		it("should find", function (done) {
-			Person.one({ firstName: 'Jane' }, function (err, person) {
-				should.not.exist(err);
-				should.exist(person);
-				should.equal(person.firstName, 'Jane');
-				should.equal(person.lastName,  'Doe');
-				done();
-			});
-		});
+    it("should find", function (done) {
+      Person.one({ firstName: 'Jane' }, function (err, person) {
+        should.not.exist(err);
+        should.exist(person);
+        should.equal(person.firstName, 'Jane');
+        should.equal(person.lastName,  'Doe');
+        done();
+      });
+    });
 
-		it("should update", function (done) {
-			Person.one({ firstName: 'Jane' }, function (err, person) {
-				should.not.exist(err);
-				should.exist(person);
+    it("should update", function (done) {
+      Person.one({ firstName: 'Jane' }, function (err, person) {
+        should.not.exist(err);
+        should.exist(person);
 
-				person.firstName = 'Jeniffer';
-				person.save(function (err) {
-					should.not.exist(err);
+        person.firstName = 'Jeniffer';
+        person.save(function (err) {
+          should.not.exist(err);
 
-					should.equal(person.firstName, 'Jeniffer');
-					should.equal(person.lastName,  'Doe');
+          should.equal(person.firstName, 'Jeniffer');
+          should.equal(person.lastName,  'Doe');
 
-					Person.get(person.firstName, person.lastName, function (err, freshPerson) {
-						should.not.exist(err);
-						should.exist(freshPerson);
+          Person.get(person.firstName, person.lastName, function (err, freshPerson) {
+            should.not.exist(err);
+            should.exist(freshPerson);
 
-						should.equal(freshPerson.firstName, 'Jeniffer');
-						should.equal(freshPerson.lastName,  'Doe');
+            should.equal(freshPerson.firstName, 'Jeniffer');
+            should.equal(freshPerson.lastName,  'Doe');
 
-						freshPerson.lastName = 'Dee';
-						freshPerson.save(function (err) {
-							should.not.exist(err);
+            freshPerson.lastName = 'Dee';
+            freshPerson.save(function (err) {
+              should.not.exist(err);
 
-							should.equal(freshPerson.firstName, 'Jeniffer');
-							should.equal(freshPerson.lastName,  'Dee');
+              should.equal(freshPerson.firstName, 'Jeniffer');
+              should.equal(freshPerson.lastName,  'Dee');
 
-							Person.get(freshPerson.firstName, freshPerson.lastName, function (err, jennifer) {
-								should.not.exist(err);
+              Person.get(freshPerson.firstName, freshPerson.lastName, function (err, jennifer) {
+                should.not.exist(err);
 
-								should.equal(jennifer.firstName, 'Jeniffer');
-								should.equal(jennifer.lastName,  'Dee');
+                should.equal(jennifer.firstName, 'Jeniffer');
+                should.equal(jennifer.lastName,  'Dee');
 
-								done();
-							});
-						});
-					});
-				});
-			});
-		});
+                done();
+              });
+            });
+          });
+        });
+      });
+    });
 
-		it("should count", function (done) {
-			Person.create({ firstName: 'Greg', lastName: 'McDoofus', age: 30 }, function (err, person) {
-				should.not.exist(err);
+    it("should count", function (done) {
+      Person.create({ firstName: 'Greg', lastName: 'McDoofus', age: 30 }, function (err, person) {
+        should.not.exist(err);
 
-				Person.find({ firstName: 'Greg', lastName: 'McDoofus' }).count(function (err, count) {
-					should.not.exist(err);
-					should.equal(count, 1);
-					done();
-				});
-			});
-		});
+        Person.find({ firstName: 'Greg', lastName: 'McDoofus' }).count(function (err, count) {
+          should.not.exist(err);
+          should.equal(count, 1);
+          done();
+        });
+      });
+    });
 
-		it("should chain delete", function (done) {
-			Person.create({ firstName: 'Alfred', lastName: 'McDoogle', age: 50 }, function (err, person) {
-				should.not.exist(err);
+    it("should chain delete", function (done) {
+      Person.create({ firstName: 'Alfred', lastName: 'McDoogle', age: 50 }, function (err, person) {
+        should.not.exist(err);
 
-				Person.find({ firstName: 'Alfred', lastName: 'McDoogle' }).count(function (err, count) {
-					should.not.exist(err);
-					should.equal(count, 1);
+        Person.find({ firstName: 'Alfred', lastName: 'McDoogle' }).count(function (err, count) {
+          should.not.exist(err);
+          should.equal(count, 1);
 
-					Person.find({ firstName: 'Alfred', lastName: 'McDoogle' }).remove(function (err) {
-						should.not.exist(err);
+          Person.find({ firstName: 'Alfred', lastName: 'McDoogle' }).remove(function (err) {
+            should.not.exist(err);
 
-						Person.find({ firstName: 'Alfred', lastName: 'McDoogle' }).count(function (err, count) {
-							should.not.exist(err);
-							should.equal(count, 0);
+            Person.find({ firstName: 'Alfred', lastName: 'McDoogle' }).count(function (err, count) {
+              should.not.exist(err);
+              should.equal(count, 0);
 
-							done()
-						});
-					});
-				});
-			});
-		});
-	});
+              done()
+            });
+          });
+        });
+      });
+    });
+  });
 });

--- a/test/integration/property-number-size.js
+++ b/test/integration/property-number-size.js
@@ -13,119 +13,119 @@ function round(num, points) {
 }
 
 function fuzzyEql(num1, num2) {
-	return round(num1 / num2, 3) == 1;
+  return round(num1 / num2, 3) == 1;
 }
 
 if (protocol != "sqlite") {
-	describe("Number Properties", function() {
-		var db = null;
-		var NumberSize = null;
-		var NumberData = {
-			int2   : 32700,
-			int4   : 2147483000,
-			int8   : 2251799813685248,
-			float4 : 1 * Math.pow(10, 36),
-			float8 : 1 * Math.pow(10, 306)
-		};
+  describe("Number Properties", function() {
+    var db = null;
+    var NumberSize = null;
+    var NumberData = {
+      int2   : 32700,
+      int4   : 2147483000,
+      int8   : 2251799813685248,
+      float4 : 1 * Math.pow(10, 36),
+      float8 : 1 * Math.pow(10, 306)
+    };
 
-		var setup = function () {
-			return function (done) {
-				NumberSize = db.define("number_size", {
-					int2   : { type: 'integer', size: 2 },
-					int4   : { type: 'integer', size: 4 },
-					int8   : { type: 'integer', size: 8 },
-					float4 : { type: 'number',  size: 4 },
-					float8 : { type: 'number',  size: 8 }
-				});
+    var setup = function () {
+      return function (done) {
+        NumberSize = db.define("number_size", {
+          int2   : { type: 'integer', size: 2 },
+          int4   : { type: 'integer', size: 4 },
+          int8   : { type: 'integer', size: 8 },
+          float4 : { type: 'number',  size: 4 },
+          float8 : { type: 'number',  size: 8 }
+        });
 
-				return helper.dropSync(NumberSize, function () {
-					NumberSize.create(NumberData, done);
-				});
-			};
-		};
+        return helper.dropSync(NumberSize, function () {
+          NumberSize.create(NumberData, done);
+        });
+      };
+    };
 
-		before(function (done) {
-			helper.connect(function (connection) {
-				db = connection;
+    before(function (done) {
+      helper.connect(function (connection) {
+        db = connection;
 
-				return done();
-			});
-		});
+        return done();
+      });
+    });
 
-		after(function () {
-			return db.close();
-		});
+    after(function () {
+      return db.close();
+    });
 
-		describe("when storing", function () {
-			before(setup());
+    describe("when storing", function () {
+      before(setup());
 
-			it("should be able to store near MAX sized values for each field", function (done) {
-				NumberSize.one(function (err, Item) {
-					should.equal(err, null);
+      it("should be able to store near MAX sized values for each field", function (done) {
+        NumberSize.one(function (err, Item) {
+          should.equal(err, null);
 
-					should(fuzzyEql(Item.int2,   NumberData.int2));
-					should(fuzzyEql(Item.int4,   NumberData.int4));
-					should(fuzzyEql(Item.int8,   NumberData.int8));
-					should(fuzzyEql(Item.float4, NumberData.float4));
-					should(fuzzyEql(Item.float8, NumberData.float8));
+          should(fuzzyEql(Item.int2,   NumberData.int2));
+          should(fuzzyEql(Item.int4,   NumberData.int4));
+          should(fuzzyEql(Item.int8,   NumberData.int8));
+          should(fuzzyEql(Item.float4, NumberData.float4));
+          should(fuzzyEql(Item.float8, NumberData.float8));
 
-					return done();
-				});
-			});
+          return done();
+        });
+      });
 
-			it("should not be able to store int2 values which are too large", function (done) {
-				NumberSize.create({ int2 : NumberData.int4 }, function (err, item) {
-					if (protocol == "mysql") {
-						should.equal(err, null);
+      it("should not be able to store int2 values which are too large", function (done) {
+        NumberSize.create({ int2 : NumberData.int4 }, function (err, item) {
+          if (protocol == "mysql") {
+            should.equal(err, null);
 
-						return NumberSize.get(item.id, function (err, item) {
-							should(!fuzzyEql(item.int2, NumberData.int4));
+            return NumberSize.get(item.id, function (err, item) {
+              should(!fuzzyEql(item.int2, NumberData.int4));
 
-							return done();
-						});
-					} else {
-						err.should.be.a.Object();
-					}
+              return done();
+            });
+          } else {
+            err.should.be.a.Object();
+          }
 
-					return done();
-				});
-			});
+          return done();
+        });
+      });
 
-			it("should not be able to store int4 values which are too large", function (done) {
-				NumberSize.create({ int4 : NumberData.int8 }, function (err, item) {
-					if (protocol == "mysql") {
-						should.equal(err, null);
+      it("should not be able to store int4 values which are too large", function (done) {
+        NumberSize.create({ int4 : NumberData.int8 }, function (err, item) {
+          if (protocol == "mysql") {
+            should.equal(err, null);
 
-						return NumberSize.get(item.id, function (err, item) {
-							should(!fuzzyEql(item.int4, NumberData.int8));
+            return NumberSize.get(item.id, function (err, item) {
+              should(!fuzzyEql(item.int4, NumberData.int8));
 
-							return done();
-						});
-					} else {
-						err.should.be.a.Object();
-					}
+              return done();
+            });
+          } else {
+            err.should.be.a.Object();
+          }
 
-					return done();
-				});
-			});
+          return done();
+        });
+      });
 
-			it("should not be able to store float4 values which are too large", function (done) {
-				NumberSize.create({ float4 : NumberData.float8 }, function (err, item) {
-					if (protocol == "mysql") {
-						should.equal(err, null);
+      it("should not be able to store float4 values which are too large", function (done) {
+        NumberSize.create({ float4 : NumberData.float8 }, function (err, item) {
+          if (protocol == "mysql") {
+            should.equal(err, null);
 
-						return NumberSize.get(item.id, function (err, item) {
-							should(!fuzzyEql(item.float4, NumberData.float8));
+            return NumberSize.get(item.id, function (err, item) {
+              should(!fuzzyEql(item.float4, NumberData.float8));
 
-							return done();
-						});
-					} else {
-						err.should.be.a.Object();
-					}
+              return done();
+            });
+          } else {
+            err.should.be.a.Object();
+          }
 
-					return done();
-				});
-			});
-		});
-	});
+          return done();
+        });
+      });
+    });
+  });
 }

--- a/test/integration/property-timezones.js
+++ b/test/integration/property-timezones.js
@@ -5,104 +5,104 @@ var ORM      = require('../../');
 
 if (common.protocol() == "mongodb") return;
 if (common.protocol() == "sqlite" && !common.getConfig().pathname) {
-	// sqlite needs a pathname for this test (because of reconnecting)
-	// if using memory, when disconnecting everything is lost and this
-	// test needs it
-	return;
+  // sqlite needs a pathname for this test (because of reconnecting)
+  // if using memory, when disconnecting everything is lost and this
+  // test needs it
+  return;
 }
 
 describe("Timezones", function() {
-	var db    = null;
-	var Event = null;
+  var db    = null;
+  var Event = null;
 
-	var setup = function (opts) {
-		return function (done) {
-			helper.connect({ query: opts.query }, function (connection) {
-				db = connection;
-				db.settings.set('instance.identityCache', false);
+  var setup = function (opts) {
+    return function (done) {
+      helper.connect({ query: opts.query }, function (connection) {
+        db = connection;
+        db.settings.set('instance.identityCache', false);
 
-				Event = db.define("event", {
-					name : { type: 'text' },
-					when : { type: 'date', time: true }
-				});
+        Event = db.define("event", {
+          name : { type: 'text' },
+          when : { type: 'date', time: true }
+        });
 
-				if (opts.sync) {
-					return helper.dropSync(Event, done);
-				} else {
-					return done();
-				}
-			});
-		};
-	};
+        if (opts.sync) {
+          return helper.dropSync(Event, done);
+        } else {
+          return done();
+        }
+      });
+    };
+  };
 
-	describe("specified", function () {
-		var a, zones = [ 'local', '-0734'/*, '+11:22'*/ ];
+  describe("specified", function () {
+    var a, zones = [ 'local', '-0734'/*, '+11:22'*/ ];
 
-		for (a = 0; a < zones.length; a++ ) {
-			describe(zones[a], function () {
-				before(setup({ sync: true, query: { timezone: zones[a] } }));
+    for (a = 0; a < zones.length; a++ ) {
+      describe(zones[a], function () {
+        before(setup({ sync: true, query: { timezone: zones[a] } }));
 
-				after(function () {
-					return db.close();
-				});
+        after(function () {
+          return db.close();
+        });
 
-				it("should get back the same date that was stored", function (done) {
-					var when = new Date(2013, 12, 5, 5, 34, 27);
+        it("should get back the same date that was stored", function (done) {
+          var when = new Date(2013, 12, 5, 5, 34, 27);
 
-					Event.create({ name: "raid fridge", when: when }, function (err) {
-						should.not.exist(err);
+          Event.create({ name: "raid fridge", when: when }, function (err) {
+            should.not.exist(err);
 
-						Event.one({ name: "raid fridge" }, function (err, item) {
-							should.not.exist(err);
-							item.when.should.eql(when);
+            Event.one({ name: "raid fridge" }, function (err, item) {
+              should.not.exist(err);
+              item.when.should.eql(when);
 
-							return done();
-						});
-					});
-				});
-			});
-		}
-	});
+              return done();
+            });
+          });
+        });
+      });
+    }
+  });
 
-	describe("different for each connection", function () {
-		before(setup({
-			sync  : true,
-			query : { timezone: '+0200' }
-		}));
+  describe("different for each connection", function () {
+    before(setup({
+      sync  : true,
+      query : { timezone: '+0200' }
+    }));
 
-		after(function () {
-			return db.close();
-		});
+    after(function () {
+      return db.close();
+    });
 
-		// This isn't consistent accross drivers. Needs more thinking and investigation.
-		it("should get back a correctly offset time", function (done) {
-			var when = new Date(2013, 12, 5, 5, 34, 27);
+    // This isn't consistent accross drivers. Needs more thinking and investigation.
+    it("should get back a correctly offset time", function (done) {
+      var when = new Date(2013, 12, 5, 5, 34, 27);
 
-			Event.create({ name: "raid fridge", when: when }, function (err, new_event) {
-				should.not.exist(err);
+      Event.create({ name: "raid fridge", when: when }, function (err, new_event) {
+        should.not.exist(err);
 
-				Event.one({ name: "raid fridge" }, function (err, item) {
-					should.not.exist(err);
-					new_event.should.not.equal(item); // new_event was not cached
-					should.equal(new_event.when.toISOString(), item.when.toISOString());
+        Event.one({ name: "raid fridge" }, function (err, item) {
+          should.not.exist(err);
+          new_event.should.not.equal(item); // new_event was not cached
+          should.equal(new_event.when.toISOString(), item.when.toISOString());
 
-					db.close(function () {
-						setup({
-							sync  : false, // don't recreate table, don't want to loose previous value
-							query : { timezone: '+0400' }
-						})(function () {
-							Event.one({ name: "raid fridge" }, function (err, item) {
-								var expected = new Date(2013, 12, 5, 3, 34, 27);
+          db.close(function () {
+            setup({
+              sync  : false, // don't recreate table, don't want to loose previous value
+              query : { timezone: '+0400' }
+            })(function () {
+              Event.one({ name: "raid fridge" }, function (err, item) {
+                var expected = new Date(2013, 12, 5, 3, 34, 27);
 
-								should.not.exist(err);
-								item.when.should.eql(expected);
+                should.not.exist(err);
+                item.when.should.eql(expected);
 
-								return done();
-							});
-						});
-					});
-				});
-			});
-		});
-	});
+                return done();
+              });
+            });
+          });
+        });
+      });
+    });
+  });
 });

--- a/test/integration/property.js
+++ b/test/integration/property.js
@@ -3,104 +3,104 @@ var ORM      = require("../..");
 var Property = ORM.Property;
 
 describe("Property", function () {
-	it("passing String should return type: 'text'", function (done) {
-		Property.normalize(
-			{ prop: String, customTypes: {}, settings: ORM.settings, name: 'abc' }
-		).type.should.equal("text");
+  it("passing String should return type: 'text'", function (done) {
+    Property.normalize(
+      { prop: String, customTypes: {}, settings: ORM.settings, name: 'abc' }
+    ).type.should.equal("text");
 
-		return done();
-	});
-	it("passing Number should return type: 'number'", function (done) {
-		Property.normalize(
-			{ prop: Number, customTypes: {}, settings: ORM.settings, name: 'abc' }
-		).type.should.equal("number");
+    return done();
+  });
+  it("passing Number should return type: 'number'", function (done) {
+    Property.normalize(
+      { prop: Number, customTypes: {}, settings: ORM.settings, name: 'abc' }
+    ).type.should.equal("number");
 
-		return done();
-	});
-	it("passing deprecated rational: false number should return type: 'integer'", function (done) {
-		Property.normalize(
-			{ prop: {type: 'number', rational: false}, customTypes: {}, settings: ORM.settings, name: 'abc'}
-		).type.should.equal("integer");
+    return done();
+  });
+  it("passing deprecated rational: false number should return type: 'integer'", function (done) {
+    Property.normalize(
+      { prop: {type: 'number', rational: false}, customTypes: {}, settings: ORM.settings, name: 'abc'}
+    ).type.should.equal("integer");
 
-		return done();
-	});
+    return done();
+  });
 
-	it("passing Boolean should return type: 'boolean'", function (done) {
-		Property.normalize(
-			{ prop: Boolean, customTypes: {}, settings: ORM.settings, name: 'abc' }
-		).type.should.equal("boolean");
+  it("passing Boolean should return type: 'boolean'", function (done) {
+    Property.normalize(
+      { prop: Boolean, customTypes: {}, settings: ORM.settings, name: 'abc' }
+    ).type.should.equal("boolean");
 
-		return done();
-	});
-	it("passing Date should return type: 'date'", function (done) {
-		Property.normalize(
-			{ prop: Date, customTypes: {}, settings: ORM.settings, name: 'abc' }
-		).type.should.equal("date");
+    return done();
+  });
+  it("passing Date should return type: 'date'", function (done) {
+    Property.normalize(
+      { prop: Date, customTypes: {}, settings: ORM.settings, name: 'abc' }
+    ).type.should.equal("date");
 
-		return done();
-	});
-	it("passing Object should return type: 'object'", function (done) {
-		Property.normalize(
-			{ prop: Object, customTypes: {}, settings: ORM.settings, name: 'abc' }
-		).type.should.equal("object");
+    return done();
+  });
+  it("passing Object should return type: 'object'", function (done) {
+    Property.normalize(
+      { prop: Object, customTypes: {}, settings: ORM.settings, name: 'abc' }
+    ).type.should.equal("object");
 
-		return done();
-	});
-	it("passing Buffer should return type: 'binary'", function (done) {
-		Property.normalize(
-			{ prop: Buffer, customTypes: {}, settings: ORM.settings, name: 'abc' }
-		).type.should.equal("binary");
+    return done();
+  });
+  it("passing Buffer should return type: 'binary'", function (done) {
+    Property.normalize(
+      { prop: Buffer, customTypes: {}, settings: ORM.settings, name: 'abc' }
+    ).type.should.equal("binary");
 
-		return done();
-	});
-	it("passing an Array of items should return type: 'enum' with list of items", function (done) {
-		var prop = Property.normalize(
-			{ prop: [1, 2, 3], customTypes: {}, settings: ORM.settings, name: 'abc' }
-		)
+    return done();
+  });
+  it("passing an Array of items should return type: 'enum' with list of items", function (done) {
+    var prop = Property.normalize(
+      { prop: [1, 2, 3], customTypes: {}, settings: ORM.settings, name: 'abc' }
+    )
 
-		prop.type.should.equal("enum");
-		prop.values.should.have.property("length", 3);
+    prop.type.should.equal("enum");
+    prop.values.should.have.property("length", 3);
 
-		return done();
-	});
-	describe("passing a string type", function () {
-		it("should return type: <type>", function (done) {
-			Property.normalize(
-				{ prop: "text", customTypes: {}, settings: ORM.settings, name: 'abc' }
-			).type.should.equal("text");
+    return done();
+  });
+  describe("passing a string type", function () {
+    it("should return type: <type>", function (done) {
+      Property.normalize(
+        { prop: "text", customTypes: {}, settings: ORM.settings, name: 'abc' }
+      ).type.should.equal("text");
 
-			return done();
-		});
+      return done();
+    });
     it("should accept: 'point'", function (done) {
       Property.normalize(
-				{ prop: "point", customTypes: {}, settings: ORM.settings, name: 'abc' }
-			).type.should.equal("point");
+        { prop: "point", customTypes: {}, settings: ORM.settings, name: 'abc' }
+      ).type.should.equal("point");
 
       return done();
     });
 
-		describe("if not valid", function () {
-			it("should throw", function (done) {
-				(function () {
-					Property.normalize(
-						{ prop: "string", customTypes: {}, settings: ORM.settings, name: 'abc' }
-					)
-				}).should.throw();
+    describe("if not valid", function () {
+      it("should throw", function (done) {
+        (function () {
+          Property.normalize(
+            { prop: "string", customTypes: {}, settings: ORM.settings, name: 'abc' }
+          )
+        }).should.throw();
 
-				return done();
-			});
-		});
-	});
-	it("should not modify the original property object", function (done) {
-		var original = { type: 'text', required: true };
+        return done();
+      });
+    });
+  });
+  it("should not modify the original property object", function (done) {
+    var original = { type: 'text', required: true };
 
-		var normalized = Property.normalize(
-			{ prop: original, customTypes: {}, settings: ORM.settings, name: 'abc' }
-		);
+    var normalized = Property.normalize(
+      { prop: original, customTypes: {}, settings: ORM.settings, name: 'abc' }
+    );
 
-		original.test = 3;
-		should.strictEqual(normalized.test, undefined);
+    original.test = 3;
+    should.strictEqual(normalized.test, undefined);
 
-		return done();
-	});
+    return done();
+  });
 });

--- a/test/integration/settings.js
+++ b/test/integration/settings.js
@@ -4,136 +4,136 @@ var ORM      = require('../../');
 var Settings = ORM.Settings;
 
 describe("Settings", function () {
-	describe("changed on connection instance", function() {
-		it("should not change global defaults", function (done) {
-			var setting = 'instance.returnAllErrors';
-			var defaultValue = ORM.settings.get(setting);
+  describe("changed on connection instance", function() {
+    it("should not change global defaults", function (done) {
+      var setting = 'instance.returnAllErrors';
+      var defaultValue = ORM.settings.get(setting);
 
-			helper.connect(function (db) {
-				db.settings.set(setting, !defaultValue);
-				db.close();
+      helper.connect(function (db) {
+        db.settings.set(setting, !defaultValue);
+        db.close();
 
-				helper.connect(function (db) {
-					db.settings.get(setting).should.equal(defaultValue);
-					db.close();
-					done();
-				});
-			});
-		});
-	});
+        helper.connect(function (db) {
+          db.settings.get(setting).should.equal(defaultValue);
+          db.close();
+          done();
+        });
+      });
+    });
+  });
 
-	describe("#get", function () {
-		var settings, returned;
+  describe("#get", function () {
+    var settings, returned;
 
-		beforeEach(function () {
-			settings = new Settings.Container({ a: [1,2] });
-			returned = null;
-		});
+    beforeEach(function () {
+      settings = new Settings.Container({ a: [1,2] });
+      returned = null;
+    });
 
-		it("should clone everything it returns", function () {
-			returned = settings.get('*');
-			returned.a = 123;
+    it("should clone everything it returns", function () {
+      returned = settings.get('*');
+      returned.a = 123;
 
-			settings.get('a').should.eql([1,2]);
-		});
+      settings.get('a').should.eql([1,2]);
+    });
 
-		it("should deep clone everything it returns", function () {
-			returned = settings.get('*');
-			returned.a.push(3);
+    it("should deep clone everything it returns", function () {
+      returned = settings.get('*');
+      returned.a.push(3);
 
-			settings.get('a').should.eql([1,2]);
-		});
-	});
+      settings.get('a').should.eql([1,2]);
+    });
+  });
 
-	describe("manipulating:", function () {
-		var testFunction = function testFunction() {
-			return "test";
-		};
-		var settings = new Settings.Container({});
+  describe("manipulating:", function () {
+    var testFunction = function testFunction() {
+      return "test";
+    };
+    var settings = new Settings.Container({});
 
-		describe("some.sub.object = 123.45", function () {
-			before(function (done) {
-				settings.set("some.sub.object", 123.45);
-				return done();
-			});
+    describe("some.sub.object = 123.45", function () {
+      before(function (done) {
+        settings.set("some.sub.object", 123.45);
+        return done();
+      });
 
-			it("should be 123.45", function (done) {
-				settings.get("some.sub.object").should.equal(123.45);
+      it("should be 123.45", function (done) {
+        settings.get("some.sub.object").should.equal(123.45);
 
-				return done();
-			});
-		});
+        return done();
+      });
+    });
 
-		describe("some....object = testFunction", function () {
-			before(function (done) {
-				settings.set("some....object", testFunction);
-				return done();
-			});
+    describe("some....object = testFunction", function () {
+      before(function (done) {
+        settings.set("some....object", testFunction);
+        return done();
+      });
 
-			it("should be testFunction", function (done) {
-				settings.get("some....object").should.equal(testFunction);
+      it("should be testFunction", function (done) {
+        settings.get("some....object").should.equal(testFunction);
 
-				return done();
-			});
-		});
+        return done();
+      });
+    });
 
-		describe("not setting some.unknown.object", function () {
-			it("should be undefined", function (done) {
-				should.equal(settings.get("some.unknown.object"), undefined);
+    describe("not setting some.unknown.object", function () {
+      it("should be undefined", function (done) {
+        should.equal(settings.get("some.unknown.object"), undefined);
 
-				return done();
-			});
-		});
+        return done();
+      });
+    });
 
-		describe("unsetting some.sub.object", function () {
-			before(function (done) {
-				settings.unset("some.sub.object");
-				return done();
-			});
+    describe("unsetting some.sub.object", function () {
+      before(function (done) {
+        settings.unset("some.sub.object");
+        return done();
+      });
 
-			it("should be undefined", function (done) {
-				should.equal(settings.get("some.sub.object"), undefined);
+      it("should be undefined", function (done) {
+        should.equal(settings.get("some.sub.object"), undefined);
 
-				return done();
-			});
-		});
+        return done();
+      });
+    });
 
-		describe("unsetting some....object", function () {
-			before(function (done) {
-				settings.unset("some....object");
-				return done();
-			});
+    describe("unsetting some....object", function () {
+      before(function (done) {
+        settings.unset("some....object");
+        return done();
+      });
 
-			it("should be undefined", function (done) {
-				should.equal(settings.get("some....object"), undefined);
+      it("should be undefined", function (done) {
+        should.equal(settings.get("some....object"), undefined);
 
-				return done();
-			});
-		});
+        return done();
+      });
+    });
 
-		describe("unsetting some.*", function () {
-			before(function (done) {
-				settings.unset("some.*");
-				return done();
-			});
+    describe("unsetting some.*", function () {
+      before(function (done) {
+        settings.unset("some.*");
+        return done();
+      });
 
-			it("should return undefined for any 'some' sub-element", function (done) {
-				should.equal(settings.get("some.other.stuff"), undefined);
+      it("should return undefined for any 'some' sub-element", function (done) {
+        should.equal(settings.get("some.other.stuff"), undefined);
 
-				return done();
-			});
-			it("should return an empty object for some.*", function (done) {
-				settings.get("some.*").should.be.a.Object();
-				Object.keys(settings.get("some.*")).should.have.lengthOf(0);
+        return done();
+      });
+      it("should return an empty object for some.*", function (done) {
+        settings.get("some.*").should.be.a.Object();
+        Object.keys(settings.get("some.*")).should.have.lengthOf(0);
 
-				return done();
-			});
-			it("should return an empty object for some", function (done) {
-				settings.get("some").should.be.a.Object();
-				Object.keys(settings.get("some")).should.have.lengthOf(0);
+        return done();
+      });
+      it("should return an empty object for some", function (done) {
+        settings.get("some").should.be.a.Object();
+        Object.keys(settings.get("some")).should.have.lengthOf(0);
 
-				return done();
-			});
-		});
-	});
+        return done();
+      });
+    });
+  });
 });

--- a/test/integration/smart-types.js
+++ b/test/integration/smart-types.js
@@ -3,7 +3,6 @@ var helper   = require('../support/spec_helper');
 var ORM      = require('../../');
 
 describe("Smart types", function () {
-    this.timeout(0);
   var db = null;
   var User = null;
   var Profile = null;

--- a/test/integration/smart-types.js
+++ b/test/integration/smart-types.js
@@ -4,130 +4,130 @@ var ORM      = require('../../');
 
 describe("Smart types", function () {
     this.timeout(0);
-	var db = null;
-	var User = null;
-	var Profile = null;
-	var Post = null;
-	var Group = null;
+  var db = null;
+  var User = null;
+  var Profile = null;
+  var Post = null;
+  var Group = null;
 
-	var setup = function () {
-		return function (done) {
-		    User = db.define("user", {
-		        username: { type: 'text', size: 64 },
+  var setup = function () {
+    return function (done) {
+        User = db.define("user", {
+            username: { type: 'text', size: 64 },
                 password: { type: 'text', size: 128 }
-		    }, {
+        }, {
                 id: 'username'
-		    });
+        });
 
-		    Profile = User.extendsTo("profile", {
-		        firstname: String,
+        Profile = User.extendsTo("profile", {
+            firstname: String,
                 lastname: String
-		    }, {
-		        reverse: 'user',
+        }, {
+            reverse: 'user',
                 required: true
-		    });
+        });
 
-		    Group = db.define("group", {
-		        name: { type: 'text', size: 64 }
-		    }, {
+        Group = db.define("group", {
+            name: { type: 'text', size: 64 }
+        }, {
                 id: 'name'
-		    });
-		    Group.hasMany('users', User, {}, {
+        });
+        Group.hasMany('users', User, {}, {
                 reverse: 'groups'
-		    });
+        });
 
-		    Post = db.define("post", {
+        Post = db.define("post", {
                 content: String
-		    }, {
+        }, {
 
-		    });
-		    Post.hasOne('user', User, {
+        });
+        Post.hasOne('user', User, {
                 reverse: 'posts'
-		    });
+        });
 
-			ORM.singleton.clear();
-			return helper.dropSync([ User, Profile, Group, Post ], function () {
-			    User.create({
-			        username: 'billy',
-			        password: 'hashed password'
-			    }, function (err, billy) {
-			        should.not.exist(err);
-			        billy.setProfile(new Profile({ firstname: 'William', lastname: 'Franklin' }), function (err, profile) {
-			            should.not.exist(err);
-			            billy.addGroups([new Group({ name: 'admins' }), new Group({ name: 'developers' })], function (err, groups) {
-			                should.not.exist(err);
-			                billy.setPosts(new Post({content: 'Hello world!'}), function(err, posts) {
-			                    should.not.exist(err);
-			                    done();
-			                });
-			            });
-			        });
-			    });
-			});
-		};
-	};
+      ORM.singleton.clear();
+      return helper.dropSync([ User, Profile, Group, Post ], function () {
+          User.create({
+              username: 'billy',
+              password: 'hashed password'
+          }, function (err, billy) {
+              should.not.exist(err);
+              billy.setProfile(new Profile({ firstname: 'William', lastname: 'Franklin' }), function (err, profile) {
+                  should.not.exist(err);
+                  billy.addGroups([new Group({ name: 'admins' }), new Group({ name: 'developers' })], function (err, groups) {
+                      should.not.exist(err);
+                      billy.setPosts(new Post({content: 'Hello world!'}), function(err, posts) {
+                          should.not.exist(err);
+                          done();
+                      });
+                  });
+              });
+          });
+      });
+    };
+  };
 
-	before(function (done) {
-		helper.connect(function (connection) {
-			db = connection;
+  before(function (done) {
+    helper.connect(function (connection) {
+      db = connection;
 
-			return done();
-		});
-	});
+      return done();
+    });
+  });
 
-	after(function () {
-		return db.close();
-	});
+  after(function () {
+    return db.close();
+  });
 
-	describe("extends", function () {
-		before(setup());
+  describe("extends", function () {
+    before(setup());
 
-		it("should be able to get extendsTo with custom id", function (done) {
-		    User.get('billy', function (err, billy) {
-		        should.not.exist(err);
-		        should.exist(billy);
+    it("should be able to get extendsTo with custom id", function (done) {
+        User.get('billy', function (err, billy) {
+            should.not.exist(err);
+            should.exist(billy);
 
-		        billy.getProfile(function (err, profile) {
-		            should.not.exist(err);
-		            should.exist(profile);
-		            should.equal(profile.firstname, 'William');
-		            should.equal(profile.lastname, 'Franklin');
+            billy.getProfile(function (err, profile) {
+                should.not.exist(err);
+                should.exist(profile);
+                should.equal(profile.firstname, 'William');
+                should.equal(profile.lastname, 'Franklin');
 
-		            done();
-		        });
-		    });
-		});
+                done();
+            });
+        });
+    });
 
-		it("should be able to get hasOne with custom id", function (done) {
-		    User.get('billy', function (err, billy) {
-		        should.not.exist(err);
-		        should.exist(billy);
+    it("should be able to get hasOne with custom id", function (done) {
+        User.get('billy', function (err, billy) {
+            should.not.exist(err);
+            should.exist(billy);
 
-		        billy.getPosts(function (err, posts) {
-		            should.not.exist(err);
-		            should.exist(posts);
-		            should.equal(posts.length, 1);
-		            should.equal(posts[0].content, 'Hello world!');
+            billy.getPosts(function (err, posts) {
+                should.not.exist(err);
+                should.exist(posts);
+                should.equal(posts.length, 1);
+                should.equal(posts[0].content, 'Hello world!');
 
-		            done();
-		        });
-		    });
-		});
+                done();
+            });
+        });
+    });
 
-		it("should be able to get hasMany with custom id", function (done) {
-		    User.get('billy', function (err, billy) {
-		        should.not.exist(err);
-		        should.exist(billy);
+    it("should be able to get hasMany with custom id", function (done) {
+        User.get('billy', function (err, billy) {
+            should.not.exist(err);
+            should.exist(billy);
 
-		        billy.getGroups(function (err, groups) {
-		            should.not.exist(err);
-		            should.exist(groups);
-		            should.equal(groups.length, 2);
+            billy.getGroups(function (err, groups) {
+                should.not.exist(err);
+                should.exist(groups);
+                should.equal(groups.length, 2);
 
-		            done();
-		        });
-		    });
-		});
+                done();
+            });
+        });
+    });
 
-	});
+  });
 });

--- a/test/integration/validation.js
+++ b/test/integration/validation.js
@@ -7,484 +7,484 @@ var protocol = common.protocol().toLowerCase();
 var ORM      = require('../../');
 
 describe("Validations", function() {
-	var db = null;
-	var Person = null;
-	var Person2 = null;
+  var db = null;
+  var Person = null;
+  var Person2 = null;
 
-	var setup = function (returnAll, required) {
-		return function (done) {
-			db.settings.set('properties.required',      required);
-			db.settings.set('instance.returnAllErrors', returnAll);
+  var setup = function (returnAll, required) {
+    return function (done) {
+      db.settings.set('properties.required',      required);
+      db.settings.set('instance.returnAllErrors', returnAll);
 
-			Person = db.define("person", {
-				name:   { type: 'text'   },
-				height: { type: 'number' },
-			}, {
-				validations: {
-					name:   ORM.validators.rangeLength(3, 30),
-					height: ORM.validators.rangeNumber(0.1, 3.0)
-				}
-			});
+      Person = db.define("person", {
+        name:   { type: 'text'   },
+        height: { type: 'number' },
+      }, {
+        validations: {
+          name:   ORM.validators.rangeLength(3, 30),
+          height: ORM.validators.rangeNumber(0.1, 3.0)
+        }
+      });
 
-			return helper.dropSync(Person, done);
-		};
-	};
+      return helper.dropSync(Person, done);
+    };
+  };
 
-	notNull = function(val, next, data) {
-		if (val != null) {
-			return next('notnull');
-		}
-		return next();
-	};
-	var setupAlwaysValidate = function () {
-		return function (done) {
-			Person2 = db.define("person2", {
-				name:   { type: 'text'   },
-				mustbenull: { type: 'text', required:false, alwaysValidate: true }
-				, canbenull: { type: 'text', required:false }
-			}, {
-				validations: {
-					name:   ORM.validators.rangeLength(3, 30),
-					mustbenull: notNull,
-					canbenull: notNull
-				}
-			});
-			return helper.dropSync(Person2, done);
-		};
-	};
+  notNull = function(val, next, data) {
+    if (val != null) {
+      return next('notnull');
+    }
+    return next();
+  };
+  var setupAlwaysValidate = function () {
+    return function (done) {
+      Person2 = db.define("person2", {
+        name:   { type: 'text'   },
+        mustbenull: { type: 'text', required:false, alwaysValidate: true }
+        , canbenull: { type: 'text', required:false }
+      }, {
+        validations: {
+          name:   ORM.validators.rangeLength(3, 30),
+          mustbenull: notNull,
+          canbenull: notNull
+        }
+      });
+      return helper.dropSync(Person2, done);
+    };
+  };
 
-	before(function (done) {
-		helper.connect(function (connection) {
-			db = connection;
-			done();
-		});
-	});
+  before(function (done) {
+    helper.connect(function (connection) {
+      db = connection;
+      done();
+    });
+  });
 
-	after(function () {
-		db.close();
-	});
+  after(function () {
+    db.close();
+  });
 
 
-	describe("alwaysValidate", function () {
-		before(setupAlwaysValidate());
+  describe("alwaysValidate", function () {
+    before(setupAlwaysValidate());
 
-		it("I want to see it fail first (the absence of evidence)", function(done) {
-			var rachel = new Person2({name: 'rachel', canbenull:null, mustbenull:null});
-			rachel.save(function (err) {
-				should.not.exist(err);
-				return done();
-			});
-		});
+    it("I want to see it fail first (the absence of evidence)", function(done) {
+      var rachel = new Person2({name: 'rachel', canbenull:null, mustbenull:null});
+      rachel.save(function (err) {
+        should.not.exist(err);
+        return done();
+      });
+    });
 
-		it("then it should work", function(done) {
-			var tom = new Person2({name: 'tom', canbenull:null, mustbenull:'notnull'});
-			tom.save(function (err) {
-				should.exist(err);
-				should.equal(typeof err,   "object");
-				should.equal(err.property, "mustbenull");
-				should.equal(err.msg,      "notnull");
-				should.equal(err.type,     "validation");
-				should.equal(tom.id,      null);
-				return done();
-			});
-		});
-	});
+    it("then it should work", function(done) {
+      var tom = new Person2({name: 'tom', canbenull:null, mustbenull:'notnull'});
+      tom.save(function (err) {
+        should.exist(err);
+        should.equal(typeof err,   "object");
+        should.equal(err.property, "mustbenull");
+        should.equal(err.msg,      "notnull");
+        should.equal(err.type,     "validation");
+        should.equal(tom.id,      null);
+        return done();
+      });
+    });
+  });
 
-	describe("predefined", function () {
-		before(setup(false, false));
+  describe("predefined", function () {
+    before(setup(false, false));
 
-		it("should work", function(done) {
-			var john = new Person({name: 'fdhdjendfjkdfhshdfhakdfjajhfdjhbfgk'});
+    it("should work", function(done) {
+      var john = new Person({name: 'fdhdjendfjkdfhshdfhakdfjajhfdjhbfgk'});
 
-			john.save(function (err) {
-				should.equal(typeof err,   "object");
-				should.equal(err.property, "name");
-				should.equal(err.value,    "fdhdjendfjkdfhshdfhakdfjajhfdjhbfgk");
-				should.equal(err.msg,      "out-of-range-length");
-				should.equal(err.type,     "validation");
-				should.equal(john.id,      null);
+      john.save(function (err) {
+        should.equal(typeof err,   "object");
+        should.equal(err.property, "name");
+        should.equal(err.value,    "fdhdjendfjkdfhshdfhakdfjajhfdjhbfgk");
+        should.equal(err.msg,      "out-of-range-length");
+        should.equal(err.type,     "validation");
+        should.equal(john.id,      null);
 
-				return done();
-			});
-		});
+        return done();
+      });
+    });
 
-		describe("unique", function () {
-			if (protocol === "mongodb") return;
+    describe("unique", function () {
+      if (protocol === "mongodb") return;
 
-			var Product = null, Supplier = null;
+      var Product = null, Supplier = null;
 
-			var setupUnique = function (ignoreCase, scope, msg) {
-				return function (done) {
-					Supplier = db.define("supplier", {
-						name     : String
+      var setupUnique = function (ignoreCase, scope, msg) {
+        return function (done) {
+          Supplier = db.define("supplier", {
+            name     : String
                     }, {
-						cache: false
-					});
-					helper.dropSync(Supplier, function(err){
-						if (err) {
-							return done(err);
-						}
-
-						Product = db.define("productUnique", {
-							instock  : { type: 'boolean', required: true, defaultValue: false },
-							name     : String,
-							category : String
-						}, {
-							cache: false,
-							validations: {
-								name      : ORM.validators.unique({ ignoreCase: ignoreCase, scope: scope }, msg),
-								instock   : ORM.validators.required(),
-								productId : ORM.validators.unique() // this must be straight after a required & validated row.
-							}
-						});
-				        Product.hasOne('supplier',  Supplier,  { field: 'supplierId' });
-
-						return helper.dropSync(Product, done);
-					});
-				};
-			};
-
-			describe("simple", function () {
-				before(setupUnique(false, false));
-
-				it("should return validation error for duplicate name", function (done) {
-					Product.create({name: 'fork'}, function (err, product) {
-						should.not.exist(err);
-
-						Product.create({name: 'fork'}, function (err, product) {
-							should.exist(err);
-
-							return done();
-						});
-					});
-				});
-
-				it("should pass with different names", function (done) {
-					Product.create({name: 'spatula'}, function (err, product) {
-						should.not.exist(err);
-
-						Product.create({name: 'plate'}, function (err, product) {
-							should.not.exist(err);
-
-							return done();
-						});
-					});
-				});
-
-				// Technically this is covered by the tests above, but I'm putting it here for clarity's sake. 3 HOURS WASTED *sigh.
-				it("should not leak required state from previous validation for association properties [regression test]", function (done) {
-					Product.create({ name: 'pencil', productId: null}, function (err, product) {
-						should.not.exist(err);
-
-						Product.create({ name: 'pencilcase', productId: null }, function (err, product) {
-							should.not.exist(err);
-
-							return done();
-						});
-					});
-				});
-			});
-
-			describe("scope", function () {
-				describe("to other property", function () {
-
-					before(setupUnique(true, ['category']));
-
-					it("should return validation error if other property also matches", function(done) {
-						Product.create({name: 'red', category: 'chair'}, function (err, product) {
-							should.not.exist(err);
-
-							Product.create({name: 'red', category: 'chair'}, function (err, product) {
-								should.exist(err);
-								should.equal(err.msg, 'not-unique');
-
-								return done();
-							});
-						});
-					});
-
-					it("should pass if other property is different", function (done) {
-						Product.create({name: 'blue', category: 'chair'}, function (err, product) {
-							should.not.exist(err);
-
-							Product.create({name: 'blue', category: 'pen'}, function (err, product) {
-								should.not.exist(err);
-
-								return done();
-							});
-						});
-					});
-
-					// In SQL unique index land, NULL values are not considered equal.
-					it("should pass if other property is null", function (done) {
-						Product.create({name: 'blue', category: null}, function (err, product) {
-							should.not.exist(err);
-
-							Product.create({name: 'blue', category: null}, function (err, product) {
-								should.not.exist(err);
-
-								return done();
-							});
-						});
-					});
-				});
-
-				describe("to hasOne property", function () {
-					firstId = secondId = null;
-
-					before(function(done){
-						setupUnique(true, ['supplierId'])(function(err) {
-							should.not.exist(err);
-							Supplier.create({name: 'first'}, function (err, supplier) {
-								should.not.exist(err);
-
-								firstId = supplier.id;
-
-								Supplier.create({name: 'second'}, function (err, supplier) {
-									should.not.exist(err);
-
-									secondId = supplier.id;
-									done();
-								});
-							});
-						});
-					});
-
-					it("should return validation error if hasOne property also matches", function(done) {
-						Product.create({name: 'red', supplierId: firstId}, function (err, product) {
-							should.not.exist(err);
-
-							Product.create({name: 'red', supplierId: firstId}, function (err, product) {
-								should.exist(err);
-								should.equal(err.msg, 'not-unique');
-
-								return done();
-							});
-						});
-					});
-
-					it("should pass if hasOne property is different", function (done) {
-						Product.create({name: 'blue', supplierId: firstId}, function (err, product) {
-							should.not.exist(err);
-
-							Product.create({name: 'blue', supplierId: secondId}, function (err, product) {
-								should.not.exist(err);
-
-								return done();
-							});
-						});
-					});
-
-					// In SQL unique index land, NULL values are not considered equal.
-					it("should pass if other property is null", function (done) {
-						Product.create({name: 'blue', category: null}, function (err, product) {
-							should.not.exist(err);
-
-							Product.create({name: 'blue', category: null}, function (err, product) {
-								should.not.exist(err);
-
-								return done();
-							});
-						});
-					});
-				});
-			});
-
-			describe("ignoreCase", function () {
-				if (protocol != 'mysql') {
-					it("false should do a case sensitive comparison", function (done) {
-						setupUnique(false, false)(function (err) {
-							should.not.exist(err);
-
-							Product.create({name: 'spork'}, function (err, product) {
-								should.not.exist(err);
-
-								Product.create({name: 'spOrk'}, function (err, product) {
-									should.not.exist(err);
-
-									return done();
-								});
-							});
-						});
-					});
-				}
-
-				it("true should do a case insensitive comparison", function (done) {
-					setupUnique(true, false)(function (err) {
-						should.not.exist(err);
-
-						Product.create({name: 'stapler'}, function (err, product) {
-							should.not.exist(err);
-
-							Product.create({name: 'staplER'}, function (err, product) {
-								should.exist(err);
-								should.equal(err.msg, 'not-unique');
-
-								return done();
-							});
-						});
-					});
-				});
-
-				it("true should do a case insensitive comparison on scoped properties too", function (done) {
-					setupUnique(true, ['category'], "name already taken for this category")(function (err) {
-						should.not.exist(err);
-
-						Product.create({name: 'black', category: 'pen'}, function (err, product) {
-							should.not.exist(err);
-
-							Product.create({name: 'Black', category: 'Pen'}, function (err, product) {
-								should.exist(err);
-								should.equal(err.msg, "name already taken for this category");
-
-								return done();
-							});
-						});
-					});
-				});
-
-			});
-		});
-	});
-
-	describe("instance.returnAllErrors = false", function() {
-		describe("properties.required = false", function() {
-			before(setup(false, false));
-
-			it("should save when properties are null", function(done) {
-				var john = new Person();
-
-				john.save(function (err) {
-					should.equal(err, null);
-					should.exist(john[Person.id]);
-
-					return done();
-				});
-			});
-
-			it("shouldn't save when a property is invalid", function(done) {
-				var john = new Person({ height: 4 });
-
-				john.save(function (err) {
-					should.notEqual(err, null);
-					should.equal(err.property, 'height');
-					should.equal(err.value,     4);
-					should.equal(err.msg,      'out-of-range-number');
-					should.equal(err.type,     'validation');
-					should.equal(john.id,      null);
-
-					return done();
-				});
-			});
-		});
-
-		describe("properties.required = true", function() {
-			before(setup(false, true));
-
-			it("should not save when properties are null", function(done) {
-				var john = new Person();
-
-				john.save(function (err) {
-					should.notEqual(err, null);
-					should.equal(john.id, null);
-
-					return done();
-				});
-			});
-
-			it("should return a required error when the first property is blank", function(done) {
-				var john = new Person({ height: 4 });
-
-				john.save(function (err) {
-					should.notEqual(err, null);
-					should.equal(err.property, 'name');
-					should.equal(err.value,    null);
-					should.equal(err.msg,      'required');
-					should.equal(err.type,     'validation');
-					should.equal(john.id,      null);
-
-					return done();
-				});
-			});
-		});
-	});
-
-	describe("instance.returnAllErrors = true", function() {
-		describe("properties.required = false", function() {
-			before(setup(true, false));
-
-			it("should return all errors when a property is invalid", function(done) {
-				var john = new Person({ name: 'n', height: 4 });
-
-				john.save(function (err) {
-					should.notEqual(err, null);
-					should(Array.isArray(err));
-					should.equal(err.length, 2);
-
-					should.deepEqual(err[0], _.extend(new Error('out-of-range-length'), {
-						property: 'name', value: 'n', msg: 'out-of-range-length', type: 'validation'
-					}));
-
-					should.deepEqual(err[1], _.extend(new Error('out-of-range-number'), {
-						property: 'height', value: 4, msg: 'out-of-range-number', type: 'validation'
-					}));
-
-					should.equal(john.id, null);
-
-					return done();
-				});
-			});
-		});
-
-		describe("properties.required = true", function() {
-			before(setup(true, true));
-
-			it("should return required and user specified validation errors", function(done) {
-				var john = new Person({ height: 4 });
-
-				john.save(function (err) {
-					should.notEqual(err, null);
-					should(Array.isArray(err));
-					should.equal(err.length, 3);
-
-					should.deepEqual(err[0], _.extend(new Error('required'), {
-						property: 'name', value: null, msg: 'required', type: 'validation'
-					}));
-
-					should.deepEqual(err[1], _.extend(new Error('undefined'), {
-						property: 'name', value: null, msg: 'undefined', type: 'validation'
-					}));
-
-					should.deepEqual(err[2], _.extend(new Error('out-of-range-number'), {
-						property: 'height', value: 4, msg: 'out-of-range-number', type: 'validation'
-					}));
-
-					should.equal(john.id, null);
-
-					return done();
-				});
-			});
-		});
-	});
-
-	describe("mockable", function() {
-		before(setup());
-
-		it("validate should be writable", function(done) {
-			var John = new Person({
-				name: "John"
-			});
-			var validateCalled = false;
-			John.validate = function(cb) {
-				validateCalled = true;
-				cb(null);
-			};
-			John.validate(function(err) {
-				should.equal(validateCalled,true);
-				return done();
-			});
-		});
-	});
+            cache: false
+          });
+          helper.dropSync(Supplier, function(err){
+            if (err) {
+              return done(err);
+            }
+
+            Product = db.define("productUnique", {
+              instock  : { type: 'boolean', required: true, defaultValue: false },
+              name     : String,
+              category : String
+            }, {
+              cache: false,
+              validations: {
+                name      : ORM.validators.unique({ ignoreCase: ignoreCase, scope: scope }, msg),
+                instock   : ORM.validators.required(),
+                productId : ORM.validators.unique() // this must be straight after a required & validated row.
+              }
+            });
+                Product.hasOne('supplier',  Supplier,  { field: 'supplierId' });
+
+            return helper.dropSync(Product, done);
+          });
+        };
+      };
+
+      describe("simple", function () {
+        before(setupUnique(false, false));
+
+        it("should return validation error for duplicate name", function (done) {
+          Product.create({name: 'fork'}, function (err, product) {
+            should.not.exist(err);
+
+            Product.create({name: 'fork'}, function (err, product) {
+              should.exist(err);
+
+              return done();
+            });
+          });
+        });
+
+        it("should pass with different names", function (done) {
+          Product.create({name: 'spatula'}, function (err, product) {
+            should.not.exist(err);
+
+            Product.create({name: 'plate'}, function (err, product) {
+              should.not.exist(err);
+
+              return done();
+            });
+          });
+        });
+
+        // Technically this is covered by the tests above, but I'm putting it here for clarity's sake. 3 HOURS WASTED *sigh.
+        it("should not leak required state from previous validation for association properties [regression test]", function (done) {
+          Product.create({ name: 'pencil', productId: null}, function (err, product) {
+            should.not.exist(err);
+
+            Product.create({ name: 'pencilcase', productId: null }, function (err, product) {
+              should.not.exist(err);
+
+              return done();
+            });
+          });
+        });
+      });
+
+      describe("scope", function () {
+        describe("to other property", function () {
+
+          before(setupUnique(true, ['category']));
+
+          it("should return validation error if other property also matches", function(done) {
+            Product.create({name: 'red', category: 'chair'}, function (err, product) {
+              should.not.exist(err);
+
+              Product.create({name: 'red', category: 'chair'}, function (err, product) {
+                should.exist(err);
+                should.equal(err.msg, 'not-unique');
+
+                return done();
+              });
+            });
+          });
+
+          it("should pass if other property is different", function (done) {
+            Product.create({name: 'blue', category: 'chair'}, function (err, product) {
+              should.not.exist(err);
+
+              Product.create({name: 'blue', category: 'pen'}, function (err, product) {
+                should.not.exist(err);
+
+                return done();
+              });
+            });
+          });
+
+          // In SQL unique index land, NULL values are not considered equal.
+          it("should pass if other property is null", function (done) {
+            Product.create({name: 'blue', category: null}, function (err, product) {
+              should.not.exist(err);
+
+              Product.create({name: 'blue', category: null}, function (err, product) {
+                should.not.exist(err);
+
+                return done();
+              });
+            });
+          });
+        });
+
+        describe("to hasOne property", function () {
+          firstId = secondId = null;
+
+          before(function(done){
+            setupUnique(true, ['supplierId'])(function(err) {
+              should.not.exist(err);
+              Supplier.create({name: 'first'}, function (err, supplier) {
+                should.not.exist(err);
+
+                firstId = supplier.id;
+
+                Supplier.create({name: 'second'}, function (err, supplier) {
+                  should.not.exist(err);
+
+                  secondId = supplier.id;
+                  done();
+                });
+              });
+            });
+          });
+
+          it("should return validation error if hasOne property also matches", function(done) {
+            Product.create({name: 'red', supplierId: firstId}, function (err, product) {
+              should.not.exist(err);
+
+              Product.create({name: 'red', supplierId: firstId}, function (err, product) {
+                should.exist(err);
+                should.equal(err.msg, 'not-unique');
+
+                return done();
+              });
+            });
+          });
+
+          it("should pass if hasOne property is different", function (done) {
+            Product.create({name: 'blue', supplierId: firstId}, function (err, product) {
+              should.not.exist(err);
+
+              Product.create({name: 'blue', supplierId: secondId}, function (err, product) {
+                should.not.exist(err);
+
+                return done();
+              });
+            });
+          });
+
+          // In SQL unique index land, NULL values are not considered equal.
+          it("should pass if other property is null", function (done) {
+            Product.create({name: 'blue', category: null}, function (err, product) {
+              should.not.exist(err);
+
+              Product.create({name: 'blue', category: null}, function (err, product) {
+                should.not.exist(err);
+
+                return done();
+              });
+            });
+          });
+        });
+      });
+
+      describe("ignoreCase", function () {
+        if (protocol != 'mysql') {
+          it("false should do a case sensitive comparison", function (done) {
+            setupUnique(false, false)(function (err) {
+              should.not.exist(err);
+
+              Product.create({name: 'spork'}, function (err, product) {
+                should.not.exist(err);
+
+                Product.create({name: 'spOrk'}, function (err, product) {
+                  should.not.exist(err);
+
+                  return done();
+                });
+              });
+            });
+          });
+        }
+
+        it("true should do a case insensitive comparison", function (done) {
+          setupUnique(true, false)(function (err) {
+            should.not.exist(err);
+
+            Product.create({name: 'stapler'}, function (err, product) {
+              should.not.exist(err);
+
+              Product.create({name: 'staplER'}, function (err, product) {
+                should.exist(err);
+                should.equal(err.msg, 'not-unique');
+
+                return done();
+              });
+            });
+          });
+        });
+
+        it("true should do a case insensitive comparison on scoped properties too", function (done) {
+          setupUnique(true, ['category'], "name already taken for this category")(function (err) {
+            should.not.exist(err);
+
+            Product.create({name: 'black', category: 'pen'}, function (err, product) {
+              should.not.exist(err);
+
+              Product.create({name: 'Black', category: 'Pen'}, function (err, product) {
+                should.exist(err);
+                should.equal(err.msg, "name already taken for this category");
+
+                return done();
+              });
+            });
+          });
+        });
+
+      });
+    });
+  });
+
+  describe("instance.returnAllErrors = false", function() {
+    describe("properties.required = false", function() {
+      before(setup(false, false));
+
+      it("should save when properties are null", function(done) {
+        var john = new Person();
+
+        john.save(function (err) {
+          should.equal(err, null);
+          should.exist(john[Person.id]);
+
+          return done();
+        });
+      });
+
+      it("shouldn't save when a property is invalid", function(done) {
+        var john = new Person({ height: 4 });
+
+        john.save(function (err) {
+          should.notEqual(err, null);
+          should.equal(err.property, 'height');
+          should.equal(err.value,     4);
+          should.equal(err.msg,      'out-of-range-number');
+          should.equal(err.type,     'validation');
+          should.equal(john.id,      null);
+
+          return done();
+        });
+      });
+    });
+
+    describe("properties.required = true", function() {
+      before(setup(false, true));
+
+      it("should not save when properties are null", function(done) {
+        var john = new Person();
+
+        john.save(function (err) {
+          should.notEqual(err, null);
+          should.equal(john.id, null);
+
+          return done();
+        });
+      });
+
+      it("should return a required error when the first property is blank", function(done) {
+        var john = new Person({ height: 4 });
+
+        john.save(function (err) {
+          should.notEqual(err, null);
+          should.equal(err.property, 'name');
+          should.equal(err.value,    null);
+          should.equal(err.msg,      'required');
+          should.equal(err.type,     'validation');
+          should.equal(john.id,      null);
+
+          return done();
+        });
+      });
+    });
+  });
+
+  describe("instance.returnAllErrors = true", function() {
+    describe("properties.required = false", function() {
+      before(setup(true, false));
+
+      it("should return all errors when a property is invalid", function(done) {
+        var john = new Person({ name: 'n', height: 4 });
+
+        john.save(function (err) {
+          should.notEqual(err, null);
+          should(Array.isArray(err));
+          should.equal(err.length, 2);
+
+          should.deepEqual(err[0], _.extend(new Error('out-of-range-length'), {
+            property: 'name', value: 'n', msg: 'out-of-range-length', type: 'validation'
+          }));
+
+          should.deepEqual(err[1], _.extend(new Error('out-of-range-number'), {
+            property: 'height', value: 4, msg: 'out-of-range-number', type: 'validation'
+          }));
+
+          should.equal(john.id, null);
+
+          return done();
+        });
+      });
+    });
+
+    describe("properties.required = true", function() {
+      before(setup(true, true));
+
+      it("should return required and user specified validation errors", function(done) {
+        var john = new Person({ height: 4 });
+
+        john.save(function (err) {
+          should.notEqual(err, null);
+          should(Array.isArray(err));
+          should.equal(err.length, 3);
+
+          should.deepEqual(err[0], _.extend(new Error('required'), {
+            property: 'name', value: null, msg: 'required', type: 'validation'
+          }));
+
+          should.deepEqual(err[1], _.extend(new Error('undefined'), {
+            property: 'name', value: null, msg: 'undefined', type: 'validation'
+          }));
+
+          should.deepEqual(err[2], _.extend(new Error('out-of-range-number'), {
+            property: 'height', value: 4, msg: 'out-of-range-number', type: 'validation'
+          }));
+
+          should.equal(john.id, null);
+
+          return done();
+        });
+      });
+    });
+  });
+
+  describe("mockable", function() {
+    before(setup());
+
+    it("validate should be writable", function(done) {
+      var John = new Person({
+        name: "John"
+      });
+      var validateCalled = false;
+      John.validate = function(cb) {
+        validateCalled = true;
+        cb(null);
+      };
+      John.validate(function(err) {
+        should.equal(validateCalled,true);
+        return done();
+      });
+    });
+  });
 
 
 });

--- a/test/logging.js
+++ b/test/logging.js
@@ -4,26 +4,26 @@ exports.info = buildMethod(process.stdout, "[i]", 34);
 exports.error = buildMethod(process.stderr, "[!]", 31);
 
 function buildMethod(stream, prefix, color) {
-	return function () {
-		var params = Array.prototype.slice.apply(arguments);
-		var text   = params.shift();
+  return function () {
+    var params = Array.prototype.slice.apply(arguments);
+    var text   = params.shift();
 
-		return printTo(stream, prefix + " ", color, text, params);
-	};
+    return printTo(stream, prefix + " ", color, text, params);
+  };
 }
 
 function printTo(stream, prefix, color, text, params) {
-	params.unshift(text);
-	text = util.format.apply(util, params);
+  params.unshift(text);
+  text = util.format.apply(util, params);
 
-	stream.write(printColor(color, true) + prefix + printColor(color) + text.replace(/\*\*(.+?)\*\*/, function (m, t) {
-		return printColor(color, true) + t + printColor(color);
-	}) + printColor(null) + "\n");
+  stream.write(printColor(color, true) + prefix + printColor(color) + text.replace(/\*\*(.+?)\*\*/, function (m, t) {
+    return printColor(color, true) + t + printColor(color);
+  }) + printColor(null) + "\n");
 }
 
 function printColor(color, bold) {
-	if (color === null) {
-		return "\033[0m";
-	}
-	return "\033[" + (bold ? "1" : "0") + ";" + color + "m";
+  if (color === null) {
+    return "\033[0m";
+  }
+  return "\033[" + (bold ? "1" : "0") + ";" + color + "m";
 }

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,2 +1,2 @@
 --reporter spec
---timeout 5000
+--timeout 10000

--- a/test/run.js
+++ b/test/run.js
@@ -8,7 +8,7 @@ var logging  = require("./logging");
 var location = path.normalize(path.join(__dirname, "integration", "**", "*.js"));
 var mocha    = new Mocha({
   reporter: "progress",
-  timeout: 5000
+  timeout: 10000
 });
 
 switch (common.hasConfig(common.protocol())) {

--- a/test/run.js
+++ b/test/run.js
@@ -7,48 +7,48 @@ var logging  = require("./logging");
 
 var location = path.normalize(path.join(__dirname, "integration", "**", "*.js"));
 var mocha    = new Mocha({
-	reporter: "progress",
-	timeout: 5000
+  reporter: "progress",
+  timeout: 5000
 });
 
 switch (common.hasConfig(common.protocol())) {
-	case 'not-defined':
-		logging.error("There's no configuration for protocol **%s**", common.protocol());
-		process.exit(0);
-	case 'not-found':
-		logging.error("**test/config.js** missing. Take a look at **test/config.example.js**");
-		process.exit(0);
+  case 'not-defined':
+    logging.error("There's no configuration for protocol **%s**", common.protocol());
+    process.exit(0);
+  case 'not-found':
+    logging.error("**test/config.js** missing. Take a look at **test/config.example.js**");
+    process.exit(0);
 }
 
 runTests();
 
 function runTests() {
-	if (common.protocol() == 'mongodb' && common.nodeVersion().major > 6) {
-		console.warn(chalk.red("MongoDB 1.x doesn't work with node 7, 8 or newer."));
-		console.warn(chalk.red("Tests will not run."));
-		console.warn(chalk.red("If you would like this to work, please submit a pull request."));
-		return;
-	}
+  if (common.protocol() == 'mongodb' && common.nodeVersion().major > 6) {
+    console.warn(chalk.red("MongoDB 1.x doesn't work with node 7, 8 or newer."));
+    console.warn(chalk.red("Tests will not run."));
+    console.warn(chalk.red("If you would like this to work, please submit a pull request."));
+    return;
+  }
 
-	glob.sync(location).forEach(function (file) {
-		if (!shouldRunTest(file)) return;
-		mocha.addFile(file);
-	});
+  glob.sync(location).forEach(function (file) {
+    if (!shouldRunTest(file)) return;
+    mocha.addFile(file);
+  });
 
-	logging.info("Testing **%s**", common.getConnectionString());
+  logging.info("Testing **%s**", common.getConnectionString());
 
-	mocha.run(function (failures) {
-		process.exit(failures);
-	});
+  mocha.run(function (failures) {
+    process.exit(failures);
+  });
 }
 
 function shouldRunTest(file) {
-	var name  = path.basename(file).slice(0, -3)
-	var proto = common.protocol();
-	var exclude = ['model-aggregate','property-number-size','smart-types'];
+  var name  = path.basename(file).slice(0, -3)
+  var proto = common.protocol();
+  var exclude = ['model-aggregate','property-number-size','smart-types'];
 
-	if (proto == "mongodb" && exclude.indexOf(name) >= 0) return false;
+  if (proto == "mongodb" && exclude.indexOf(name) >= 0) return false;
 
-	return true;
+  return true;
 }
 

--- a/test/support/my_plugin.js
+++ b/test/support/my_plugin.js
@@ -1,19 +1,19 @@
 module.exports = function MyPlugin(DB, opts) {
-	opts.option.should.be.true;
-	opts.calledDefine.should.be.false;
+  opts.option.should.be.true;
+  opts.calledDefine.should.be.false;
 
-	return {
-		define: function (Model) {
-			Model.should.be.a.Function();
-			Model.id.should.be.a.Object();
-			Model.id[0].should.be.a.String();
+  return {
+    define: function (Model) {
+      Model.should.be.a.Function();
+      Model.id.should.be.a.Object();
+      Model.id[0].should.be.a.String();
 
-			opts.calledDefine = true;
-		},
-		beforeDefine: function (model_name, model_props, model_opts) {
-			if (opts.beforeDefine) {
-				opts.beforeDefine(model_name, model_props, model_opts);
-			}
-		}
-	};
+      opts.calledDefine = true;
+    },
+    beforeDefine: function (model_name, model_props, model_opts) {
+      if (opts.beforeDefine) {
+        opts.beforeDefine(model_name, model_props, model_opts);
+      }
+    }
+  };
 };

--- a/test/support/spec_helper.js
+++ b/test/support/spec_helper.js
@@ -3,33 +3,33 @@ var async  = require('async');
 var should = require('should');
 
 module.exports.connect = function(cb) {
-	var opts = {};
+  var opts = {};
 
-	if (1 in arguments) {
-		opts = arguments[0];
-		cb   = arguments[1];
-	}
-	common.createConnection(opts, function (err, conn) {
-		if (err) throw err;
-		cb(conn);
-	});
+  if (1 in arguments) {
+    opts = arguments[0];
+    cb   = arguments[1];
+  }
+  common.createConnection(opts, function (err, conn) {
+    if (err) throw err;
+    cb(conn);
+  });
 };
 
 module.exports.dropSync = function (models, done) {
-	if (!Array.isArray(models)) {
-		models = [models];
-	}
+  if (!Array.isArray(models)) {
+    models = [models];
+  }
 
-	async.eachSeries(models, function (item, cb) {
-		item.drop(function (err) {
-			if (err) throw err;
+  async.eachSeries(models, function (item, cb) {
+    item.drop(function (err) {
+      if (err) throw err;
 
-			item.sync(cb);
-		});
-	}, function (err) {
-		if (common.protocol() != 'sqlite') {
-			if (err) throw err;
-		}
-		done(err);
-	});
+      item.sync(cb);
+    });
+  }, function (err) {
+    if (common.protocol() != 'sqlite') {
+      if (err) throw err;
+    }
+    done(err);
+  });
 };

--- a/test/support/spec_load.js
+++ b/test/support/spec_load.js
@@ -1,7 +1,7 @@
 module.exports = function (db, cb) {
-	db.define("person", {
-		name : String
-	});
+  db.define("person", {
+    name : String
+  });
 
-	return db.load("./spec_load_second", cb);
+  return db.load("./spec_load_second", cb);
 };

--- a/test/support/spec_load_second.js
+++ b/test/support/spec_load_second.js
@@ -1,9 +1,9 @@
 module.exports = function (db, cb) {
-	db.define("pet", {
-		name : String
-	});
+  db.define("pet", {
+    name : String
+  });
 
-	setTimeout(function () {
-		return cb();
-	}, 200);
+  setTimeout(function () {
+    return cb();
+  }, 200);
 };

--- a/test/support/spec_load_third.js
+++ b/test/support/spec_load_third.js
@@ -1,9 +1,9 @@
 module.exports = function (db, cb) {
-	db.define("person", {
-		name : String
-	});
+  db.define("person", {
+    name : String
+  });
 
-	setTimeout(function () {
-		return cb();
-	}, 200);
+  setTimeout(function () {
+    return cb();
+  }, 200);
 };


### PR DESCRIPTION
Sorry [Richard Hendricks](https://www.youtube.com/watch?v=SsoOG6ZeyUI), spaces are better than tabs.

We keep having to clean this up when people submit PRs with a mix of spaces & tabs.
This switches us to spaces which should make things easier.
Code will also be much nicer to look at in github with an indentation of 2 instead of 4.