### PR TITLE
FIX timezone bug in sqlite:issue #820

### DIFF
--- a/lib/Drivers/DML/sqlite.js
+++ b/lib/Drivers/DML/sqlite.js
@@ -273,12 +273,13 @@ Driver.prototype.valueToProperty = function (value, property) {
         if (this.config.timezone && this.config.timezone != 'local') {
           var tz = convertTimezone(this.config.timezone);
 
-          // shift local to UTC
-          value.setTime(value.getTime() - (value.getTimezoneOffset() * 60000));
           if (tz !== false) {
             // shift UTC to timezone
             value.setTime(value.getTime() - (tz * 60000));
           }
+        }else {
+          // shift local to UTC
+          value.setTime(value.getTime() - (value.getTimezoneOffset() * 60000));
         }
       }
       break;

--- a/lib/Drivers/DML/sqlite.js
+++ b/lib/Drivers/DML/sqlite.js
@@ -279,7 +279,7 @@ Driver.prototype.valueToProperty = function (value, property) {
           }
         }else {
           // shift local to UTC
-          value.setTime(value.getTime() - (value.getTimezoneOffset() * 60000));
+          value.setTime(value.getTime() + (value.getTimezoneOffset() * 60000));
         }
       }
       break;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "orm",
-	"version": "3.2.4",
+	"version": "4.0.1",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/test/integration/drivers/sqlite_spec.js
+++ b/test/integration/drivers/sqlite_spec.js
@@ -72,6 +72,40 @@ describe("Sqlite driver", function() {
           should.strictEqual(valueToProperty('1.200 '), 1);
         });
       });
+
+      describe("date", function () {
+        var timezone = /GMT([+/-]\d{4})/.exec(new Date().toString())[1];
+
+        function valueToProperty (value) {
+          return driver.valueToProperty(value, { type: 'date' });
+        }
+
+        it("should return origin object when given non-string", function () {
+          var now = new Date();
+          should.strictEqual(valueToProperty(now), now);
+          var array = [];
+          should.strictEqual(valueToProperty(array), array);
+          var obj = {};
+          should.strictEqual(valueToProperty(obj), obj);
+        })
+
+        it("should pass on normal time", function () {
+          var normal = '2017-12-07 00:00:00';
+          should.strictEqual(valueToProperty(normal).toString(), new Date(normal).toString());
+        })
+
+        it("should pass on utc time by orm saved with local config", function () {
+          var utc = '2017-12-07T00:00:00';
+          should.strictEqual(valueToProperty(utc+'Z').toString(), new Date(utc+timezone).toString());
+        })
+
+        it("should pass on utc time by orm saved with timezone config", function () {
+          var utc = '2017-12-07T00:00:00';
+          driver.config.timezone = timezone;
+          should.strictEqual(valueToProperty(utc+'Z').toString(), new Date(utc+timezone).toString());
+          driver.config.timezone = '';
+        })
+      });
     });
   });
 


### PR DESCRIPTION
sample test js script
```javascript
var orm = require('orm');
var path = require('path');

// orm.connect("sqlite://" + path.resolve(process.cwd(), './database.db?timezone=+08:00'), function(err, db) {
orm.connect("sqlite://" + path.resolve(process.cwd(), './database.db'), function(err, db) {
  if (err) throw err;

  var Person = db.define("person", {
		uuid: {type: 'text', required: false},
		date: {type: 'date',time: true},
	});
  console.log('current date:', new Date());
  console.log('------');
  db.sync(function() {
    Person.create({
      uuid: 1,
      date: new Date()
    }, (err, p) => {
      console.log(JSON.stringify(p));// data from memory
      console.log('------');

      Person.get(p.id, function(err, d) {
        console.log(JSON.stringify(d));// data from sqlite file
      })
    })
  })
})
```