### PR TITLE
Add allAsync and whereAsync to a chain call

### DIFF
--- a/lib/ChainFind.js
+++ b/lib/ChainFind.js
@@ -259,6 +259,8 @@ function ChainFind(Model, opts) {
   chain.all = chain.where = chain.find;
 
   chain['find' + promiseFunctionPostfix]   = Promise.promisify(chain.find);
+  chain['all' + promiseFunctionPostfix]    = Promise.promisify(chain.all);
+  chain['where' + promiseFunctionPostfix]  = Promise.promisify(chain.where);
   chain['first' + promiseFunctionPostfix]  = Promise.promisify(chain.first);
   chain['last' + promiseFunctionPostfix]   = Promise.promisify(chain.last);
   chain['run' + promiseFunctionPostfix]    = Promise.promisify(chain.run);

--- a/test/integration/model-find-chain-async.js
+++ b/test/integration/model-find-chain-async.js
@@ -182,4 +182,50 @@ describe("Model.find() chaining", function() {
         });
     });
   });
+
+  describe(".allAsync()", function () {
+    before(setup());
+
+    it("should return all records without any restriction", function () {
+      return Person.find()
+        .allAsync()
+        .then(function(persons) {
+          should.equal(persons.length, 3);
+        });
+    });
+
+    it("should restrict conditions from pervious chain calls", function () {
+      return Person.find({ age: 18 })
+        .order('-name')
+        .allAsync()
+        .then(function(persons) {
+          should.equal(persons.length, 2);
+          should.equal(persons[0].name, 'John');
+          should.equal(persons[1].name, 'Jane');
+        });
+    });
+  });
+
+  describe(".whereAsync()", function () {
+    before(setup());
+
+    it("should return all records without any restriction", function () {
+      return Person.find()
+        .whereAsync()
+        .then(function(persons) {
+          should.equal(persons.length, 3);
+        });
+    });
+
+    it("should restrict conditions from pervious chain calls", function () {
+      return Person.find({ age: 18 })
+        .order('-name')
+        .whereAsync()
+        .then(function(persons) {
+          should.equal(persons.length, 2);
+          should.equal(persons[0].name, 'John');
+          should.equal(persons[1].name, 'Jane');
+        });
+    });
+  });
 });


### PR DESCRIPTION
Add async forms for `all` and `where` methods for a chain.

It'll add a possibility to use not only `findAsync` method at the end of the chan calls but `whereAsync` and `allAsync`. From the example below, all queries will generate the same conditions:
```js
Person.find({ name: 'John' }).where('age >= ? OR age =< ?', [18, 20]).findAsync();
Person.find({ name: 'John' }).where('age >= ? OR age =< ?', [18, 20]).allAsync();
Person.find({ name: 'John' }).where('age >= ? OR age =< ?', [18, 20]).whereAsync();
```

These changes also will fix the example from readme page:
```js
Person.find({ age: 18 }).where("LOWER(surname) LIKE ?", ['dea%']).allAsync( ... );
```
As `allAsync` will be called from model level. 

Realizations of `find` methods in the [model](https://github.com/dresende/node-orm2/blob/master/lib/Model.js#L328) and in the [chain](https://github.com/dresende/node-orm2/blob/master/lib/ChainFind.js#L94) are different. Do we really need to keep them in separate places?