### PR TITLE
target a slightly newer sinon to avoid critical npm audit issue

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,24 @@
 {
 	"name": "orm",
-	"version": "4.0.1",
+	"version": "4.0.2",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
+		"@sinonjs/formatio": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-2.0.0.tgz",
+			"integrity": "sha512-ls6CAMA6/5gG+O/IdsBcblvnd8qcO/l1TYoNeAzp3wcISOxlPXQEus0mLcdwazEkWjaBdaJ3TaxmNgCLWwvWzg==",
+			"requires": {
+				"samsam": "1.3.0"
+			}
+		},
 		"ansi-styles": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.1.0.tgz",
 			"integrity": "sha1-CcIC1ckX7CMYjKpcnLkXnNlUd1A=",
 			"dev": true,
 			"requires": {
-				"color-convert": "1.9.0"
+				"color-convert": "^1.0.0"
 			}
 		},
 		"ap": {
@@ -24,7 +32,7 @@
 			"resolved": "https://registry.npmjs.org/async/-/async-2.5.0.tgz",
 			"integrity": "sha512-e+lJAJeNWuPCNyxZKOBdaJGyLGHugXVQtrAwtuAe2vhxTYxFTKE73p8JuTmdH0qdQZtDvI4dhJwjZc5zsfIsYw==",
 			"requires": {
-				"lodash": "4.17.4"
+				"lodash": "^4.14.0"
 			}
 		},
 		"balanced-match": {
@@ -50,7 +58,7 @@
 			"integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
 			"dev": true,
 			"requires": {
-				"balanced-match": "1.0.0",
+				"balanced-match": "^1.0.0",
 				"concat-map": "0.0.1"
 			}
 		},
@@ -66,7 +74,7 @@
 			"integrity": "sha1-/NoQPybQwHTVpS1Qkn24D9ArSzk=",
 			"dev": true,
 			"requires": {
-				"nan": "1.8.4"
+				"nan": "~1.8"
 			}
 		},
 		"buffer-writer": {
@@ -81,9 +89,9 @@
 			"integrity": "sha512-Mp+FXEI+FrwY/XYV45b2YD3E8i3HwnEAoFcM0qlZzq/RZ9RwWitt2Y/c7cqRAz70U7hfekqx6qNYthuKFO6K0g==",
 			"dev": true,
 			"requires": {
-				"ansi-styles": "3.1.0",
-				"escape-string-regexp": "1.0.5",
-				"supports-color": "4.2.0"
+				"ansi-styles": "^3.1.0",
+				"escape-string-regexp": "^1.0.5",
+				"supports-color": "^4.0.0"
 			}
 		},
 		"color-convert": {
@@ -92,7 +100,7 @@
 			"integrity": "sha1-Gsz5fdc5uYO/mU1W/sj5WFNkG3o=",
 			"dev": true,
 			"requires": {
-				"color-name": "1.1.3"
+				"color-name": "^1.1.1"
 			}
 		},
 		"color-name": {
@@ -107,7 +115,7 @@
 			"integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
 			"dev": true,
 			"requires": {
-				"graceful-readlink": "1.0.1"
+				"graceful-readlink": ">= 1.0.0"
 			}
 		},
 		"concat-map": {
@@ -147,14 +155,6 @@
 			"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
 			"dev": true
 		},
-		"formatio": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/formatio/-/formatio-1.2.0.tgz",
-			"integrity": "sha1-87IWfZBoxGmKjVH092CjmlTYGOs=",
-			"requires": {
-				"samsam": "1.2.1"
-			}
-		},
 		"fs.realpath": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -173,12 +173,12 @@
 			"integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
 			"dev": true,
 			"requires": {
-				"fs.realpath": "1.0.0",
-				"inflight": "1.0.6",
-				"inherits": "2.0.3",
-				"minimatch": "3.0.4",
-				"once": "1.4.0",
-				"path-is-absolute": "1.0.1"
+				"fs.realpath": "^1.0.0",
+				"inflight": "^1.0.4",
+				"inherits": "2",
+				"minimatch": "^3.0.4",
+				"once": "^1.3.0",
+				"path-is-absolute": "^1.0.0"
 			}
 		},
 		"graceful-readlink": {
@@ -210,8 +210,8 @@
 			"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
 			"dev": true,
 			"requires": {
-				"once": "1.4.0",
-				"wrappy": "1.0.2"
+				"once": "^1.3.0",
+				"wrappy": "1"
 			}
 		},
 		"inherits": {
@@ -234,9 +234,9 @@
 			"dev": true
 		},
 		"just-extend": {
-			"version": "1.1.22",
-			"resolved": "https://registry.npmjs.org/just-extend/-/just-extend-1.1.22.tgz",
-			"integrity": "sha1-MzCvdWyralQnAMZLLk5KoGLVL/8="
+			"version": "1.1.27",
+			"resolved": "https://registry.npmjs.org/just-extend/-/just-extend-1.1.27.tgz",
+			"integrity": "sha512-mJVp13Ix6gFo3SBAy9U/kL+oeZqzlYYYLQBwXVBlVzIsZwBqGREnOro24oC/8s8aox+rJhtZ2DiQof++IrkA+g=="
 		},
 		"kerberos": {
 			"version": "0.0.4",
@@ -256,8 +256,8 @@
 			"integrity": "sha1-jDigmVAPIVrQnlnxci/QxSv+Ck4=",
 			"dev": true,
 			"requires": {
-				"lodash._basecopy": "3.0.1",
-				"lodash.keys": "3.1.2"
+				"lodash._basecopy": "^3.0.0",
+				"lodash.keys": "^3.0.0"
 			}
 		},
 		"lodash._basecopy": {
@@ -290,10 +290,15 @@
 			"integrity": "sha1-1/KEnw29p+BGgruM1yqwIkYd6+c=",
 			"dev": true,
 			"requires": {
-				"lodash._baseassign": "3.2.0",
-				"lodash._basecreate": "3.0.3",
-				"lodash._isiterateecall": "3.0.9"
+				"lodash._baseassign": "^3.0.0",
+				"lodash._basecreate": "^3.0.0",
+				"lodash._isiterateecall": "^3.0.0"
 			}
+		},
+		"lodash.get": {
+			"version": "4.4.2",
+			"resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+			"integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk="
 		},
 		"lodash.isarguments": {
 			"version": "3.1.0",
@@ -313,15 +318,15 @@
 			"integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
 			"dev": true,
 			"requires": {
-				"lodash._getnative": "3.9.1",
-				"lodash.isarguments": "3.1.0",
-				"lodash.isarray": "3.0.4"
+				"lodash._getnative": "^3.0.0",
+				"lodash.isarguments": "^3.0.0",
+				"lodash.isarray": "^3.0.0"
 			}
 		},
 		"lolex": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/lolex/-/lolex-2.1.2.tgz",
-			"integrity": "sha1-JpS5U8nqTQE+W4v7qJHJkQJbJik="
+			"version": "2.7.0",
+			"resolved": "https://registry.npmjs.org/lolex/-/lolex-2.7.0.tgz",
+			"integrity": "sha512-uJkH2e0BVfU5KOJUevbTOtpDduooSarH5PopO+LfM/vZf8Z9sJzODqKev804JYM2i++ktJfUmC1le4LwFQ1VMg=="
 		},
 		"minimatch": {
 			"version": "3.0.4",
@@ -329,7 +334,7 @@
 			"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
 			"dev": true,
 			"requires": {
-				"brace-expansion": "1.1.8"
+				"brace-expansion": "^1.1.7"
 			}
 		},
 		"minimist": {
@@ -372,12 +377,12 @@
 					"integrity": "sha1-gFIR3wT6rxxjo2ADBs31reULLsg=",
 					"dev": true,
 					"requires": {
-						"fs.realpath": "1.0.0",
-						"inflight": "1.0.6",
-						"inherits": "2.0.3",
-						"minimatch": "3.0.4",
-						"once": "1.4.0",
-						"path-is-absolute": "1.0.1"
+						"fs.realpath": "^1.0.0",
+						"inflight": "^1.0.4",
+						"inherits": "2",
+						"minimatch": "^3.0.2",
+						"once": "^1.3.0",
+						"path-is-absolute": "^1.0.0"
 					}
 				},
 				"has-flag": {
@@ -392,7 +397,7 @@
 					"integrity": "sha1-cqJiiU2dQIuVbKBf83su2KbiotU=",
 					"dev": true,
 					"requires": {
-						"has-flag": "1.0.0"
+						"has-flag": "^1.0.0"
 					}
 				}
 			}
@@ -403,9 +408,9 @@
 			"integrity": "sha1-6wEjlshB1H3GKtNicu6lUOW2l5s=",
 			"dev": true,
 			"requires": {
-				"bson": "0.2.22",
+				"bson": "~0.2",
 				"kerberos": "0.0.4",
-				"readable-stream": "2.3.3"
+				"readable-stream": "latest"
 			}
 		},
 		"ms": {
@@ -437,10 +442,10 @@
 					"integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
 					"dev": true,
 					"requires": {
-						"core-util-is": "1.0.2",
-						"inherits": "2.0.3",
+						"core-util-is": "~1.0.0",
+						"inherits": "~2.0.1",
 						"isarray": "0.0.1",
-						"string_decoder": "0.10.31"
+						"string_decoder": "~0.10.x"
 					}
 				},
 				"string_decoder": {
@@ -457,27 +462,16 @@
 			"integrity": "sha1-PHa1OC6rM+RLdY0oE8qdkuk0LzQ=",
 			"dev": true
 		},
-		"native-promise-only": {
-			"version": "0.8.1",
-			"resolved": "https://registry.npmjs.org/native-promise-only/-/native-promise-only-0.8.1.tgz",
-			"integrity": "sha1-IKMYwwy0X3H+et+/eyHJnBRy7xE="
-		},
 		"nise": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/nise/-/nise-1.0.1.tgz",
-			"integrity": "sha1-DakrEKhU6XwPSW9sKEWjASgLPu8=",
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/nise/-/nise-1.4.1.tgz",
+			"integrity": "sha512-9JX3YwoIt3kS237scmSSOpEv7vCukVzLfwK0I0XhocDSHUANid8ZHnLEULbbSkfeMn98B2y5kphIWzZUylESRQ==",
 			"requires": {
-				"formatio": "1.2.0",
-				"just-extend": "1.1.22",
-				"lolex": "1.6.0",
-				"path-to-regexp": "1.7.0"
-			},
-			"dependencies": {
-				"lolex": {
-					"version": "1.6.0",
-					"resolved": "https://registry.npmjs.org/lolex/-/lolex-1.6.0.tgz",
-					"integrity": "sha1-OpoCg0UqR9dDnnJzG54H1zhuSfY="
-				}
+				"@sinonjs/formatio": "^2.0.0",
+				"just-extend": "^1.1.27",
+				"lolex": "^2.3.2",
+				"path-to-regexp": "^1.7.0",
+				"text-encoding": "^0.6.4"
 			}
 		},
 		"object-assign": {
@@ -492,7 +486,7 @@
 			"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
 			"dev": true,
 			"requires": {
-				"wrappy": "1.0.2"
+				"wrappy": "1"
 			}
 		},
 		"packet-reader": {
@@ -530,9 +524,9 @@
 				"buffer-writer": "1.0.1",
 				"packet-reader": "0.3.1",
 				"pg-connection-string": "0.1.3",
-				"pg-pool": "1.8.0",
-				"pg-types": "1.12.0",
-				"pgpass": "1.0.2",
+				"pg-pool": "1.*",
+				"pg-types": "1.*",
+				"pgpass": "1.*",
 				"semver": "4.3.2"
 			},
 			"dependencies": {
@@ -566,11 +560,11 @@
 			"integrity": "sha1-itO3uJfj/UY+Yt4kGtX8ZAtKZvA=",
 			"dev": true,
 			"requires": {
-				"ap": "0.2.0",
-				"postgres-array": "1.0.2",
-				"postgres-bytea": "1.0.0",
-				"postgres-date": "1.0.3",
-				"postgres-interval": "1.1.0"
+				"ap": "~0.2.0",
+				"postgres-array": "~1.0.0",
+				"postgres-bytea": "~1.0.0",
+				"postgres-date": "~1.0.0",
+				"postgres-interval": "^1.1.0"
 			}
 		},
 		"pgpass": {
@@ -579,7 +573,7 @@
 			"integrity": "sha1-Knu0G2BltnkH6R2hsHwYR8h3swY=",
 			"dev": true,
 			"requires": {
-				"split": "1.0.0"
+				"split": "^1.0.0"
 			}
 		},
 		"postgres-array": {
@@ -606,7 +600,7 @@
 			"integrity": "sha1-EDHnusNFZBMoYq3J62xtLzqnW7Q=",
 			"dev": true,
 			"requires": {
-				"xtend": "4.0.1"
+				"xtend": "^4.0.0"
 			}
 		},
 		"process-nextick-args": {
@@ -623,13 +617,13 @@
 			"dev": true,
 			"optional": true,
 			"requires": {
-				"core-util-is": "1.0.2",
-				"inherits": "2.0.3",
-				"isarray": "1.0.0",
-				"process-nextick-args": "1.0.7",
-				"safe-buffer": "5.1.1",
-				"string_decoder": "1.0.3",
-				"util-deprecate": "1.0.2"
+				"core-util-is": "~1.0.0",
+				"inherits": "~2.0.3",
+				"isarray": "~1.0.0",
+				"process-nextick-args": "~1.0.6",
+				"safe-buffer": "~5.1.1",
+				"string_decoder": "~1.0.3",
+				"util-deprecate": "~1.0.1"
 			}
 		},
 		"safe-buffer": {
@@ -639,9 +633,9 @@
 			"dev": true
 		},
 		"samsam": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/samsam/-/samsam-1.2.1.tgz",
-			"integrity": "sha1-7dOQk6MYQ3DLhZJDsr3yVefY6mc="
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/samsam/-/samsam-1.3.0.tgz",
+			"integrity": "sha512-1HwIYD/8UlOtFS3QO3w7ey+SdSDFE4HRNLZoZRYVQefrOY3l17epswImeB1ijgJFQJodIaHcwkp3r/myBjFVbg=="
 		},
 		"semver": {
 			"version": "5.3.0",
@@ -655,11 +649,11 @@
 			"integrity": "sha1-kPVRRVUtAc/CAGZuToGKHJZw7aI=",
 			"dev": true,
 			"requires": {
-				"should-equal": "1.0.1",
-				"should-format": "3.0.3",
-				"should-type": "1.4.0",
-				"should-type-adaptors": "1.0.1",
-				"should-util": "1.0.0"
+				"should-equal": "^1.0.0",
+				"should-format": "^3.0.2",
+				"should-type": "^1.4.0",
+				"should-type-adaptors": "^1.0.1",
+				"should-util": "^1.0.0"
 			}
 		},
 		"should-equal": {
@@ -668,7 +662,7 @@
 			"integrity": "sha1-C26VFvJgGp+wuy3MNpr6HH4gCvc=",
 			"dev": true,
 			"requires": {
-				"should-type": "1.4.0"
+				"should-type": "^1.0.0"
 			}
 		},
 		"should-format": {
@@ -677,8 +671,8 @@
 			"integrity": "sha1-m/yPdPo5IFxT04w01xcwPidxJPE=",
 			"dev": true,
 			"requires": {
-				"should-type": "1.4.0",
-				"should-type-adaptors": "1.0.1"
+				"should-type": "^1.3.0",
+				"should-type-adaptors": "^1.0.1"
 			}
 		},
 		"should-type": {
@@ -693,8 +687,8 @@
 			"integrity": "sha1-7+VVPN9oz/ZuXF9RtxLcNRx3vqo=",
 			"dev": true,
 			"requires": {
-				"should-type": "1.4.0",
-				"should-util": "1.0.0"
+				"should-type": "^1.3.0",
+				"should-util": "^1.0.0"
 			}
 		},
 		"should-util": {
@@ -704,19 +698,32 @@
 			"dev": true
 		},
 		"sinon": {
-			"version": "3.2.1",
-			"resolved": "https://registry.npmjs.org/sinon/-/sinon-3.2.1.tgz",
-			"integrity": "sha512-KY3OLOWpek/I4NGAMHetuutVgS2aRgMR5g5/1LSYvPJ3qo2BopIvk3esFztPxF40RWf/NNNJzdFPriSkXUVK3A==",
+			"version": "4.4.6",
+			"resolved": "https://registry.npmjs.org/sinon/-/sinon-4.4.6.tgz",
+			"integrity": "sha512-bzQag30yErCC4lJPv+C2HcmD1+3ula4JQNePZldKcagi0Exq6XDfcC2yqXVfEwtfTIq1rYGujrUIZbwHPpKjog==",
 			"requires": {
-				"diff": "3.2.0",
-				"formatio": "1.2.0",
-				"lolex": "2.1.2",
-				"native-promise-only": "0.8.1",
-				"nise": "1.0.1",
-				"path-to-regexp": "1.7.0",
-				"samsam": "1.2.1",
-				"text-encoding": "0.6.4",
-				"type-detect": "4.0.3"
+				"@sinonjs/formatio": "^2.0.0",
+				"diff": "^3.1.0",
+				"lodash.get": "^4.4.2",
+				"lolex": "^2.2.0",
+				"nise": "^1.2.0",
+				"supports-color": "^5.1.0",
+				"type-detect": "^4.0.5"
+			},
+			"dependencies": {
+				"has-flag": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
+				},
+				"supports-color": {
+					"version": "5.4.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+					"integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+					"requires": {
+						"has-flag": "^3.0.0"
+					}
+				}
 			}
 		},
 		"split": {
@@ -725,7 +732,7 @@
 			"integrity": "sha1-xDlc5oOrzSVLwo/h2rtuXCfc/64=",
 			"dev": true,
 			"requires": {
-				"through": "2.3.8"
+				"through": "2"
 			}
 		},
 		"sql-ddl-sync": {
@@ -747,8 +754,8 @@
 			"integrity": "sha1-TLz5Zdi5AdGxAVy8f8QVquFX36o=",
 			"dev": true,
 			"requires": {
-				"nan": "2.4.0",
-				"node-pre-gyp": "0.6.31"
+				"nan": "~2.4.0",
+				"node-pre-gyp": "~0.6.31"
 			},
 			"dependencies": {
 				"nan": {
@@ -762,15 +769,15 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"mkdirp": "0.5.1",
-						"nopt": "3.0.6",
-						"npmlog": "4.0.0",
-						"rc": "1.1.6",
-						"request": "2.76.0",
-						"rimraf": "2.5.4",
-						"semver": "5.3.0",
-						"tar": "2.2.1",
-						"tar-pack": "3.3.0"
+						"mkdirp": "~0.5.1",
+						"nopt": "~3.0.6",
+						"npmlog": "^4.0.0",
+						"rc": "~1.1.6",
+						"request": "^2.75.0",
+						"rimraf": "~2.5.4",
+						"semver": "~5.3.0",
+						"tar": "~2.2.1",
+						"tar-pack": "~3.3.0"
 					},
 					"dependencies": {
 						"mkdirp": {
@@ -793,7 +800,7 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"abbrev": "1.0.9"
+								"abbrev": "1"
 							},
 							"dependencies": {
 								"abbrev": {
@@ -808,10 +815,10 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"are-we-there-yet": "1.1.2",
-								"console-control-strings": "1.1.0",
-								"gauge": "2.6.0",
-								"set-blocking": "2.0.0"
+								"are-we-there-yet": "~1.1.2",
+								"console-control-strings": "~1.1.0",
+								"gauge": "~2.6.0",
+								"set-blocking": "~2.0.0"
 							},
 							"dependencies": {
 								"are-we-there-yet": {
@@ -819,8 +826,8 @@
 									"bundled": true,
 									"dev": true,
 									"requires": {
-										"delegates": "1.0.0",
-										"readable-stream": "2.1.5"
+										"delegates": "^1.0.0",
+										"readable-stream": "^2.0.0 || ^1.1.13"
 									},
 									"dependencies": {
 										"delegates": {
@@ -833,13 +840,13 @@
 											"bundled": true,
 											"dev": true,
 											"requires": {
-												"buffer-shims": "1.0.0",
-												"core-util-is": "1.0.2",
-												"inherits": "2.0.3",
-												"isarray": "1.0.0",
-												"process-nextick-args": "1.0.7",
-												"string_decoder": "0.10.31",
-												"util-deprecate": "1.0.2"
+												"buffer-shims": "^1.0.0",
+												"core-util-is": "~1.0.0",
+												"inherits": "~2.0.1",
+												"isarray": "~1.0.0",
+												"process-nextick-args": "~1.0.6",
+												"string_decoder": "~0.10.x",
+												"util-deprecate": "~1.0.1"
 											},
 											"dependencies": {
 												"buffer-shims": {
@@ -891,15 +898,15 @@
 									"bundled": true,
 									"dev": true,
 									"requires": {
-										"aproba": "1.0.4",
-										"console-control-strings": "1.1.0",
-										"has-color": "0.1.7",
-										"has-unicode": "2.0.1",
-										"object-assign": "4.1.0",
-										"signal-exit": "3.0.1",
-										"string-width": "1.0.2",
-										"strip-ansi": "3.0.1",
-										"wide-align": "1.1.0"
+										"aproba": "^1.0.3",
+										"console-control-strings": "^1.0.0",
+										"has-color": "^0.1.7",
+										"has-unicode": "^2.0.0",
+										"object-assign": "^4.1.0",
+										"signal-exit": "^3.0.0",
+										"string-width": "^1.0.1",
+										"strip-ansi": "^3.0.1",
+										"wide-align": "^1.1.0"
 									},
 									"dependencies": {
 										"aproba": {
@@ -932,9 +939,9 @@
 											"bundled": true,
 											"dev": true,
 											"requires": {
-												"code-point-at": "1.0.1",
-												"is-fullwidth-code-point": "1.0.0",
-												"strip-ansi": "3.0.1"
+												"code-point-at": "^1.0.0",
+												"is-fullwidth-code-point": "^1.0.0",
+												"strip-ansi": "^3.0.0"
 											},
 											"dependencies": {
 												"code-point-at": {
@@ -942,7 +949,7 @@
 													"bundled": true,
 													"dev": true,
 													"requires": {
-														"number-is-nan": "1.0.1"
+														"number-is-nan": "^1.0.0"
 													},
 													"dependencies": {
 														"number-is-nan": {
@@ -957,7 +964,7 @@
 													"bundled": true,
 													"dev": true,
 													"requires": {
-														"number-is-nan": "1.0.1"
+														"number-is-nan": "^1.0.0"
 													},
 													"dependencies": {
 														"number-is-nan": {
@@ -974,7 +981,7 @@
 											"bundled": true,
 											"dev": true,
 											"requires": {
-												"ansi-regex": "2.0.0"
+												"ansi-regex": "^2.0.0"
 											},
 											"dependencies": {
 												"ansi-regex": {
@@ -989,7 +996,7 @@
 											"bundled": true,
 											"dev": true,
 											"requires": {
-												"string-width": "1.0.2"
+												"string-width": "^1.0.1"
 											}
 										}
 									}
@@ -1006,10 +1013,10 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"deep-extend": "0.4.1",
-								"ini": "1.3.4",
-								"minimist": "1.2.0",
-								"strip-json-comments": "1.0.4"
+								"deep-extend": "~0.4.0",
+								"ini": "~1.3.0",
+								"minimist": "^1.2.0",
+								"strip-json-comments": "~1.0.4"
 							},
 							"dependencies": {
 								"deep-extend": {
@@ -1039,26 +1046,26 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"aws-sign2": "0.6.0",
-								"aws4": "1.5.0",
-								"caseless": "0.11.0",
-								"combined-stream": "1.0.5",
-								"extend": "3.0.0",
-								"forever-agent": "0.6.1",
-								"form-data": "2.1.1",
-								"har-validator": "2.0.6",
-								"hawk": "3.1.3",
-								"http-signature": "1.1.1",
-								"is-typedarray": "1.0.0",
-								"isstream": "0.1.2",
-								"json-stringify-safe": "5.0.1",
-								"mime-types": "2.1.12",
-								"node-uuid": "1.4.7",
-								"oauth-sign": "0.8.2",
-								"qs": "6.3.0",
-								"stringstream": "0.0.5",
-								"tough-cookie": "2.3.2",
-								"tunnel-agent": "0.4.3"
+								"aws-sign2": "~0.6.0",
+								"aws4": "^1.2.1",
+								"caseless": "~0.11.0",
+								"combined-stream": "~1.0.5",
+								"extend": "~3.0.0",
+								"forever-agent": "~0.6.1",
+								"form-data": "~2.1.1",
+								"har-validator": "~2.0.6",
+								"hawk": "~3.1.3",
+								"http-signature": "~1.1.0",
+								"is-typedarray": "~1.0.0",
+								"isstream": "~0.1.2",
+								"json-stringify-safe": "~5.0.1",
+								"mime-types": "~2.1.7",
+								"node-uuid": "~1.4.7",
+								"oauth-sign": "~0.8.1",
+								"qs": "~6.3.0",
+								"stringstream": "~0.0.4",
+								"tough-cookie": "~2.3.0",
+								"tunnel-agent": "~0.4.1"
 							},
 							"dependencies": {
 								"aws-sign2": {
@@ -1081,7 +1088,7 @@
 									"bundled": true,
 									"dev": true,
 									"requires": {
-										"delayed-stream": "1.0.0"
+										"delayed-stream": "~1.0.0"
 									},
 									"dependencies": {
 										"delayed-stream": {
@@ -1106,9 +1113,9 @@
 									"bundled": true,
 									"dev": true,
 									"requires": {
-										"asynckit": "0.4.0",
-										"combined-stream": "1.0.5",
-										"mime-types": "2.1.12"
+										"asynckit": "^0.4.0",
+										"combined-stream": "^1.0.5",
+										"mime-types": "^2.1.12"
 									},
 									"dependencies": {
 										"asynckit": {
@@ -1123,10 +1130,10 @@
 									"bundled": true,
 									"dev": true,
 									"requires": {
-										"chalk": "1.1.3",
-										"commander": "2.9.0",
-										"is-my-json-valid": "2.15.0",
-										"pinkie-promise": "2.0.1"
+										"chalk": "^1.1.1",
+										"commander": "^2.9.0",
+										"is-my-json-valid": "^2.12.4",
+										"pinkie-promise": "^2.0.0"
 									},
 									"dependencies": {
 										"chalk": {
@@ -1134,11 +1141,11 @@
 											"bundled": true,
 											"dev": true,
 											"requires": {
-												"ansi-styles": "2.2.1",
-												"escape-string-regexp": "1.0.5",
-												"has-ansi": "2.0.0",
-												"strip-ansi": "3.0.1",
-												"supports-color": "2.0.0"
+												"ansi-styles": "^2.2.1",
+												"escape-string-regexp": "^1.0.2",
+												"has-ansi": "^2.0.0",
+												"strip-ansi": "^3.0.0",
+												"supports-color": "^2.0.0"
 											},
 											"dependencies": {
 												"ansi-styles": {
@@ -1156,7 +1163,7 @@
 													"bundled": true,
 													"dev": true,
 													"requires": {
-														"ansi-regex": "2.0.0"
+														"ansi-regex": "^2.0.0"
 													},
 													"dependencies": {
 														"ansi-regex": {
@@ -1171,7 +1178,7 @@
 													"bundled": true,
 													"dev": true,
 													"requires": {
-														"ansi-regex": "2.0.0"
+														"ansi-regex": "^2.0.0"
 													},
 													"dependencies": {
 														"ansi-regex": {
@@ -1193,7 +1200,7 @@
 											"bundled": true,
 											"dev": true,
 											"requires": {
-												"graceful-readlink": "1.0.1"
+												"graceful-readlink": ">= 1.0.0"
 											},
 											"dependencies": {
 												"graceful-readlink": {
@@ -1208,10 +1215,10 @@
 											"bundled": true,
 											"dev": true,
 											"requires": {
-												"generate-function": "2.0.0",
-												"generate-object-property": "1.2.0",
-												"jsonpointer": "4.0.0",
-												"xtend": "4.0.1"
+												"generate-function": "^2.0.0",
+												"generate-object-property": "^1.1.0",
+												"jsonpointer": "^4.0.0",
+												"xtend": "^4.0.0"
 											},
 											"dependencies": {
 												"generate-function": {
@@ -1224,7 +1231,7 @@
 													"bundled": true,
 													"dev": true,
 													"requires": {
-														"is-property": "1.0.2"
+														"is-property": "^1.0.0"
 													},
 													"dependencies": {
 														"is-property": {
@@ -1251,7 +1258,7 @@
 											"bundled": true,
 											"dev": true,
 											"requires": {
-												"pinkie": "2.0.4"
+												"pinkie": "^2.0.0"
 											},
 											"dependencies": {
 												"pinkie": {
@@ -1268,10 +1275,10 @@
 									"bundled": true,
 									"dev": true,
 									"requires": {
-										"boom": "2.10.1",
-										"cryptiles": "2.0.5",
-										"hoek": "2.16.3",
-										"sntp": "1.0.9"
+										"boom": "2.x.x",
+										"cryptiles": "2.x.x",
+										"hoek": "2.x.x",
+										"sntp": "1.x.x"
 									},
 									"dependencies": {
 										"boom": {
@@ -1279,7 +1286,7 @@
 											"bundled": true,
 											"dev": true,
 											"requires": {
-												"hoek": "2.16.3"
+												"hoek": "2.x.x"
 											}
 										},
 										"cryptiles": {
@@ -1287,7 +1294,7 @@
 											"bundled": true,
 											"dev": true,
 											"requires": {
-												"boom": "2.10.1"
+												"boom": "2.x.x"
 											}
 										},
 										"hoek": {
@@ -1300,7 +1307,7 @@
 											"bundled": true,
 											"dev": true,
 											"requires": {
-												"hoek": "2.16.3"
+												"hoek": "2.x.x"
 											}
 										}
 									}
@@ -1310,9 +1317,9 @@
 									"bundled": true,
 									"dev": true,
 									"requires": {
-										"assert-plus": "0.2.0",
-										"jsprim": "1.3.1",
-										"sshpk": "1.10.1"
+										"assert-plus": "^0.2.0",
+										"jsprim": "^1.2.2",
+										"sshpk": "^1.7.0"
 									},
 									"dependencies": {
 										"assert-plus": {
@@ -1355,15 +1362,15 @@
 											"bundled": true,
 											"dev": true,
 											"requires": {
-												"asn1": "0.2.3",
-												"assert-plus": "1.0.0",
-												"bcrypt-pbkdf": "1.0.0",
-												"dashdash": "1.14.0",
-												"ecc-jsbn": "0.1.1",
-												"getpass": "0.1.6",
-												"jodid25519": "1.0.2",
-												"jsbn": "0.1.0",
-												"tweetnacl": "0.14.3"
+												"asn1": "~0.2.3",
+												"assert-plus": "^1.0.0",
+												"bcrypt-pbkdf": "^1.0.0",
+												"dashdash": "^1.12.0",
+												"ecc-jsbn": "~0.1.1",
+												"getpass": "^0.1.1",
+												"jodid25519": "^1.0.0",
+												"jsbn": "~0.1.0",
+												"tweetnacl": "~0.14.0"
 											},
 											"dependencies": {
 												"asn1": {
@@ -1382,7 +1389,7 @@
 													"dev": true,
 													"optional": true,
 													"requires": {
-														"tweetnacl": "0.14.3"
+														"tweetnacl": "^0.14.3"
 													}
 												},
 												"dashdash": {
@@ -1390,7 +1397,7 @@
 													"bundled": true,
 													"dev": true,
 													"requires": {
-														"assert-plus": "1.0.0"
+														"assert-plus": "^1.0.0"
 													}
 												},
 												"ecc-jsbn": {
@@ -1399,7 +1406,7 @@
 													"dev": true,
 													"optional": true,
 													"requires": {
-														"jsbn": "0.1.0"
+														"jsbn": "~0.1.0"
 													}
 												},
 												"getpass": {
@@ -1407,7 +1414,7 @@
 													"bundled": true,
 													"dev": true,
 													"requires": {
-														"assert-plus": "1.0.0"
+														"assert-plus": "^1.0.0"
 													}
 												},
 												"jodid25519": {
@@ -1416,7 +1423,7 @@
 													"dev": true,
 													"optional": true,
 													"requires": {
-														"jsbn": "0.1.0"
+														"jsbn": "~0.1.0"
 													}
 												},
 												"jsbn": {
@@ -1455,7 +1462,7 @@
 									"bundled": true,
 									"dev": true,
 									"requires": {
-										"mime-db": "1.24.0"
+										"mime-db": "~1.24.0"
 									},
 									"dependencies": {
 										"mime-db": {
@@ -1490,7 +1497,7 @@
 									"bundled": true,
 									"dev": true,
 									"requires": {
-										"punycode": "1.4.1"
+										"punycode": "^1.4.1"
 									},
 									"dependencies": {
 										"punycode": {
@@ -1512,7 +1519,7 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"glob": "7.1.1"
+								"glob": "^7.0.5"
 							},
 							"dependencies": {
 								"glob": {
@@ -1520,12 +1527,12 @@
 									"bundled": true,
 									"dev": true,
 									"requires": {
-										"fs.realpath": "1.0.0",
-										"inflight": "1.0.6",
-										"inherits": "2.0.3",
-										"minimatch": "3.0.3",
-										"once": "1.4.0",
-										"path-is-absolute": "1.0.1"
+										"fs.realpath": "^1.0.0",
+										"inflight": "^1.0.4",
+										"inherits": "2",
+										"minimatch": "^3.0.2",
+										"once": "^1.3.0",
+										"path-is-absolute": "^1.0.0"
 									},
 									"dependencies": {
 										"fs.realpath": {
@@ -1538,8 +1545,8 @@
 											"bundled": true,
 											"dev": true,
 											"requires": {
-												"once": "1.4.0",
-												"wrappy": "1.0.2"
+												"once": "^1.3.0",
+												"wrappy": "1"
 											},
 											"dependencies": {
 												"wrappy": {
@@ -1559,7 +1566,7 @@
 											"bundled": true,
 											"dev": true,
 											"requires": {
-												"brace-expansion": "1.1.6"
+												"brace-expansion": "^1.0.0"
 											},
 											"dependencies": {
 												"brace-expansion": {
@@ -1567,7 +1574,7 @@
 													"bundled": true,
 													"dev": true,
 													"requires": {
-														"balanced-match": "0.4.2",
+														"balanced-match": "^0.4.1",
 														"concat-map": "0.0.1"
 													},
 													"dependencies": {
@@ -1590,7 +1597,7 @@
 											"bundled": true,
 											"dev": true,
 											"requires": {
-												"wrappy": "1.0.2"
+												"wrappy": "1"
 											},
 											"dependencies": {
 												"wrappy": {
@@ -1619,9 +1626,9 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"block-stream": "0.0.9",
-								"fstream": "1.0.10",
-								"inherits": "2.0.3"
+								"block-stream": "*",
+								"fstream": "^1.0.2",
+								"inherits": "2"
 							},
 							"dependencies": {
 								"block-stream": {
@@ -1629,7 +1636,7 @@
 									"bundled": true,
 									"dev": true,
 									"requires": {
-										"inherits": "2.0.3"
+										"inherits": "~2.0.0"
 									}
 								},
 								"fstream": {
@@ -1637,10 +1644,10 @@
 									"bundled": true,
 									"dev": true,
 									"requires": {
-										"graceful-fs": "4.1.9",
-										"inherits": "2.0.3",
-										"mkdirp": "0.5.1",
-										"rimraf": "2.5.4"
+										"graceful-fs": "^4.1.2",
+										"inherits": "~2.0.0",
+										"mkdirp": ">=0.5 0",
+										"rimraf": "2"
 									},
 									"dependencies": {
 										"graceful-fs": {
@@ -1662,14 +1669,14 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"debug": "2.2.0",
-								"fstream": "1.0.10",
-								"fstream-ignore": "1.0.5",
-								"once": "1.3.3",
-								"readable-stream": "2.1.5",
-								"rimraf": "2.5.4",
-								"tar": "2.2.1",
-								"uid-number": "0.0.6"
+								"debug": "~2.2.0",
+								"fstream": "~1.0.10",
+								"fstream-ignore": "~1.0.5",
+								"once": "~1.3.3",
+								"readable-stream": "~2.1.4",
+								"rimraf": "~2.5.1",
+								"tar": "~2.2.1",
+								"uid-number": "~0.0.6"
 							},
 							"dependencies": {
 								"debug": {
@@ -1692,10 +1699,10 @@
 									"bundled": true,
 									"dev": true,
 									"requires": {
-										"graceful-fs": "4.1.9",
-										"inherits": "2.0.3",
-										"mkdirp": "0.5.1",
-										"rimraf": "2.5.4"
+										"graceful-fs": "^4.1.2",
+										"inherits": "~2.0.0",
+										"mkdirp": ">=0.5 0",
+										"rimraf": "2"
 									},
 									"dependencies": {
 										"graceful-fs": {
@@ -1715,9 +1722,9 @@
 									"bundled": true,
 									"dev": true,
 									"requires": {
-										"fstream": "1.0.10",
-										"inherits": "2.0.3",
-										"minimatch": "3.0.3"
+										"fstream": "^1.0.0",
+										"inherits": "2",
+										"minimatch": "^3.0.0"
 									},
 									"dependencies": {
 										"inherits": {
@@ -1730,7 +1737,7 @@
 											"bundled": true,
 											"dev": true,
 											"requires": {
-												"brace-expansion": "1.1.6"
+												"brace-expansion": "^1.0.0"
 											},
 											"dependencies": {
 												"brace-expansion": {
@@ -1738,7 +1745,7 @@
 													"bundled": true,
 													"dev": true,
 													"requires": {
-														"balanced-match": "0.4.2",
+														"balanced-match": "^0.4.1",
 														"concat-map": "0.0.1"
 													},
 													"dependencies": {
@@ -1763,7 +1770,7 @@
 									"bundled": true,
 									"dev": true,
 									"requires": {
-										"wrappy": "1.0.2"
+										"wrappy": "1"
 									},
 									"dependencies": {
 										"wrappy": {
@@ -1778,13 +1785,13 @@
 									"bundled": true,
 									"dev": true,
 									"requires": {
-										"buffer-shims": "1.0.0",
-										"core-util-is": "1.0.2",
-										"inherits": "2.0.3",
-										"isarray": "1.0.0",
-										"process-nextick-args": "1.0.7",
-										"string_decoder": "0.10.31",
-										"util-deprecate": "1.0.2"
+										"buffer-shims": "^1.0.0",
+										"core-util-is": "~1.0.0",
+										"inherits": "~2.0.1",
+										"isarray": "~1.0.0",
+										"process-nextick-args": "~1.0.6",
+										"string_decoder": "~0.10.x",
+										"util-deprecate": "~1.0.1"
 									},
 									"dependencies": {
 										"buffer-shims": {
@@ -1848,7 +1855,7 @@
 			"dev": true,
 			"optional": true,
 			"requires": {
-				"safe-buffer": "5.1.1"
+				"safe-buffer": "~5.1.0"
 			}
 		},
 		"supports-color": {
@@ -1857,7 +1864,7 @@
 			"integrity": "sha512-Ts0Mu/A1S1aZxEJNG88I4Oc9rcZSBFNac5e27yh4j2mqbhZSSzR1Ah79EYwSn9Zuh7lrlGD2cVGzw1RKGzyLSg==",
 			"dev": true,
 			"requires": {
-				"has-flag": "2.0.0"
+				"has-flag": "^2.0.0"
 			}
 		},
 		"text-encoding": {
@@ -1872,9 +1879,9 @@
 			"dev": true
 		},
 		"type-detect": {
-			"version": "4.0.3",
-			"resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.3.tgz",
-			"integrity": "sha1-Dj8mcLRAmbC0bChNE2p+9Jx0wuo="
+			"version": "4.0.8",
+			"resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+			"integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g=="
 		},
 		"util-deprecate": {
 			"version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "sqlite",
     "mongodb"
   ],
-  "version": "4.0.2",
+  "version": "4.0.3",
   "license": "MIT",
   "homepage": "http://dresende.github.io/node-orm2",
   "repository": "http://github.com/dresende/node-orm2.git",
@@ -67,7 +67,7 @@
     "hat": "0.0.3",
     "lodash": "4.17.4",
     "path-is-absolute": "1.0.1",
-    "sinon": "^3.2.1",
+    "sinon": "4.4.6",
     "sql-ddl-sync": "0.3.13",
     "sql-query": "0.1.26"
   },


### PR DESCRIPTION
old sinon uses unmaintained 'build' package which bumps into
https://nodesecurity.io/advisories/16
