### PR TITLE
Update async package to resolve security vulnerabilities

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,9 @@
+### v7.0.0
+- Update `async` package from v2 to v3 to resolve security vulnerabilities ([858](../../pull/858))
+- Drop support for node < 6 (due to `async` package update)
+
 ### v6.2.0
-- [Feature] Add `.driver.generateQuery` function - same as `.driver.execQuery` but returns the SQL instead of executing it
+- [Feature] Add `.driver.generateQuery` function - same as `.driver.execQuery` but returns the SQL instead of executing it ([857](../../pull/857))
 
 ### v6.1.0
 - [Feature] Accept options when calling `Model.create` ([856](../../pull/856))

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "orm",
-	"version": "6.2.0",
+	"version": "7.0.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
@@ -558,12 +558,9 @@
 			"optional": true
 		},
 		"async": {
-			"version": "2.6.3",
-			"resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
-			"integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
-			"requires": {
-				"lodash": "^4.17.14"
-			}
+			"version": "3.2.3",
+			"resolved": "https://registry.npmjs.org/async/-/async-3.2.3.tgz",
+			"integrity": "sha512-spZRyzKL5l5BZQrr/6m/SqFdBN0q3OCI0f9rjfBzCMBIP4p75P620rR3gTmaksNOhmzgdxcaxdNfMy6anrbM0g=="
 		},
 		"asynckit": {
 			"version": "0.4.0",
@@ -695,9 +692,9 @@
 			}
 		},
 		"camelcase": {
-			"version": "6.2.0",
-			"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.2.0.tgz",
-			"integrity": "sha512-c7wVvbw3f37nuobQNtgsgG9POC9qMbNuMQmTCqZv23b6MIz0fcYpBiOlv9gEN/hdLdnZTDQhg6e9Dq5M1vKvfg==",
+			"version": "6.3.0",
+			"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
+			"integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
 			"dev": true
 		},
 		"caniuse-lite": {
@@ -724,9 +721,9 @@
 			}
 		},
 		"chokidar": {
-			"version": "3.5.2",
-			"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.2.tgz",
-			"integrity": "sha512-ekGhOnNVPgT77r4K/U3GDhu+FQ2S8TnK/s2KbIGXi0SZWuwkZ2QNyfWdZW+TVfn84DpEP7rLeCt2UI6bJ8GwbQ==",
+			"version": "3.5.3",
+			"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.3.tgz",
+			"integrity": "sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==",
 			"dev": true,
 			"requires": {
 				"anymatch": "~3.1.2",
@@ -1698,9 +1695,9 @@
 			}
 		},
 		"minimist": {
-			"version": "1.2.5",
-			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-			"integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+			"version": "1.2.6",
+			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
+			"integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
 			"dev": true
 		},
 		"minipass": {
@@ -1746,49 +1743,61 @@
 			}
 		},
 		"mocha": {
-			"version": "9.1.3",
-			"resolved": "https://registry.npmjs.org/mocha/-/mocha-9.1.3.tgz",
-			"integrity": "sha512-Xcpl9FqXOAYqI3j79pEtHBBnQgVXIhpULjGQa7DVb0Po+VzmSIK9kanAiWLHoRR/dbZ2qpdPshuXr8l1VaHCzw==",
+			"version": "9.2.2",
+			"resolved": "https://registry.npmjs.org/mocha/-/mocha-9.2.2.tgz",
+			"integrity": "sha512-L6XC3EdwT6YrIk0yXpavvLkn8h+EU+Y5UcCHKECyMbdUIxyMuZj4bX4U9e1nvnvUUvQVsV2VHQr5zLdcUkhW/g==",
 			"dev": true,
 			"requires": {
 				"@ungap/promise-all-settled": "1.1.2",
 				"ansi-colors": "4.1.1",
 				"browser-stdout": "1.3.1",
-				"chokidar": "3.5.2",
-				"debug": "4.3.2",
+				"chokidar": "3.5.3",
+				"debug": "4.3.3",
 				"diff": "5.0.0",
 				"escape-string-regexp": "4.0.0",
 				"find-up": "5.0.0",
-				"glob": "7.1.7",
+				"glob": "7.2.0",
 				"growl": "1.10.5",
 				"he": "1.2.0",
 				"js-yaml": "4.1.0",
 				"log-symbols": "4.1.0",
-				"minimatch": "3.0.4",
+				"minimatch": "4.2.1",
 				"ms": "2.1.3",
-				"nanoid": "3.1.25",
+				"nanoid": "3.3.1",
 				"serialize-javascript": "6.0.0",
 				"strip-json-comments": "3.1.1",
 				"supports-color": "8.1.1",
 				"which": "2.0.2",
-				"workerpool": "6.1.5",
+				"workerpool": "6.2.0",
 				"yargs": "16.2.0",
 				"yargs-parser": "20.2.4",
 				"yargs-unparser": "2.0.0"
 			},
 			"dependencies": {
-				"glob": {
-					"version": "7.1.7",
-					"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.7.tgz",
-					"integrity": "sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==",
+				"debug": {
+					"version": "4.3.3",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
+					"integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
 					"dev": true,
 					"requires": {
-						"fs.realpath": "^1.0.0",
-						"inflight": "^1.0.4",
-						"inherits": "2",
-						"minimatch": "^3.0.4",
-						"once": "^1.3.0",
-						"path-is-absolute": "^1.0.0"
+						"ms": "2.1.2"
+					},
+					"dependencies": {
+						"ms": {
+							"version": "2.1.2",
+							"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+							"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+							"dev": true
+						}
+					}
+				},
+				"minimatch": {
+					"version": "4.2.1",
+					"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-4.2.1.tgz",
+					"integrity": "sha512-9Uq1ChtSZO+Mxa/CL1eGizn2vRn3MlLgzhT0Iz8zaY8NdvxvB0d5QdPFmCKf7JKA9Lerx5vRrnwO03jsSfGG9g==",
+					"dev": true,
+					"requires": {
+						"brace-expansion": "^1.1.7"
 					}
 				},
 				"supports-color": {
@@ -1876,9 +1885,9 @@
 			"dev": true
 		},
 		"nanoid": {
-			"version": "3.1.25",
-			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.25.tgz",
-			"integrity": "sha512-rdwtIXaXCLFAQbnfqDRnI6jaRHp9fTcYBjtFKE8eezcZ7LuLjhUaQGNeMXf1HmRoCH32CLz6XwX0TtxEOS/A3Q==",
+			"version": "3.3.1",
+			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.1.tgz",
+			"integrity": "sha512-n6Vs/3KGyxPQd6uO0eH4Bv0ojGSUvuLlIHtC3Y0kEO23YRge8H9x1GCzLn28YX0H66pMkxuaeESFq4tKISKwdw==",
 			"dev": true
 		},
 		"needle": {
@@ -2456,9 +2465,9 @@
 			"dev": true
 		},
 		"picomatch": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.0.tgz",
-			"integrity": "sha512-lY1Q/PiJGC2zOv/z391WOTD+Z02bCgsFfvxoXXf6h7kv9o+WmsmzYqrAwY63sNgOxE4xEdq0WyUnXfKeBrSvYw==",
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+			"integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
 			"dev": true
 		},
 		"pkg-dir": {
@@ -3148,9 +3157,9 @@
 			}
 		},
 		"workerpool": {
-			"version": "6.1.5",
-			"resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.1.5.tgz",
-			"integrity": "sha512-XdKkCK0Zqc6w3iTxLckiuJ81tiD/o5rBE/m+nXpRCB+/Sq4DqkfXZ/x0jW02DG1tGsfUGXbTJyZDP+eu67haSw==",
+			"version": "6.2.0",
+			"resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.2.0.tgz",
+			"integrity": "sha512-Rsk5qQHJ9eowMH28Jwhe8HEbmdYDX4lwoMWshiCXugjtHqMD9ZbiqSDLxcsfdqsETPzVUtX5s1Z5kStiIM6l4A==",
 			"dev": true
 		},
 		"wrap-ansi": {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "sqlite",
     "mongodb"
   ],
-  "version": "6.2.0",
+  "version": "7.0.0",
   "license": "MIT",
   "homepage": "http://dresende.github.io/node-orm2",
   "repository": "http://github.com/dresende/node-orm2.git",
@@ -57,11 +57,11 @@
     "test": "nyc make test"
   },
   "engines": {
-    "node": ">= 4.0.0"
+    "node": ">= 6.0.0"
   },
   "analyse": false,
   "dependencies": {
-    "async": "~2.6.3",
+    "async": "~3.2.3",
     "bluebird": "3.5.1",
     "enforce": "0.1.7",
     "hat": "0.0.3",
@@ -73,7 +73,7 @@
   "devDependencies": {
     "chalk": "~4.1.2",
     "glob": "~7.2.0",
-    "mocha": "~9.1.3",
+    "mocha": "~9.2.2",
     "mongodb": "~1.4.10",
     "mysql": "~2.18.1",
     "nyc": "~15.1.0",


### PR DESCRIPTION
This drops support for nodejs < 6 due to changes in `async` package.